### PR TITLE
docs: add Windows bash/cygpath note

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ CLI-Anything is distributed as a Claude Code plugin marketplace hosted on GitHub
 
 That's it. The plugin is now available in your Claude Code session.
 
+**Windows note:** Claude Code runs shell commands via `bash`. On Windows, install Git for Windows (includes `bash` and
+`cygpath`) or use WSL; otherwise commands may fail with `cygpath: command not found`.
+
 **Step 3: Build a CLI in One Command**
 
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -81,6 +81,9 @@ CLI-Anything 以 Claude Code 插件市场的形式托管在 GitHub 上。
 
 搞定。插件已经在你的 Claude Code 会话中可用了。
 
+**Windows 注意：** Claude Code 通过 `bash` 执行命令。Windows 下请安装 Git for Windows（包含 `bash` 和 `cygpath`）
+或使用 WSL，否则可能出现 `cygpath: command not found`。
+
 **第三步：一行命令生成 CLI**
 
 ```bash

--- a/cli-anything-plugin/README.md
+++ b/cli-anything-plugin/README.md
@@ -46,6 +46,9 @@ The result: A stateful CLI with REPL mode, JSON output, undo/redo, and full test
 - `pytest` - Testing framework
 - HARNESS.md (included in this plugin at `~/.claude/plugins/cli-anything/HARNESS.md`)
 
+**Windows note:** Claude Code runs shell commands via `bash`. On Windows, install Git for Windows (includes `bash` and
+`cygpath`) or use WSL; otherwise commands may fail with `cygpath: command not found`.
+
 Install Python dependencies:
 ```bash
 pip install click pytest


### PR DESCRIPTION
## Summary
- Document the Windows requirement for bash + cygpath (Git for Windows or WSL) when using Claude Code.

## Changes
- Add Windows notes to README.md, README_CN.md, and cli-anything-plugin/README.md.

## Notes
- Documentation only; no code changes.

Fixes #57
