### PR TITLE
fix: [shotcut] add missing lxml dependency to shotcut/agent-harness/setup.py

### DIFF
--- a/shotcut/agent-harness/setup.py
+++ b/shotcut/agent-harness/setup.py
@@ -36,6 +36,7 @@ setup(
     install_requires=[
         "click>=8.0.0",
         "prompt-toolkit>=3.0.0",
+        "lxml>=4.9.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
This PR adds `lxml` to the `install_requires` list in `shotcut/agent-harness/setup.py`.

**The Problem:**
Currently, installing the package via standard tools fails to produce a working CLI because a core dependency is missing from the installation manifest. Specifically, my use case was:
> **"Installing `cli-anything-shotcut` via the `uv tool install .` command failed for me."**
Note: This was attempted from the `./shotcut/agent-harness` directory.

The installation completed, but running `cli-anything-shotcut` immediately crashed with a `ModuleNotFoundError: No module named 'lxml'`.

**The Justification:**
The codebase relies heavily on `lxml.etree` for all MLT XML project manipulation (found in `cli_anything/shotcut/core/` and `cli_anything/shotcut/utils/mlt_xml.py`).

Furthermore, **`lxml` is already documented as a requirement** in `cli_anything/shotcut/README.md` under the **Prerequisites** and **Install Dependencies** sections:
> *From README.md:*
> ```markdown
> ## Prerequisites
> - Python 3.10+
> - lxml (XML manipulation)
> ...
> ## Install Dependencies
> pip install lxml click prompt_toolkit
> ```

By adding it to `setup.py`, we ensure that `pip install`, `uv tool install`, and other package managers automatically resolve and install `lxml` without requiring manual user intervention.

### **Changes**
- Updated `shotcut/agent-harness/setup.py` to include `lxml>=4.9.0` in the `install_requires` list.

### **Verification Results**
- **Platform:** Linux (Ubuntu/Debian)
- **Tool:** `uv tool install .`
- **Result:** After the change, the command `cli-anything-shotcut --help` successfully executes from a clean global environment.
