### PR TITLE
Docs: add Goose Desktop/CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The command runs as a subtask and follows the same 7-phase methodology as Claude
 </details>
 
 <details>
-<summary><h4 id="-goose">⚡ Goose (Desktop / CLI)</h4></summary>
+<summary><h4 id="-goose">⚡ Goose (Desktop / CLI) <sup><code>Experimental</code></sup> <sup><code>Community</code></sup></h4></summary>
 
 **Step 1: Install Goose**
 


### PR DESCRIPTION
## Summary
Add a short “Goose (Desktop / CLI)” section to the platform picker in README.

## Details
- Guides Goose users to configure a CLI provider (e.g., Claude Code)
- Shows example CLI‑Anything commands inside a Goose session
- Notes that Goose runs through the configured CLI provider

## Scope
- README.md only

## Testing
Not required (docs-only change).

Fixes #66
