### PR TITLE
docs(shotcut): clarify REPL vs one-shot auto-save

### DIFF
--- a/shotcut/agent-harness/HARNESS.md
+++ b/shotcut/agent-harness/HARNESS.md
@@ -215,6 +215,68 @@ agent-harness/
 └── workflow_demo.py        # Full demo: 3-segment highlight reel
 ```
 
+## Shotcut CLI Execution & Persistence Model
+
+The Shotcut CLI (`shotcut-cli`) intentionally supports **both**:
+
+- A **stateful REPL** for interactive editing, and
+- **One-shot commands** for scripting and pipelines.
+
+Because session and process lifetime differ in these two modes, **persistence
+rules must be explicit**, especially for agents.
+
+### REPL mode
+
+- Started via the `repl` subcommand:
+  - `shotcut-cli repl`
+- Runs as a single long-lived process.
+- All commands share the same in-memory `Session`.
+- Project changes are **not automatically saved** to disk.
+- The user/agent is expected to call an explicit save when ready:
+  - `project save [path]`
+
+### One-shot mode
+
+- Any `shotcut-cli` invocation **without** the `repl` subcommand:
+  - `shotcut-cli project new ...`
+  - `shotcut-cli timeline add-track --type video`
+  - `shotcut-cli filter add brightness ...`
+- Each invocation runs in a **fresh process** with a fresh `Session`.
+- By default, changes are **in-memory only** and are **not persisted** unless
+  the command:
+  - Performs an explicit save (e.g., `project save`), or
+  - Runs with auto-save enabled (see below).
+
+### Auto-save for one-shot commands
+
+To make one-shot commands behave more like "run and persist", the CLI supports
+an `-s/--save` flag on the main entrypoint:
+
+```bash
+# Without auto-save: changes are in-memory only
+shotcut-cli --project edit.mlt timeline add-track --type video
+shotcut-cli --project edit.mlt project info  # track_count: 0
+
+# With auto-save: changes are written back to edit.mlt
+shotcut-cli --project edit.mlt -s timeline add-track --type video
+shotcut-cli --project edit.mlt project info  # track_count: 1
+```
+
+- `-s/--save` sets a global `auto_save` flag on the CLI group.
+- An internal `_auto_save_callback()` runs after each command.
+- Auto-save is **only applied in one-shot mode**:
+  - In REPL mode, the user/agent remains in full control of when to save.
+
+> **Design note**
+>
+> Today, one-shot commands **do not** auto-save by default, even though many
+> users might intuitively expect that behavior when they are *not* using
+> `repl`. The `-s/--save` flag makes this behavior explicit and opt-in.
+>
+> In the future, we may consider flipping this default (auto-save for one-shot
+> by default, with an explicit `--no-save` override) if that better matches
+> common usage patterns.
+
 ## Applying This to Other Software
 
 This same SOP applies to any GUI application:


### PR DESCRIPTION
## Summary

Clarify the execution model for Shotcut's REPL vs one-shot usage in
`shotcut/agent-harness/HARNESS.md`, and document how the new
`-s/--save` flag affects auto-save behavior in one-shot mode.

This addresses follow-up concerns raised in
[#15](https://github.com/HKUDS/CLI-Anything/pull/15) about user
expectations for persistence when *not* using the `repl` subcommand.

## Background

In #15 we introduced the `-s/--save` flag and an `auto_save` global
flag so that one-shot commands can automatically persist changes to the
project file after each mutation command.

As @jarrodcolburn pointed out, if the `repl` subcommand is not used,
many users might reasonably expect that commands will save changes by
default, making an explicit `--save` flag feel redundant.

@yuh-yang suggested addressing this more fundamentally via
`HARNESS.md`, which this PR does.

## Changes

- Document the distinction between:
  - **REPL mode**: long-running process, shared in-memory session,
    no automatic saving.
  - **One-shot mode**: fresh process per invocation, in-memory changes
    only unless saved explicitly or via auto-save.
- Document how `-s/--save` enables auto-save for one-shot commands,
  including a concrete before/after example with `timeline add-track`.
- Add a short "Design note" acknowledging that:
  - Today, one-shot commands do *not* auto-save by default.
  - This is an intentional, explicit design that may be revisited
    (e.g. flipping the default to auto-save with a `--no-save` override)
    if it proves to better match common usage patterns.

## Rationale

This PR does **not** change any behavior introduced in #15. Instead, it:

- Makes the execution and persistence model explicit in `HARNESS.md`.
- Documents the reasoning and trade-offs behind the current default.
- Provides a clear place to discuss potential future changes (such as
  default auto-save for one-shot with a `--no-save` opt-out).

This should help set expectations for users running one-shot commands,
and directly addresses the concerns raised in the discussion on #15.
