### PR TITLE
docs: Replace hardcoded /root/ paths with portable ~/ paths

### DIFF
--- a/audacity/agent-harness/cli_anything/audacity/README.md
+++ b/audacity/agent-harness/cli_anything/audacity/README.md
@@ -22,7 +22,7 @@ No other dependencies required. Core functionality uses only Python stdlib.
 
 ```bash
 # From the agent-harness/ directory:
-cd /root/cli-anything/audacity/agent-harness
+cd ~/cli-anything/audacity/agent-harness
 
 # One-shot commands
 python3 -m cli.audacity_cli project new --name "My Podcast"
@@ -41,7 +41,7 @@ python3 -m cli.audacity_cli repl
 ## Run Tests
 
 ```bash
-cd /root/cli-anything/audacity/agent-harness
+cd ~/cli-anything/audacity/agent-harness
 
 # All tests
 python3 -m pytest cli/tests/ -v

--- a/audacity/agent-harness/cli_anything/audacity/tests/TEST.md
+++ b/audacity/agent-harness/cli_anything/audacity/tests/TEST.md
@@ -170,7 +170,7 @@ E2E tests use real WAV file I/O with numpy arrays for audio sample verification.
 ```
 ============================= test session starts ==============================
 platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.5.0
-rootdir: /root/cli-anything
+rootdir: ~/cli-anything
 plugins: langsmith-0.5.1, anyio-4.12.0
 collected 154 items
 

--- a/blender/agent-harness/cli_anything/blender/tests/TEST.md
+++ b/blender/agent-harness/cli_anything/blender/tests/TEST.md
@@ -162,7 +162,7 @@ E2E tests validate BPY (Blender Python) script generation, scene roundtrips, and
 ```
 ============================= test session starts ==============================
 platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.5.0
-rootdir: /root/cli-anything
+rootdir: ~/cli-anything
 plugins: langsmith-0.5.1, anyio-4.12.0
 collected 200 items
 

--- a/cli-anything-plugin/HARNESS.md
+++ b/cli-anything-plugin/HARNESS.md
@@ -589,7 +589,7 @@ side-by-side in the same Python environment without conflicts.
 
 4. **Test local installation**:
    ```bash
-   cd /root/cli-anything/<software>/agent-harness
+   cd ~/cli-anything/<software>/agent-harness
    pip install -e .
    ```
 
@@ -601,7 +601,7 @@ side-by-side in the same Python environment without conflicts.
 
 6. **Run tests against the installed command**:
    ```bash
-   cd /root/cli-anything/<software>/agent-harness
+   cd ~/cli-anything/<software>/agent-harness
    CLI_ANYTHING_FORCE_INSTALLED=1 python3 -m pytest cli_anything/<software>/tests/ -v -s
    ```
    The output must show `[_resolve_cli] Using installed command: /path/to/cli-anything-<software>`

--- a/cli-anything-plugin/PUBLISHING.md
+++ b/cli-anything-plugin/PUBLISHING.md
@@ -8,7 +8,7 @@ This guide explains how to make the cli-anything plugin installable and publish 
 
 1. **Copy to Claude Code plugins directory:**
    ```bash
-   cp -r /root/cli-anything/cli-anything-plugin ~/.claude/plugins/cli-anything
+   cp -r ~/cli-anything/cli-anything-plugin ~/.claude/plugins/cli-anything
    ```
 
 2. **Reload plugins in Claude Code:**
@@ -25,7 +25,7 @@ This guide explains how to make the cli-anything plugin installable and publish 
 
 Package as a tarball:
 ```bash
-cd /root/cli-anything
+cd ~/cli-anything
 tar -czf cli-anything-plugin-v1.0.0.tar.gz cli-anything-plugin/
 ```
 
@@ -40,7 +40,7 @@ tar -xzf cli-anything-plugin-v1.0.0.tar.gz
 ### 1. Create GitHub Repository
 
 ```bash
-cd /root/cli-anything/cli-anything-plugin
+cd ~/cli-anything/cli-anything-plugin
 
 # Initialize git
 git init
@@ -105,7 +105,7 @@ Ensure your plugin meets requirements:
    ```bash
    cd claude-plugins-official
    mkdir -p external_plugins/cli-anything
-   cp -r /root/cli-anything/cli-anything-plugin/* external_plugins/cli-anything/
+   cp -r ~/cli-anything/cli-anything-plugin/* external_plugins/cli-anything/
    ```
 
 3. **Create pull request:**

--- a/cli-anything-plugin/QUICKSTART.md
+++ b/cli-anything-plugin/QUICKSTART.md
@@ -6,7 +6,7 @@ Get started with the cli-anything plugin in 5 minutes.
 
 ```bash
 # Copy plugin to Claude Code plugins directory
-cp -r /root/cli-anything/cli-anything-plugin ~/.claude/plugins/cli-anything
+cp -r ~/cli-anything/cli-anything-plugin ~/.claude/plugins/cli-anything
 
 # Reload plugins in Claude Code
 /reload-plugins
@@ -35,13 +35,13 @@ This will:
 
 **Time:** ~10-15 minutes (depending on complexity)
 
-**Output:** `/root/cli-anything/gimp/agent-harness/`
+**Output:** `~/cli-anything/gimp/agent-harness/`
 
 ## Install the CLI
 
 ```bash
 # Install to system PATH
-cd /root/cli-anything/gimp/agent-harness
+cd ~/cli-anything/gimp/agent-harness
 pip install -e .
 
 # Verify it's in PATH
@@ -55,7 +55,7 @@ cli-anything-gimp --help
 
 ```bash
 # Navigate to the CLI directory
-cd /root/cli-anything/gimp/agent-harness
+cd ~/cli-anything/gimp/agent-harness
 
 # Run the CLI directly (if installed)
 cli-anything-gimp --help
@@ -77,7 +77,7 @@ cli-anything-gimp repl
 /cli-anything:test gimp
 
 # Or manually
-cd /root/cli-anything/gimp/agent-harness
+cd ~/cli-anything/gimp/agent-harness
 python3 -m pytest cli_anything/gimp/tests/ -v
 
 # Force tests to use the installed command (recommended for validation)
@@ -130,7 +130,7 @@ After the initial build, use the refine command to expand coverage:
 /cli-anything /home/user/blender
 /cli-anything:validate /home/user/blender
 /cli-anything:test /home/user/blender
-cd /root/cli-anything/blender/agent-harness
+cd ~/cli-anything/blender/agent-harness
 pip install -e .
 which cli-anything-blender
 ```
@@ -170,10 +170,10 @@ pip install click pytest pillow numpy
 ### CLI doesn't work
 ```bash
 # Check if all files were created
-ls /root/cli-anything/<software>/agent-harness/cli_anything/<software>/
+ls ~/cli-anything/<software>/agent-harness/cli_anything/<software>/
 
 # Verify Python can import
-cd /root/cli-anything/<software>/agent-harness
+cd ~/cli-anything/<software>/agent-harness
 python3 -c "import cli_anything.<software>"
 
 # Check if installed to PATH
@@ -188,7 +188,7 @@ pip install -e .
 Once your CLI is ready:
 
 ```bash
-cd /root/cli-anything/<software>/agent-harness
+cd ~/cli-anything/<software>/agent-harness
 
 # Install build tools
 pip install build twine
@@ -210,7 +210,7 @@ cli-anything-blender --help
 ## Next Steps
 
 1. **Read the full README:** `cat README.md`
-2. **Study an example:** Explore `/root/cli-anything/gimp/agent-harness/cli_anything/gimp/`
+2. **Study an example:** Explore `~/cli-anything/gimp/agent-harness/cli_anything/gimp/`
 3. **Read HARNESS.md:** Understand the methodology at `~/.claude/plugins/cli-anything/HARNESS.md`
 4. **Build your own:** Choose a GUI app and run `/cli-anything <app-name>`
 

--- a/cli-anything-plugin/README.md
+++ b/cli-anything-plugin/README.md
@@ -311,7 +311,7 @@ After building a CLI with this plugin, you can:
 
 ### Install Locally
 ```bash
-cd /root/cli-anything/<software>/agent-harness
+cd ~/cli-anything/<software>/agent-harness
 pip install -e .
 cli-anything-<software> --help
 ```
@@ -342,7 +342,7 @@ This makes CLIs discoverable by AI agents that can check `which cli-anything-<so
 
 ### CLI not found
 
-- Verify output directory: `ls -la /root/cli-anything/<software>/agent-harness/cli_anything/<software>/`
+- Verify output directory: `ls -la ~/cli-anything/<software>/agent-harness/cli_anything/<software>/`
 - Check for errors in build phase
 - Try rebuilding: `/cli-anything <software-path>`
 
@@ -382,7 +382,7 @@ Inspired by the ralph-loop plugin's iterative development approach.
 
 - Documentation: See HARNESS.md in this plugin for the complete methodology
 - Issues: Report bugs or request features on GitHub
-- Examples: Check `/root/cli-anything/` for reference implementations
+- Examples: Check `~/cli-anything/` for reference implementations
 
 ## Version History
 

--- a/cli-anything-plugin/commands/test.md
+++ b/cli-anything-plugin/commands/test.md
@@ -20,7 +20,7 @@ Run tests for a CLI harness and update TEST.md with results.
 
   If a GitHub URL is provided, the agent clones the repo locally first, then works on the local copy.
 
-  The software name is derived from the directory name. The agent locates the CLI harness at `/root/cli-anything/<software-name>/agent-harness/`.
+  The software name is derived from the directory name. The agent locates the CLI harness at `~/cli-anything/<software-name>/agent-harness/`.
 
 ## What This Command Does
 

--- a/cli-anything-plugin/commands/validate.md
+++ b/cli-anything-plugin/commands/validate.md
@@ -20,7 +20,7 @@ Validate a CLI harness against HARNESS.md standards and best practices.
 
   If a GitHub URL is provided, the agent clones the repo locally first, then works on the local copy.
 
-  The software name is derived from the directory name. The agent locates the CLI harness at `/root/cli-anything/<software-name>/agent-harness/`.
+  The software name is derived from the directory name. The agent locates the CLI harness at `~/cli-anything/<software-name>/agent-harness/`.
 
 ## What This Command Validates
 
@@ -98,7 +98,7 @@ The command generates a detailed report:
 ```
 CLI Harness Validation Report
 Software: gimp
-Path: /root/cli-anything/gimp/agent-harness/cli_anything/gimp
+Path: ~/cli-anything/gimp/agent-harness/cli_anything/gimp
 
 Directory Structure (5/5 checks passed)
 Required Files (9/9 files present)

--- a/gimp/agent-harness/cli_anything/gimp/tests/TEST.md
+++ b/gimp/agent-harness/cli_anything/gimp/tests/TEST.md
@@ -126,7 +126,7 @@ E2E tests use real files: PNG images via PIL/Pillow, numpy arrays for pixel-leve
 ```
 ============================= test session starts ==============================
 platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.5.0
-rootdir: /root/cli-anything
+rootdir: ~/cli-anything
 plugins: langsmith-0.5.1, anyio-4.12.0
 collected 103 items
 

--- a/inkscape/agent-harness/cli_anything/inkscape/tests/TEST.md
+++ b/inkscape/agent-harness/cli_anything/inkscape/tests/TEST.md
@@ -180,7 +180,7 @@ E2E tests generate real SVG XML and validate structure, export to SVG/PNG with P
 ```
 ============================= test session starts ==============================
 platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.5.0
-rootdir: /root/cli-anything
+rootdir: ~/cli-anything
 plugins: langsmith-0.5.1, anyio-4.12.0
 collected 197 items
 

--- a/kdenlive/agent-harness/KDENLIVE.md
+++ b/kdenlive/agent-harness/KDENLIVE.md
@@ -7,7 +7,7 @@ The Kdenlive CLI harness provides a stateful command-line interface for non-line
 ## Setup
 
 ```bash
-cd /root/cli-anything/kdenlive/agent-harness
+cd ~/cli-anything/kdenlive/agent-harness
 pip install click
 ```
 
@@ -109,7 +109,7 @@ python3 -m cli.kdenlive_cli repl --project project.json
 ## Testing
 
 ```bash
-cd /root/cli-anything/kdenlive/agent-harness
+cd ~/cli-anything/kdenlive/agent-harness
 
 # Run all tests
 python3 -m pytest cli/tests/ -v

--- a/kdenlive/agent-harness/cli_anything/kdenlive/tests/TEST.md
+++ b/kdenlive/agent-harness/cli_anything/kdenlive/tests/TEST.md
@@ -145,7 +145,7 @@ E2E tests generate real MLT XML and validate structure, format correctness, and 
 ```
 ============================= test session starts ==============================
 platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.5.0
-rootdir: /root/cli-anything
+rootdir: ~/cli-anything
 plugins: langsmith-0.5.1, anyio-4.12.0
 collected 151 items
 

--- a/libreoffice/agent-harness/LIBREOFFICE.md
+++ b/libreoffice/agent-harness/LIBREOFFICE.md
@@ -51,7 +51,7 @@ Documents are stored as JSON project files (`.lo-cli.json`) with this structure:
 ## Running
 
 ```bash
-cd /root/cli-anything/libreoffice/agent-harness
+cd ~/cli-anything/libreoffice/agent-harness
 pip install click
 python3 -m cli.libreoffice_cli --help
 python3 -m pytest cli/tests/ -v

--- a/libreoffice/agent-harness/cli_anything/libreoffice/tests/TEST.md
+++ b/libreoffice/agent-harness/cli_anything/libreoffice/tests/TEST.md
@@ -157,7 +157,7 @@ E2E tests produce real ODF files (ODT/ODS/ODP) and validate ZIP structure, XML c
 ```
 ============================= test session starts ==============================
 platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.5.0
-rootdir: /root/cli-anything
+rootdir: ~/cli-anything
 plugins: langsmith-0.5.1, anyio-4.12.0
 collected 143 items
 

--- a/obs-studio/agent-harness/OBS.md
+++ b/obs-studio/agent-harness/OBS.md
@@ -18,7 +18,7 @@ control over OBS scene collections via JSON configuration files.
 ## CLI Harness Location
 
 ```
-/root/cli-anything/obs-studio/agent-harness/cli/
+~/cli-anything/obs-studio/agent-harness/cli/
 ```
 
 ## Usage
@@ -26,7 +26,7 @@ control over OBS scene collections via JSON configuration files.
 ### Creating a Stream Setup
 
 ```bash
-cd /root/cli-anything/obs-studio/agent-harness
+cd ~/cli-anything/obs-studio/agent-harness
 
 # 1. Create project
 python3 -m cli.obs_cli project new --name "my_stream" -o stream.json
@@ -142,7 +142,7 @@ python3 -m cli.obs_cli repl --project stream.json
 ## Testing
 
 ```bash
-cd /root/cli-anything/obs-studio/agent-harness
+cd ~/cli-anything/obs-studio/agent-harness
 python3 -m pytest cli/tests/ -v
 ```
 

--- a/obs-studio/agent-harness/cli_anything/obs_studio/tests/TEST.md
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/tests/TEST.md
@@ -153,7 +153,7 @@ E2E tests validate complete streaming/recording workflows without OBS Studio ins
 ```
 ============================= test session starts ==============================
 platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.5.0
-rootdir: /root/cli-anything
+rootdir: ~/cli-anything
 plugins: langsmith-0.5.1, anyio-4.12.0
 collected 153 items
 


### PR DESCRIPTION
## Summary

Fixes issue #3 - Documentation uses non-portable `/root/` paths in examples

## Changes

- Replaced all `/root/cli-anything` occurrences with `~/cli-anything`
- Makes examples work for non-root users
- More consistent with user home directory conventions

## Files Changed

17 documentation files updated (README.md, QUICKSTART.md, HARNESS.md, PUBLISHING.md, etc.)

## Testing

- Verified all paths are now portable
- No functional changes, documentation only