### PR TITLE
fix: replace remaining placeholder URLs in zoom and drawio setup.py

### DIFF
--- a/drawio/agent-harness/setup.py
+++ b/drawio/agent-harness/setup.py
@@ -19,7 +19,7 @@ setup(
     description="CLI harness for Draw.io - Diagram creation and export via draw.io CLI. Requires: draw.io desktop app (draw.io --export)",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/anthropics/cli-anything",
+    url="https://github.com/HKUDS/CLI-Anything",
     packages=find_namespace_packages(include=["cli_anything.*"]),
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/zoom/agent-harness/setup.py
+++ b/zoom/agent-harness/setup.py
@@ -18,7 +18,7 @@ setup(
     if __import__("os").path.exists("cli_anything/zoom/README.md")
     else "CLI harness for Zoom meeting management.",
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/cli-anything-zoom",
+    url="https://github.com/HKUDS/CLI-Anything",
     packages=find_namespace_packages(include=["cli_anything.*"]),
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

- **`zoom/agent-harness/setup.py`**: replaced `https://github.com/yourusername/cli-anything-zoom` with `https://github.com/HKUDS/CLI-Anything`
- **`drawio/agent-harness/setup.py`**: replaced `https://github.com/anthropics/cli-anything` with `https://github.com/HKUDS/CLI-Anything`

PR #26 fixed placeholder URLs across most harness `setup.py` files but missed these two. This PR completes that work so all 11 harnesses now point to the correct repository URL.

## Test plan

- [x] Verified all other `setup.py` files already use `https://github.com/HKUDS/CLI-Anything`
- [x] Confirmed no other placeholder URLs remain (`yourusername`, `anthropics`, `example.com`)