### PR TITLE
Add PowerShell installer for Codex skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ git clone https://github.com/HKUDS/CLI-Anything.git
 bash CLI-Anything/codex-skill/scripts/install.sh
 ```
 
+On Windows PowerShell, use:
+
+```powershell
+.\CLI-Anything\codex-skill\scripts\install.ps1
+```
+
 This installs the skill to `$CODEX_HOME/skills/cli-anything` (or `~/.codex/skills/cli-anything` if `CODEX_HOME` is unset).
 
 Restart Codex after installation so it is discovered.

--- a/README_CN.md
+++ b/README_CN.md
@@ -220,6 +220,12 @@ git clone https://github.com/HKUDS/CLI-Anything.git
 bash CLI-Anything/codex-skill/scripts/install.sh
 ```
 
+在 Windows PowerShell 中，可以使用：
+
+```powershell
+.\CLI-Anything\codex-skill\scripts\install.ps1
+```
+
 脚本会把 skill 安装到 `$CODEX_HOME/skills/cli-anything`；如果没有设置 `CODEX_HOME`，则默认安装到 `~/.codex/skills/cli-anything`。
 
 安装后重启 Codex，让它重新发现这个 skill。

--- a/codex-skill/scripts/install.ps1
+++ b/codex-skill/scripts/install.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$skillDir = Split-Path -Parent $scriptDir
+
+$codexHome = if ($env:CODEX_HOME) {
+    $env:CODEX_HOME
+} elseif ($env:USERPROFILE) {
+    Join-Path $env:USERPROFILE ".codex"
+} else {
+    throw "CODEX_HOME is not set and USERPROFILE is unavailable."
+}
+
+$destRoot = Join-Path $codexHome "skills"
+$destDir = Join-Path $destRoot "cli-anything"
+
+New-Item -ItemType Directory -Path $destRoot -Force | Out-Null
+
+if (Test-Path $destDir) {
+    Write-Error "Refusing to overwrite existing skill: $destDir`nRemove it manually if you want to reinstall."
+}
+
+Copy-Item -Path $skillDir -Destination $destDir -Recurse
+
+Write-Host "Installed Codex skill to: $destDir"
+Write-Host "Restart Codex to pick up the new skill."


### PR DESCRIPTION
## Summary
- add codex-skill/scripts/install.ps1 for Windows PowerShell users
- keep the same install location and overwrite protection as install.sh
- document the PowerShell install command in both English and Chinese README sections

## Verification
- parsed codex-skill/scripts/install.ps1 with the PowerShell parser locally