### PR TITLE
Docs: clarify OpenCode command directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ cp CLI-Anything/opencode-commands/*.md .opencode/commands/
 cp CLI-Anything/cli-anything-plugin/HARNESS.md .opencode/commands/
 ```
 
+> **Note:** Some OpenCode builds use `~/.config/opencode/command/` (singular) instead of `commands/`. If `commands/` does not exist, use `command/` for both global and project-level installs.
+
 > **Note:** `HARNESS.md` is the methodology spec that all commands reference. It must be in the same directory as the commands.
 
 This adds 5 slash commands: `/cli-anything`, `/cli-anything-refine`, `/cli-anything-test`, `/cli-anything-validate`, and `/cli-anything-list`.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ cp CLI-Anything/opencode-commands/*.md .opencode/commands/
 cp CLI-Anything/cli-anything-plugin/HARNESS.md .opencode/commands/
 ```
 
-> **Note:** Some OpenCode builds use `~/.config/opencode/command/` (singular) instead of `commands/`. If `commands/` does not exist, use `command/` for both global and project-level installs.
+> **Note:** Please upgrade to the latest OpenCode. Older versions use `command/` (singular) instead of `commands/`. If `commands/` does not exist, use `command/` for both global and project-level installs.
 
 > **Note:** `HARNESS.md` is the methodology spec that all commands reference. It must be in the same directory as the commands.
 


### PR DESCRIPTION
## Summary
Clarify the OpenCode commands directory name in the README.

## Details
Some OpenCode builds use `~/.config/opencode/command/` (singular). This note helps users pick the correct path when `commands/` doesn’t exist.

## Scope
- README.md only

## Testing
Not required (docs-only change).

Fixes #35
