### PR TITLE
Use gimp-file-load for non-PNG inputs in apply_filter_and_export

### DIFF
--- a/gimp/agent-harness/cli_anything/gimp/utils/gimp_backend.py
+++ b/gimp/agent-harness/cli_anything/gimp/utils/gimp_backend.py
@@ -196,7 +196,7 @@ def apply_filter_and_export(
 
     script = (
         f'(let* ('
-        f'(image (car (file-png-load RUN-NONINTERACTIVE "{safe_abs_input}" "{safe_abs_input}")))'
+        f'(image (car (gimp-file-load RUN-NONINTERACTIVE "{safe_abs_input}" "{safe_abs_input}")))'
         f'(drawable (car (gimp-image-flatten image)))'
         f')'
         f'{script_fu_filter}'


### PR DESCRIPTION
## Summary
`apply_filter_and_export()` was calling `file-png-load` unconditionally, which fails for non‑PNG inputs. This change switches to `gimp-file-load` so JPEG/WebP/TIFF inputs load correctly while keeping PNG behavior unchanged.

## Rationale
Using a PNG‑specific loader can break legitimate inputs. `gimp-file-load` is the general loader and matches the function’s intent.

## Scope
- 1 line change in `gimp/utils/gimp_backend.py`

## Testing
Not run (not required for this small change).
