### PR TITLE
fix: replace placeholder URLs with correct HKUDS/CLI-Anything URL

### DIFF
--- a/audacity/agent-harness/setup.py
+++ b/audacity/agent-harness/setup.py
@@ -19,7 +19,7 @@ setup(
     description="CLI harness for Audacity - Audio editing and processing via sox. Requires: sox (apt install sox)",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/cli-anything-audacity",
+    url="https://github.com/HKUDS/CLI-Anything",
     packages=find_namespace_packages(include=["cli_anything.*"]),
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/blender/agent-harness/setup.py
+++ b/blender/agent-harness/setup.py
@@ -19,7 +19,7 @@ setup(
     description="CLI harness for Blender - 3D modeling, animation, and rendering via blender --background --python. Requires: blender (apt install blender)",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/cli-anything-blender",
+    url="https://github.com/HKUDS/CLI-Anything",
     packages=find_namespace_packages(include=["cli_anything.*"]),
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/gimp/agent-harness/setup.py
+++ b/gimp/agent-harness/setup.py
@@ -19,7 +19,7 @@ setup(
     description="CLI harness for GIMP - Raster image processing via gimp -i -b (batch mode). Requires: gimp (apt install gimp)",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/cli-anything-gimp",
+    url="https://github.com/HKUDS/CLI-Anything",
     packages=find_namespace_packages(include=["cli_anything.*"]),
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/inkscape/agent-harness/setup.py
+++ b/inkscape/agent-harness/setup.py
@@ -19,7 +19,7 @@ setup(
     description="CLI harness for Inkscape - SVG vector graphics with export via inkscape --export-filename. Requires: inkscape (apt install inkscape)",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/cli-anything-inkscape",
+    url="https://github.com/HKUDS/CLI-Anything",
     packages=find_namespace_packages(include=["cli_anything.*"]),
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/kdenlive/agent-harness/setup.py
+++ b/kdenlive/agent-harness/setup.py
@@ -19,7 +19,7 @@ setup(
     description="CLI harness for Kdenlive - Video editing and rendering via melt. Requires: melt (apt install melt)",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/cli-anything-kdenlive",
+    url="https://github.com/HKUDS/CLI-Anything",
     packages=find_namespace_packages(include=["cli_anything.*"]),
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/libreoffice/agent-harness/setup.py
+++ b/libreoffice/agent-harness/setup.py
@@ -19,7 +19,7 @@ setup(
     description="CLI harness for LibreOffice - Create and manipulate ODF documents, export to PDF/DOCX/XLSX/PPTX via LibreOffice headless",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/cli-anything-libreoffice",
+    url="https://github.com/HKUDS/CLI-Anything",
     packages=find_namespace_packages(include=["cli_anything.*"]),
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/obs-studio/agent-harness/setup.py
+++ b/obs-studio/agent-harness/setup.py
@@ -19,7 +19,7 @@ setup(
     description="CLI harness for OBS Studio - Create and manage streaming/recording scenes via command line",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/cli-anything-obs-studio",
+    url="https://github.com/HKUDS/CLI-Anything",
     packages=find_namespace_packages(include=["cli_anything.*"]),
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/shotcut/agent-harness/setup.py
+++ b/shotcut/agent-harness/setup.py
@@ -19,7 +19,7 @@ setup(
     description="CLI harness for Shotcut - Video editing and rendering via melt/ffmpeg. Requires: melt (apt install melt), ffmpeg (apt install ffmpeg)",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/cli-anything-shotcut",
+    url="https://github.com/HKUDS/CLI-Anything",
     packages=find_namespace_packages(include=["cli_anything.*"]),
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Fixed 8 setup.py files that had placeholder URLs:
- Changed 'yourusername' to 'HKUDS'  
- Changed repo name to 'CLI-Anything'

This fixes broken metadata when packages are published to PyPI.

Fixes #17