### PR TITLE
fix(libreoffice): enable real LibreOffice backend on Windows and macOS

### DIFF
--- a/libreoffice/agent-harness/cli_anything/libreoffice/utils/lo_backend.py
+++ b/libreoffice/agent-harness/cli_anything/libreoffice/utils/lo_backend.py
@@ -20,29 +20,61 @@ from typing import Optional
 def find_libreoffice() -> str:
     """Find the LibreOffice executable.
 
-    Returns the absolute path to the libreoffice binary.
+    Returns the absolute path to the libreoffice/soffice binary.
+    Searches PATH first, then common installation directories on each platform.
     Raises RuntimeError if not found.
     """
+    # 1) Check PATH
     for name in ("libreoffice", "soffice"):
         path = shutil.which(name)
         if path:
             return path
+
+    # 2) Check common installation paths (Windows)
+    import sys
+    if sys.platform == "win32" or os.name == "nt" or "MSYS" in os.environ.get("MSYSTEM", "") or "msys" in sys.platform or os.path.exists("C:/"):
+        win_candidates = [
+            os.path.join(os.environ.get("PROGRAMFILES", r"C:\Program Files"),
+                         "LibreOffice", "program", "soffice.exe"),
+            os.path.join(os.environ.get("PROGRAMFILES(X86)", r"C:\Program Files (x86)"),
+                         "LibreOffice", "program", "soffice.exe"),
+            r"C:\Program Files\LibreOffice\program\soffice.exe",
+            r"C:\Program Files (x86)\LibreOffice\program\soffice.exe",
+        ]
+        for candidate in win_candidates:
+            if os.path.isfile(candidate):
+                return candidate
+
+    # 3) Check common installation paths (macOS)
+    mac_candidate = "/Applications/LibreOffice.app/Contents/MacOS/soffice"
+    if os.path.isfile(mac_candidate):
+        return mac_candidate
+
     raise RuntimeError(
         "LibreOffice is not installed. Install it with:\n"
-        "  apt install libreoffice        # Debian/Ubuntu\n"
-        "  brew install --cask libreoffice # macOS\n"
-        "  choco install libreoffice       # Windows"
+        "  apt install libreoffice          # Debian/Ubuntu\n"
+        "  brew install --cask libreoffice   # macOS\n"
+        "  winget install TheDocumentFoundation.LibreOffice  # Windows"
     )
 
 
 def get_version() -> str:
     """Get the installed LibreOffice version string."""
     lo = find_libreoffice()
-    result = subprocess.run(
-        [lo, "--version"],
-        capture_output=True, text=True, timeout=10,
-    )
-    return result.stdout.strip()
+    try:
+        result = subprocess.run(
+            [lo, "--headless", "--version"],
+            capture_output=True, text=True, timeout=15,
+        )
+        version = result.stdout.strip()
+        if version:
+            return version
+        # Some Windows builds print to stderr
+        if result.stderr.strip():
+            return result.stderr.strip()
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return f"LibreOffice (path: {lo})"
 
 
 def convert(


### PR DESCRIPTION
## Summary

The LibreOffice harness has solid architecture — ODF generation via Python stdlib + real LibreOffice headless for PDF/DOCX/XLSX/PPTX conversion. However, it didn't work out of the box on **Windows** or **macOS** due to two issues:

- **`find_libreoffice()`** only searched `PATH`. On Windows, LibreOffice installs to `C:\Program Files\LibreOffice\program\` which is not on PATH by default. On macOS it's under `/Applications/LibreOffice.app/`. Added platform-aware fallback paths.

- **`get_version()`** called `soffice --version` without `--headless`, which opens a GUI splash screen on Windows and hangs indefinitely (timeout after 10s). Added `--headless` flag and graceful timeout fallback.

## Test results (Windows, LibreOffice 26.2.1)

```
test_core.py          89 passed  ✅  (unit tests, synthetic data)
test_full_e2e.py      69 passed  ✅  (including 13 real LibreOffice backend tests)
─────────────────────────────────────────────
TOTAL                158 passed  ✅  100% pass rate
```

Real backend conversions verified:
| Format | Size | Validation |
|--------|------|-----------|
| Writer → PDF | 23,544 bytes | `%PDF-` magic bytes |
| Writer → PDF (rich) | 39,638 bytes | `%PDF-` magic bytes |
| Writer → DOCX | 5,918 bytes | OOXML ZIP structure |
| Calc → XLSX | 5,612 bytes | OOXML ZIP structure |
| Calc → CSV | 22 bytes | Content verification |
| Impress → PPTX | 11,198 bytes | OOXML ZIP structure |
| CLI subprocess → PDF | 6,490 bytes | `%PDF-` magic bytes |

## Changes

Only **1 file** changed: `libreoffice/agent-harness/cli_anything/libreoffice/utils/lo_backend.py`
- `find_libreoffice()`: +Windows/macOS install path fallbacks
- `get_version()`: +`--headless` flag, +timeout error handling

No new dependencies. Fully backward-compatible with Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)