### PR TITLE
fix(shotcut): add auto-save option for one-shot mode

### DIFF
--- a/shotcut/agent-harness/cli_anything/shotcut/shotcut_cli.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/shotcut_cli.py
@@ -114,6 +114,7 @@ def handle_error(func):
 
 
 _repl_mode = False
+_auto_save = False
 
 
 # ============================================================================
@@ -124,17 +125,23 @@ _repl_mode = False
 @click.option("--json", "json_mode", is_flag=True, help="Output in JSON format")
 @click.option("--session", "session_id", default=None, help="Session ID to use/resume")
 @click.option("--project", "project_path", default=None, help="Open a project file")
+@click.option("-s", "--save", "auto_save", is_flag=True, 
+              help="Auto-save project after each mutation command (one-shot mode)")
 @click.pass_context
-def cli(ctx, json_mode, session_id, project_path):
+def cli(ctx, json_mode, session_id, project_path, auto_save):
     """Shotcut CLI — Video editing from the command line.
 
     A stateful CLI for manipulating Shotcut/MLT video projects.
     Designed for AI agents and power users.
 
     Run without a subcommand to enter interactive REPL mode.
+    
+    Use -s/--save to automatically save changes after each mutation command.
+    This is useful in one-shot mode where each command runs in a new process.
     """
-    global _json_output, _session
+    global _json_output, _session, _auto_save
     _json_output = json_mode
+    _auto_save = auto_save
 
     if session_id:
         _session = Session(session_id)
@@ -144,8 +151,24 @@ def cli(ctx, json_mode, session_id, project_path):
     if project_path:
         _session.open_project(project_path)
 
+    # Register auto-save callback to run after each command
+    ctx.call_on_close(_auto_save_callback)
+
     if ctx.invoked_subcommand is None:
         ctx.invoke(repl, project_path=None)
+
+
+def _auto_save_callback():
+    """Auto-save callback that runs after each command."""
+    global _auto_save, _session
+    if _auto_save and _session and _session.is_open and _session.is_modified:
+        # Don't auto-save if we're in REPL mode (user can explicitly save)
+        if not _repl_mode:
+            try:
+                _session.save_project()
+                click.echo(f"Auto-saved to: {_session.project_path}")
+            except Exception as e:
+                click.echo(f"Auto-save failed: {e}", err=True)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Add `-s/--save` flag to automatically save project after each mutation command. This fixes the issue where one-shot commands don't persist changes because each command runs in a new process with a fresh session.

## Changes

- Add `auto_save` global flag to CLI group
- Add `-s/--save` option to the main CLI
- Implement `_auto_save_callback()` that runs after each command
- Auto-save only in one-shot mode (not REPL mode)

## Usage

```bash
# Before (changes not persisted):
shotcut-cli --project edit.mlt timeline add-track --type video
shotcut-cli --project edit.mlt project info  # track_count: 0

# After (with -s flag):
shotcut-cli --project edit.mlt -s timeline add-track --type video
# Auto-saved to: edit.mlt
shotcut-cli --project edit.mlt project info  # track_count: 1
```

## Test

Verified the fix works:
- Created new project
- Added track with `-s` flag
- Track persisted in project file

Fixes #14