### PR TITLE
feat(session): sort JSON keys for deterministic agent diffing

### DIFF
--- a/anygen/agent-harness/cli_anything/anygen/core/session.py
+++ b/anygen/agent-harness/cli_anything/anygen/core/session.py
@@ -103,7 +103,7 @@ class Session:
         }
         Path(path).parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w") as f:
-            json.dump(data, f, indent=2, default=str)
+            json.dump(data, f, indent=2, sort_keys=True, default=str)
 
     def _load(self, path: str):
         p = Path(path)

--- a/audacity/agent-harness/cli_anything/audacity/core/session.py
+++ b/audacity/agent-harness/cli_anything/audacity/core/session.py
@@ -121,7 +121,7 @@ class Session:
         self.project["metadata"]["modified"] = datetime.now().isoformat()
         os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
         with open(save_path, "w") as f:
-            json.dump(self.project, f, indent=2, default=str)
+            json.dump(self.project, f, indent=2, sort_keys=True, default=str)
 
         self.project_path = save_path
         self._modified = False

--- a/blender/agent-harness/cli_anything/blender/core/session.py
+++ b/blender/agent-harness/cli_anything/blender/core/session.py
@@ -112,7 +112,7 @@ class Session:
         # Save project
         self.project["metadata"]["modified"] = datetime.now().isoformat()
         with open(save_path, "w") as f:
-            json.dump(self.project, f, indent=2, default=str)
+            json.dump(self.project, f, indent=2, sort_keys=True, default=str)
 
         self.project_path = save_path
         self._modified = False

--- a/drawio/agent-harness/cli_anything/drawio/core/session.py
+++ b/drawio/agent-harness/cli_anything/drawio/core/session.py
@@ -127,7 +127,7 @@ class Session:
         }
         path = SESSION_DIR / f"{self.session_id}.json"
         with open(path, "w") as f:
-            json.dump(state, f, indent=2)
+            json.dump(state, f, indent=2, sort_keys=True)
         return str(path)
 
     @classmethod

--- a/gimp/agent-harness/cli_anything/gimp/core/session.py
+++ b/gimp/agent-harness/cli_anything/gimp/core/session.py
@@ -112,7 +112,7 @@ class Session:
         # Save project
         self.project["metadata"]["modified"] = datetime.now().isoformat()
         with open(save_path, "w") as f:
-            json.dump(self.project, f, indent=2, default=str)
+            json.dump(self.project, f, indent=2, sort_keys=True, default=str)
 
         self.project_path = save_path
         self._modified = False

--- a/inkscape/agent-harness/cli_anything/inkscape/core/session.py
+++ b/inkscape/agent-harness/cli_anything/inkscape/core/session.py
@@ -112,7 +112,7 @@ class Session:
         self.project["metadata"]["modified"] = datetime.now().isoformat()
         os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
         with open(save_path, "w") as f:
-            json.dump(self.project, f, indent=2, default=str)
+            json.dump(self.project, f, indent=2, sort_keys=True, default=str)
 
         self.project_path = save_path
         self._modified = False

--- a/kdenlive/agent-harness/cli_anything/kdenlive/core/session.py
+++ b/kdenlive/agent-harness/cli_anything/kdenlive/core/session.py
@@ -110,7 +110,7 @@ class Session:
         if parent:
             os.makedirs(parent, exist_ok=True)
         with open(save_path, "w") as f:
-            json.dump(self.project, f, indent=2, default=str)
+            json.dump(self.project, f, indent=2, sort_keys=True, default=str)
 
         self.project_path = save_path
         self._modified = False

--- a/libreoffice/agent-harness/cli_anything/libreoffice/core/session.py
+++ b/libreoffice/agent-harness/cli_anything/libreoffice/core/session.py
@@ -119,7 +119,7 @@ class Session:
         self.project["metadata"]["modified"] = datetime.now().isoformat()
         os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
         with open(save_path, "w") as f:
-            json.dump(self.project, f, indent=2, default=str)
+            json.dump(self.project, f, indent=2, sort_keys=True, default=str)
 
         self.project_path = save_path
         self._modified = False

--- a/obs-studio/agent-harness/cli_anything/obs_studio/core/session.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/core/session.py
@@ -108,7 +108,7 @@ class Session:
         self.project["metadata"]["modified"] = datetime.now().isoformat()
         os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
         with open(save_path, "w") as f:
-            json.dump(self.project, f, indent=2, default=str)
+            json.dump(self.project, f, indent=2, sort_keys=True, default=str)
 
         self.project_path = save_path
         self._modified = False

--- a/shotcut/agent-harness/cli_anything/shotcut/core/session.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/session.py
@@ -155,7 +155,7 @@ class Session:
         }
         path = SESSION_DIR / f"{self.session_id}.json"
         with open(path, "w") as f:
-            json.dump(state, f, indent=2)
+            json.dump(state, f, indent=2, sort_keys=True)
         return str(path)
 
     @classmethod


### PR DESCRIPTION
## Description

The core philosophy of CLI-Anything is making software *Agent-Native*. When agents evaluate project changes, they often rely on diffs (like `git diff` or text context diffs).

Currently, `session_state.json` and project state JSONs are dumped using insertion order. Over multiple state loads, mutations, and saves, this can cause the entire JSON dictionary ordering to shuffle, creating massive, noisy diffs that blow out an agent's context window and obscure the actual changes.

This PR simply adds `sort_keys=True` to all `json.dump()` calls inside the `core/session.py` managers across the 10 harnesses.

### Benefits
- **Minimal Diffs**: JSON files will now serialize perfectly deterministically.
- **Context Preservation**: Agents parsing state changes will only see exactly what was modified.
- **Git Friendly**: Much easier to track session state changes across source control.

*(Code refactoring fully executed and dogfooded using the newly open-sourced [0-editor](https://github.com/0-protocol/0-editor))*