### PR TITLE
Fix hardcoded plugin path assumptions

### DIFF
--- a/cli-anything-plugin/HARNESS.md
+++ b/cli-anything-plugin/HARNESS.md
@@ -589,7 +589,7 @@ side-by-side in the same Python environment without conflicts.
 
 4. **Test local installation**:
    ```bash
-   cd /root/cli-anything/<software>/agent-harness
+   cd <software-path>/agent-harness
    pip install -e .
    ```
 
@@ -601,7 +601,7 @@ side-by-side in the same Python environment without conflicts.
 
 6. **Run tests against the installed command**:
    ```bash
-   cd /root/cli-anything/<software>/agent-harness
+   cd <software-path>/agent-harness
    CLI_ANYTHING_FORCE_INSTALLED=1 python3 -m pytest cli_anything/<software>/tests/ -v -s
    ```
    The output must show `[_resolve_cli] Using installed command: /path/to/cli-anything-<software>`

--- a/cli-anything-plugin/PUBLISHING.md
+++ b/cli-anything-plugin/PUBLISHING.md
@@ -8,7 +8,8 @@ This guide explains how to make the cli-anything plugin installable and publish 
 
 1. **Copy to Claude Code plugins directory:**
    ```bash
-   cp -r /root/cli-anything/cli-anything-plugin ~/.claude/plugins/cli-anything
+   REPO_ROOT=/path/to/CLI-Anything
+   cp -r "$REPO_ROOT/cli-anything-plugin" ~/.claude/plugins/cli-anything
    ```
 
 2. **Reload plugins in Claude Code:**
@@ -25,7 +26,8 @@ This guide explains how to make the cli-anything plugin installable and publish 
 
 Package as a tarball:
 ```bash
-cd /root/cli-anything
+REPO_ROOT=/path/to/CLI-Anything
+cd "$REPO_ROOT"
 tar -czf cli-anything-plugin-v1.0.0.tar.gz cli-anything-plugin/
 ```
 
@@ -40,7 +42,8 @@ tar -xzf cli-anything-plugin-v1.0.0.tar.gz
 ### 1. Create GitHub Repository
 
 ```bash
-cd /root/cli-anything/cli-anything-plugin
+REPO_ROOT=/path/to/CLI-Anything
+cd "$REPO_ROOT/cli-anything-plugin"
 
 # Initialize git
 git init
@@ -103,9 +106,10 @@ Ensure your plugin meets requirements:
 
 2. **Add your plugin to external_plugins:**
    ```bash
+   REPO_ROOT=/path/to/CLI-Anything
    cd claude-plugins-official
    mkdir -p external_plugins/cli-anything
-   cp -r /root/cli-anything/cli-anything-plugin/* external_plugins/cli-anything/
+   cp -r "$REPO_ROOT/cli-anything-plugin/"* external_plugins/cli-anything/
    ```
 
 3. **Create pull request:**

--- a/cli-anything-plugin/QUICKSTART.md
+++ b/cli-anything-plugin/QUICKSTART.md
@@ -6,7 +6,8 @@ Get started with the cli-anything plugin in 5 minutes.
 
 ```bash
 # Copy plugin to Claude Code plugins directory
-cp -r /root/cli-anything/cli-anything-plugin ~/.claude/plugins/cli-anything
+REPO_ROOT=/path/to/CLI-Anything
+cp -r "$REPO_ROOT/cli-anything-plugin" ~/.claude/plugins/cli-anything
 
 # Reload plugins in Claude Code
 /reload-plugins
@@ -21,7 +22,7 @@ Let's build a CLI for a simple GUI application:
 
 ```bash
 # Build complete CLI harness for GIMP
-/cli-anything gimp
+/cli-anything /path/to/gimp-source
 ```
 
 This will:
@@ -35,13 +36,13 @@ This will:
 
 **Time:** ~10-15 minutes (depending on complexity)
 
-**Output:** `/root/cli-anything/gimp/agent-harness/`
+**Output:** `/path/to/gimp-source/agent-harness/`
 
 ## Install the CLI
 
 ```bash
 # Install to system PATH
-cd /root/cli-anything/gimp/agent-harness
+cd /path/to/gimp-source/agent-harness
 pip install -e .
 
 # Verify it's in PATH
@@ -55,7 +56,7 @@ cli-anything-gimp --help
 
 ```bash
 # Navigate to the CLI directory
-cd /root/cli-anything/gimp/agent-harness
+cd /path/to/gimp-source/agent-harness
 
 # Run the CLI directly (if installed)
 cli-anything-gimp --help
@@ -74,10 +75,10 @@ cli-anything-gimp repl
 
 ```bash
 # Run all tests
-/cli-anything:test gimp
+/cli-anything:test /path/to/gimp-source
 
 # Or manually
-cd /root/cli-anything/gimp/agent-harness
+cd /path/to/gimp-source/agent-harness
 python3 -m pytest cli_anything/gimp/tests/ -v
 
 # Force tests to use the installed command (recommended for validation)
@@ -89,20 +90,20 @@ CLI_ANYTHING_FORCE_INSTALLED=1 python3 -m pytest cli_anything/gimp/tests/ -v -s
 
 ```bash
 # Check if CLI meets all standards
-/cli-anything:validate gimp
+/cli-anything:validate /path/to/gimp-source
 ```
 
 ## Build Another CLI
 
 ```bash
 # Build CLI for Blender (3D software)
-/cli-anything blender
+/cli-anything /path/to/blender-source
 
 # Build CLI for Inkscape (vector graphics)
-/cli-anything inkscape
+/cli-anything /path/to/inkscape-source
 
 # Build CLI for Audacity (audio editor)
-/cli-anything audacity
+/cli-anything /path/to/audacity-source
 ```
 
 ## Refining an Existing CLI
@@ -130,7 +131,7 @@ After the initial build, use the refine command to expand coverage:
 /cli-anything /home/user/blender
 /cli-anything:validate /home/user/blender
 /cli-anything:test /home/user/blender
-cd /root/cli-anything/blender/agent-harness
+cd /home/user/blender/agent-harness
 pip install -e .
 which cli-anything-blender
 ```
@@ -170,10 +171,10 @@ pip install click pytest pillow numpy
 ### CLI doesn't work
 ```bash
 # Check if all files were created
-ls /root/cli-anything/<software>/agent-harness/cli_anything/<software>/
+ls <software-path>/agent-harness/cli_anything/<software>/
 
 # Verify Python can import
-cd /root/cli-anything/<software>/agent-harness
+cd <software-path>/agent-harness
 python3 -c "import cli_anything.<software>"
 
 # Check if installed to PATH
@@ -188,7 +189,7 @@ pip install -e .
 Once your CLI is ready:
 
 ```bash
-cd /root/cli-anything/<software>/agent-harness
+cd <software-path>/agent-harness
 
 # Install build tools
 pip install build twine
@@ -210,9 +211,9 @@ cli-anything-blender --help
 ## Next Steps
 
 1. **Read the full README:** `cat README.md`
-2. **Study an example:** Explore `/root/cli-anything/gimp/agent-harness/cli_anything/gimp/`
-3. **Read HARNESS.md:** Understand the methodology at `~/.claude/plugins/cli-anything/HARNESS.md`
-4. **Build your own:** Choose a GUI app and run `/cli-anything <app-name>`
+2. **Study an example:** Explore `<software-path>/agent-harness/cli_anything/<software>/`
+3. **Read HARNESS.md:** Understand the methodology at `<plugin-dir>/HARNESS.md` (commonly `~/.claude/plugins/cli-anything/HARNESS.md`)
+4. **Build your own:** Choose a GUI app and run `/cli-anything <software-path-or-repo>`
 
 ## Tips
 

--- a/cli-anything-plugin/README.md
+++ b/cli-anything-plugin/README.md
@@ -44,7 +44,7 @@ The result: A stateful CLI with REPL mode, JSON output, undo/redo, and full test
 - Python 3.10+
 - `click` - CLI framework
 - `pytest` - Testing framework
-- HARNESS.md (included in this plugin at `~/.claude/plugins/cli-anything/HARNESS.md`)
+- HARNESS.md (included alongside this plugin at `<plugin-dir>/HARNESS.md`; commonly `~/.claude/plugins/cli-anything/HARNESS.md`)
 
 Install Python dependencies:
 ```bash
@@ -341,7 +341,7 @@ After building a CLI with this plugin, you can:
 
 ### Install Locally
 ```bash
-cd /root/cli-anything/<software>/agent-harness
+cd <software-path>/agent-harness
 pip install -e .
 cli-anything-<software> --help
 ```
@@ -372,7 +372,7 @@ This makes CLIs discoverable by AI agents that can check `which cli-anything-<so
 
 ### CLI not found
 
-- Verify output directory: `ls -la /root/cli-anything/<software>/agent-harness/cli_anything/<software>/`
+- Verify output directory: `ls -la <software-path>/agent-harness/cli_anything/<software>/`
 - Check for errors in build phase
 - Try rebuilding: `/cli-anything <software-path>`
 
@@ -412,7 +412,7 @@ Inspired by the ralph-loop plugin's iterative development approach.
 
 - Documentation: See HARNESS.md in this plugin for the complete methodology
 - Issues: Report bugs or request features on GitHub
-- Examples: Check `/root/cli-anything/` for reference implementations
+- Examples: Check the software directories in this repository (`gimp/`, `blender/`, `drawio/`, etc.) for reference implementations
 
 ## Version History
 

--- a/cli-anything-plugin/commands/test.md
+++ b/cli-anything-plugin/commands/test.md
@@ -20,7 +20,7 @@ Run tests for a CLI harness and update TEST.md with results.
 
   If a GitHub URL is provided, the agent clones the repo locally first, then works on the local copy.
 
-  The software name is derived from the directory name. The agent locates the CLI harness at `/root/cli-anything/<software-name>/agent-harness/`.
+  The software name is derived from the directory name. The agent locates the CLI harness relative to the resolved local source tree at `<software-path>/agent-harness/`.
 
 ## What This Command Does
 

--- a/cli-anything-plugin/commands/validate.md
+++ b/cli-anything-plugin/commands/validate.md
@@ -20,7 +20,7 @@ Validate a CLI harness against HARNESS.md standards and best practices.
 
   If a GitHub URL is provided, the agent clones the repo locally first, then works on the local copy.
 
-  The software name is derived from the directory name. The agent locates the CLI harness at `/root/cli-anything/<software-name>/agent-harness/`.
+  The software name is derived from the directory name. The agent locates the CLI harness relative to the resolved local source tree at `<software-path>/agent-harness/`.
 
 ## What This Command Validates
 
@@ -98,7 +98,7 @@ The command generates a detailed report:
 ```
 CLI Harness Validation Report
 Software: gimp
-Path: /root/cli-anything/gimp/agent-harness/cli_anything/gimp
+Path: /home/user/gimp/agent-harness/cli_anything/gimp
 
 Directory Structure (5/5 checks passed)
 Required Files (9/9 files present)

--- a/cli-anything-plugin/scripts/setup-cli-anything.sh
+++ b/cli-anything-plugin/scripts/setup-cli-anything.sh
@@ -13,6 +13,8 @@ NC='\033[0m' # No Color
 # Plugin info
 PLUGIN_NAME="cli-anything"
 PLUGIN_VERSION="1.0.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${BLUE}  cli-anything Plugin v${PLUGIN_VERSION}${NC}"
@@ -21,12 +23,14 @@ echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━�
 echo ""
 
 # Check if HARNESS.md exists
-HARNESS_PATH="/root/cli-anything/HARNESS.md"
+HARNESS_PATH="$PLUGIN_DIR/HARNESS.md"
 if [ ! -f "$HARNESS_PATH" ]; then
     echo -e "${YELLOW}⚠️  HARNESS.md not found at $HARNESS_PATH${NC}"
-    echo -e "${YELLOW}   The cli-anything methodology requires HARNESS.md${NC}"
-    echo -e "${YELLOW}   You can create it or specify a custom path with --harness-path${NC}"
+    echo -e "${YELLOW}   The cli-anything methodology expects HARNESS.md to ship with the plugin${NC}"
+    echo -e "${YELLOW}   Reinstall or re-copy the plugin if this file is missing${NC}"
     echo ""
+else
+    echo -e "${GREEN}✓${NC} HARNESS.md found: ${HARNESS_PATH}"
 fi
 
 # Check Python version
@@ -85,7 +89,8 @@ echo -e "  ${BLUE}/cli-anything:validate${NC} /home/user/audacity"
 echo ""
 echo "Documentation:"
 echo ""
-echo "  HARNESS.md: /root/cli-anything/HARNESS.md"
+echo "  Plugin directory: ${PLUGIN_DIR}"
+echo "  HARNESS.md: ${HARNESS_PATH}"
 echo "  Plugin README: Use '/help cli-anything' for more info"
 echo ""
 echo -e "${GREEN}Ready to build CLI harnesses! 🚀${NC}"


### PR DESCRIPTION
## Summary
- resolve `HARNESS.md` relative to the installed plugin directory in `setup-cli-anything.sh`
- replace `/root/cli-anything/...` guidance with plugin-relative and source-relative paths in the plugin docs
- update quickstart, publishing, and methodology examples so they work from any local checkout layout

## Verification
- `bash -n cli-anything-plugin/scripts/setup-cli-anything.sh`
- `git diff --check`
