### PR TITLE
feat: add Qodercli skill support for CLI-Anything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 # Step 3: Allow cli-anything-plugin entirely
 !/cli-anything-plugin/
+!/qodercli-skill/
 
 # Step 4: Allow each software dir (top level only)
 !/gimp/

--- a/README.md
+++ b/README.md
@@ -183,6 +183,35 @@ The command runs as a subtask and follows the same 7-phase methodology as Claude
 </details>
 
 <details>
+<summary><h4 id="-qodercli">⚡ Qodercli</h4></summary>
+
+**Step 1: Install the Skill**
+
+```bash
+git clone https://github.com/HKUDS/CLI-Anything.git
+bash CLI-Anything/qodercli-skill/scripts/install.sh
+```
+
+This installs the skill to `$QODER_HOME/skills/cli-anything` (or `~/.qoder/skills/cli-anything` if `QODER_HOME` is unset).
+
+Restart Qodercli after installation so it is discovered.
+
+**Step 2: Use CLI-Anything from Qodercli**
+
+Describe the task in natural language, for example:
+
+```text
+Use CLI-Anything to build a harness for ./gimp
+Use CLI-Anything to refine ./shotcut for picture-in-picture workflows
+Use CLI-Anything to validate ./libreoffice
+```
+
+The Qodercli skill adapts the same methodology used by the Claude Code plugin and
+OpenCode commands, while keeping the generated Python harness format unchanged.
+
+</details>
+
+<details>
 <summary><h4 id="-more-platforms-coming-soon">🔮 More Platforms (Coming Soon)</h4></summary>
 
 CLI-Anything is designed to be platform-agnostic. Support for more AI coding agents is planned:
@@ -209,7 +238,6 @@ cli-anything-gimp --json layer add -n "Background" --type solid --color "#1a1a2e
 # Enter interactive REPL
 cli-anything-gimp
 ```
-
 ---
 
 ## 💡 CLI-Anything's Vision: Building Agent-Native Software

--- a/README_CN.md
+++ b/README_CN.md
@@ -183,6 +183,34 @@ cp CLI-Anything/cli-anything-plugin/HARNESS.md .opencode/commands/
 </details>
 
 <details>
+<summary><h4 id="-qodercli">⚡ Qodercli</h4></summary>
+
+**第一步：安装 Skill**
+
+```bash
+git clone https://github.com/HKUDS/CLI-Anything.git
+bash CLI-Anything/qodercli-skill/scripts/install.sh
+```
+
+这会将 skill 安装到 `$QODER_HOME/skills/cli-anything`（如果未设置 `QODER_HOME`，则为 `~/.qoder/skills/cli-anything`）。
+
+安装后重启 Qodercli 以使其被发现。
+
+**第二步：在 Qodercli 中使用 CLI-Anything**
+
+用自然语言描述任务，例如：
+
+```text
+Use CLI-Anything to build a harness for ./gimp
+Use CLI-Anything to refine ./shotcut for picture-in-picture workflows
+Use CLI-Anything to validate ./libreoffice
+```
+
+Qodercli skill 采用与 Claude Code 插件和 OpenCode 命令相同的方法论，同时保持生成的 Python harness 格式不变。
+
+</details>
+
+<details>
 <summary><h4 id="-更多平台即将支持">🔮 更多平台（即将支持）</h4></summary>
 
 CLI-Anything 的设计是平台无关的，计划支持更多 AI 编程工具：
@@ -209,7 +237,6 @@ cli-anything-gimp --json layer add -n "Background" --type solid --color "#1a1a2e
 # 进入交互式 REPL
 cli-anything-gimp
 ```
-
 ---
 
 ## 💡 CLI-Anything 的愿景：构建 Agent 原生的软件生态

--- a/qodercli-skill/SKILL.md
+++ b/qodercli-skill/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: cli-anything
+description: Use when the user wants Qodercli to build, refine, test, or validate a CLI-Anything harness for a GUI application or source repository. Adapts the CLI-Anything methodology to Qodercli without changing the generated Python harness format.
+---
+
+# CLI-Anything for Qodercli
+
+Use this skill when the user wants Qodercli to act like the `CLI-Anything` builder.
+
+If this skill is being used from inside the `CLI-Anything` repository, read `../cli-anything-plugin/HARNESS.md` before implementation. That file is the full methodology source of truth. If it is not available, follow the condensed rules below.
+
+## Inputs
+
+Accept either:
+
+- A local source path such as `./gimp` or `/path/to/software`
+- A GitHub repository URL
+
+Derive the software name from the local directory name after cloning if needed.
+
+## Modes
+
+### Build
+
+Use when the user wants a new harness.
+
+Produce this structure:
+
+```text
+<software>/
+└── agent-harness/
+    ├── <SOFTWARE>.md
+    ├── setup.py
+    └── cli_anything/
+        └── <software>/
+            ├── README.md
+            ├── __init__.py
+            ├── __main__.py
+            ├── <software>_cli.py
+            ├── core/
+            ├── utils/
+            └── tests/
+```
+
+Implement a stateful Click CLI with:
+
+- one-shot subcommands
+- REPL mode as the default when no subcommand is given
+- `--json` machine-readable output
+- session state with undo/redo where the target software supports it
+
+### Refine
+
+Use when the harness already exists.
+
+First inventory current commands and tests, then do gap analysis against the target software. Prefer:
+
+- high-impact missing features
+- easy wrappers around existing backend APIs or CLIs
+- additions that compose well with existing commands
+
+Do not remove existing commands unless the user explicitly asks for a breaking change.
+
+### Test
+
+Plan tests before writing them. Keep both:
+
+- `test_core.py` for unit coverage
+- `test_full_e2e.py` for workflow and backend validation
+
+When possible, test the installed command via subprocess using `cli-anything-<software>` rather than only module imports.
+
+### Validate
+
+Check that the harness:
+
+- uses the `cli_anything.<software>` namespace package layout
+- has an installable `setup.py` entry point
+- supports JSON output
+- has a REPL default path
+- documents usage and tests
+
+## Backend Rules
+
+Prefer the real software backend over reimplementation. Wrap the actual executable or scripting interface in `utils/<software>_backend.py` when possible. Use synthetic reimplementation only when the project explicitly requires it or no viable native backend exists.
+
+## Packaging Rules
+
+- Use `find_namespace_packages(include=["cli_anything.*"])`
+- Keep `cli_anything/` as a namespace package without a top-level `__init__.py`
+- Expose `cli-anything-<software>` through `console_scripts`
+
+## Workflow
+
+1. Acquire the source tree locally.
+2. Analyze architecture, data model, existing CLIs, and GUI-to-API mappings.
+3. Design command groups and state model.
+4. Implement the harness.
+5. Write `TEST.md`, then tests, then run them.
+6. Update README usage docs.
+7. Verify local installation with `pip install -e .`
+
+## Output Expectations
+
+When reporting progress or final results, include:
+
+- target software and source path
+- files added or changed
+- validation commands run
+- open risks or backend limitations

--- a/qodercli-skill/scripts/install.sh
+++ b/qodercli-skill/scripts/install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEST_ROOT="${QODER_HOME:-$HOME/.qoder}/skills"
+DEST_DIR="${DEST_ROOT}/cli-anything"
+
+mkdir -p "${DEST_ROOT}"
+
+if [[ -e "${DEST_DIR}" ]]; then
+  echo "Refusing to overwrite existing skill: ${DEST_DIR}" >&2
+  echo "Remove it manually if you want to reinstall." >&2
+  exit 1
+fi
+
+cp -R "${SKILL_DIR}" "${DEST_DIR}"
+
+echo "Installed Qodercli skill to: ${DEST_DIR}"
+echo "Restart Qodercli to pick up the new skill."


### PR DESCRIPTION
## Summary

This PR extends CLI-Anything support to Qodercli by adding a dedicated skill that adapts the core methodology to Qodercli's skill system.

## What's Added

- **SKILL.md**: A comprehensive skill definition supporting four modes:
  - `build` – Create new CLI harnesses from scratch
  - `refine` – Enhance existing harnesses with gap analysis
  - `test` – Plan and implement unit/e2e test coverage
  - `validate` – Verify harness compliance with CLI-Anything standards

- **install.sh**: One-command installation script that:
  - Installs to `$QODER_HOME/skills/cli-anything` (defaults to `~/.qoder/skills`)
  - Includes safety checks to prevent accidental overwrites
  - Provides clear post-install instructions

- **Documentation**: Updated both English and Chinese READMEs with Qodercli usage instructions

## Why This Matters

Qodercli users can now describe tasks in natural language like:

- "Use CLI-Anything to build a harness for ./gimp"
- "Use CLI-Anything to refine ./shotcut for picture-in-picture workflows"

After installation, the `cli-anything` skill will appear in Qodercli's `/skills` list, making it easy to discover and invoke directly from the skill menu.

The skill preserves the same Python harness format and methodology used by Claude Code and OpenCode integrations, ensuring consistency across all supported platforms.

## Installation

```bash
git clone https://github.com/HKUDS/CLI-Anything.git
bash CLI-Anything/qodercli-skill/scripts/install.sh
```