### PR TITLE
Harden draw.io CLI harness

### DIFF
--- a/drawio/agent-harness/DRAWIO.md
+++ b/drawio/agent-harness/DRAWIO.md
@@ -54,9 +54,9 @@ The desktop Electron app supports headless export:
 - `draw.io --export input.drawio --output out.pdf --format pdf`
 - `draw.io --export input.drawio --output out.svg --format svg`
 
-**Fallback: direct XML write**
-When draw.io CLI is not installed, the CLI saves the `.drawio` file directly.
-Users can open it in draw.io (web or desktop) for manual export.
+**Native-format write**
+The CLI can always save `.drawio` and uncompressed XML output directly.
+Rendered export to PNG, PDF, SVG, and VSDX must go through the real draw.io desktop CLI and fails clearly if the app is not installed.
 
 ## CLI Strategy
 

--- a/drawio/agent-harness/cli_anything/drawio/README.md
+++ b/drawio/agent-harness/cli_anything/drawio/README.md
@@ -1,6 +1,6 @@
 # cli-anything-drawio
 
-A CLI harness for **Draw.io** — create, edit, and export diagrams from the command line.
+A CLI harness for **Draw.io** - create, edit, and export diagrams from the command line.
 
 Designed for AI agents and power users who need to generate diagrams programmatically.
 
@@ -12,13 +12,19 @@ Designed for AI agents and power users who need to generate diagrams programmati
   - Linux: `snap install drawio`
   - Windows: `winget install JGraph.Draw`
 
-Note: The CLI can create and manipulate `.drawio` files without the desktop app installed. The app is only needed for rasterized export (PNG, PDF, SVG).
+Note: The CLI can create and manipulate `.drawio` files without the desktop app installed. The desktop app is a hard dependency for `export render` when the target format is `png`, `pdf`, `svg`, or `vsdx`; those commands fail with install instructions if draw.io is unavailable.
 
 ## Installation
 
 ```bash
 cd drawio/agent-harness
-pip install -e .
+python -m pip install -e .
+```
+
+For local test runs:
+
+```bash
+python -m pip install -e .[dev]
 ```
 
 ## Usage
@@ -80,5 +86,5 @@ straight, orthogonal, curved, entity-relation
 
 ```bash
 cd drawio/agent-harness
-python3 -m pytest cli_anything/drawio/tests/ -v
+python -m pytest cli_anything/drawio/tests/ -v --tb=no
 ```

--- a/drawio/agent-harness/cli_anything/drawio/__main__.py
+++ b/drawio/agent-harness/cli_anything/drawio/__main__.py
@@ -1,0 +1,7 @@
+"""Module entry point for `python -m cli_anything.drawio`."""
+
+from .drawio_cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/drawio/agent-harness/cli_anything/drawio/core/export.py
+++ b/drawio/agent-harness/cli_anything/drawio/core/export.py
@@ -1,7 +1,6 @@
 """Export/render operations: export diagrams to PNG, PDF, SVG."""
 
 import os
-import shutil
 import tempfile
 from typing import Optional
 
@@ -109,22 +108,5 @@ def render(session: Session, output_path: str,
 
 def render_or_save(session: Session, output_path: str,
                    fmt: str = "png", **kwargs) -> dict:
-    """Export with fallback: if draw.io CLI is not available, save the .drawio
-    file and provide instructions for manual export.
-    """
-    try:
-        return render(session, output_path, fmt, **kwargs)
-    except RuntimeError as e:
-        if "not installed" not in str(e):
-            raise
-        # Fallback: save .drawio and generate instructions
-        drawio_path = os.path.splitext(output_path)[0] + ".drawio"
-        drawio_xml.write_drawio(session.root, drawio_path)
-        return {
-            "action": "export_fallback",
-            "drawio_file": os.path.abspath(drawio_path),
-            "target_output": output_path,
-            "target_format": fmt,
-            "note": "draw.io CLI not found. Open the .drawio file in draw.io to export manually.",
-            "install_hint": str(e),
-        }
+    """Backward-compatible wrapper for callers that still import this helper."""
+    return render(session, output_path, fmt, **kwargs)

--- a/drawio/agent-harness/cli_anything/drawio/drawio_cli.py
+++ b/drawio/agent-harness/cli_anything/drawio/drawio_cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Draw.io CLI — A stateful command-line interface for diagram creation.
+"""Draw.io CLI - A stateful command-line interface for diagram creation.
 
 This CLI manipulates Draw.io XML files directly, providing full diagram
 creation capabilities for AI agents and power users.
@@ -132,7 +132,7 @@ def handle_error(func):
 @click.option("--project", "project_path", default=None, help="Open a project file")
 @click.pass_context
 def cli(ctx, json_mode, session_id, project_path):
-    """Draw.io CLI — Diagram creation from the command line.
+    """Draw.io CLI - Diagram creation from the command line.
 
     A stateful CLI for manipulating draw.io diagram files.
     Designed for AI agents and power users.
@@ -385,7 +385,7 @@ def connect_add(source_id, target_id, edge_style, label, page):
     """Add a connector between two shapes."""
     session = get_session()
     result = conn_mod.add_connector(session, source_id, target_id, edge_style, label, page)
-    output(result, f"Connected: {source_id} → {target_id}")
+    output(result, f"Connected: {source_id} -> {target_id}")
 
 
 @connect.command("remove")
@@ -765,11 +765,11 @@ def _run_repl(s: Session, skin):
                     continue
                 edge_style = args[2] if len(args) > 2 else "orthogonal"
                 result = conn_mod.add_connector(s, args[0], args[1], edge_style)
-                skin.success(f"Connected: {args[0]} → {args[1]} ({result['id']})")
+                skin.success(f"Connected: {args[0]} -> {args[1]} ({result['id']})")
             elif cmd == "connectors":
                 result = conn_mod.list_connectors(s)
                 for e in result:
-                    click.echo(f"  {e['id']}: {e.get('source', '')} → {e.get('target', '')} {e.get('value', '')}")
+                    click.echo(f"  {e['id']}: {e.get('source', '')} -> {e.get('target', '')} {e.get('value', '')}")
                 skin.info(f"Total: {len(result)} connectors")
             elif cmd == "pages":
                 result = pages_mod.list_pages(s)
@@ -802,5 +802,10 @@ def _run_repl(s: Session, skin):
             skin.error(str(e))
 
 
-if __name__ == "__main__":
+def main():
+    """Entry point for console_scripts and python -m."""
     cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/drawio/agent-harness/cli_anything/drawio/tests/TEST.md
+++ b/drawio/agent-harness/cli_anything/drawio/tests/TEST.md
@@ -1,4 +1,4 @@
-# Draw.io CLI — Test Plan & Results
+# Draw.io CLI - Test Plan & Results
 
 ## Test Plan
 
@@ -9,6 +9,7 @@
 - System cells (id=0, id=1) always present
 - No user cells in blank diagram
 - Add vertex with all attributes
+- Generate unique cell IDs across rapid inserts
 - Add edge with source/target
 - Remove cell
 - Remove vertex also removes connected edges
@@ -96,6 +97,7 @@
 **Export Module (TestExport)**
 - List formats
 - Export to XML (no draw.io CLI needed)
+- Propagate backend install errors without fallback export
 - Export with no project raises error
 - Invalid format raises error
 - File exists raises error
@@ -125,6 +127,7 @@
 
 **CLI Subprocess (TestCLISubprocess)**
 - --help output
+- `python -m cli_anything.drawio --help` module entry point
 - project new --json
 - project info --json
 - shape add --json
@@ -145,9 +148,176 @@
 
 ## Test Results
 
+Command run:
+
+```bash
+python -m pytest cli_anything/drawio/tests/ -v --tb=no
 ```
-drawio:  138 passed, 3 skipped (116 unit + 22 e2e)
-         3 skipped: real draw.io export (PNG/SVG/PDF) — requires draw.io desktop app
+```
+
+Latest result:
+
+```
+drawio: 141 passed, 3 skipped
+3 skipped: real draw.io export (PNG/SVG/PDF) - requires draw.io desktop app
 ```
 
 **100% pass rate on all available tests.**
+
+Latest `pytest -v --tb=no` output:
+
+```text
+============================= test session starts =============================
+platform win32 -- Python 3.12.10, pytest-9.0.2, pluggy-1.6.0 -- C:\Users\gram\AppData\Local\Programs\Python\Python312\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\gram\Downloads\코덱스 프로젝트\오픈소스 CLI변환\CLI-Anything\drawio\agent-harness
+plugins: cov-7.0.0
+collecting ... collected 144 items
+
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_create_blank_diagram PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_system_cells_present PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_no_user_cells_in_blank PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_add_vertex PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_generated_ids_are_unique PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_add_edge PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_remove_cell PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_remove_vertex_also_removes_edges PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_find_cell_by_id PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_find_cell_not_exists PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_update_cell_label PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_move_cell PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_resize_cell PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_get_cell_info PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_get_vertices PASSED
+cli_anything/drawio/tests/test_core.py::TestDrawioXml::test_write_and_parse_roundtrip PASSED
+cli_anything/drawio/tests/test_core.py::TestStyleParsing::test_parse_empty PASSED
+cli_anything/drawio/tests/test_core.py::TestStyleParsing::test_parse_basic PASSED
+cli_anything/drawio/tests/test_core.py::TestStyleParsing::test_parse_base_style PASSED
+cli_anything/drawio/tests/test_core.py::TestStyleParsing::test_build_style PASSED
+cli_anything/drawio/tests/test_core.py::TestStyleParsing::test_roundtrip PASSED
+cli_anything/drawio/tests/test_core.py::TestStyleParsing::test_set_style_property PASSED
+cli_anything/drawio/tests/test_core.py::TestStyleParsing::test_remove_style_property PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[rectangle] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[rounded] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[ellipse] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[diamond] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[triangle] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[hexagon] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[cylinder] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[cloud] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[parallelogram] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[process] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[document] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[callout] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[note] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[actor] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_shape_types[text] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_edge_styles[straight] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_edge_styles[orthogonal] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_edge_styles[curved] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapePresets::test_all_edge_styles[entity-relation] PASSED
+cli_anything/drawio/tests/test_core.py::TestPages::test_single_page_default PASSED
+cli_anything/drawio/tests/test_core.py::TestPages::test_add_page PASSED
+cli_anything/drawio/tests/test_core.py::TestPages::test_remove_page PASSED
+cli_anything/drawio/tests/test_core.py::TestPages::test_cannot_remove_last_page PASSED
+cli_anything/drawio/tests/test_core.py::TestPages::test_rename_page PASSED
+cli_anything/drawio/tests/test_core.py::TestPages::test_shapes_on_different_pages PASSED
+cli_anything/drawio/tests/test_core.py::TestSession::test_new_session PASSED
+cli_anything/drawio/tests/test_core.py::TestSession::test_new_project PASSED
+cli_anything/drawio/tests/test_core.py::TestSession::test_undo_redo PASSED
+cli_anything/drawio/tests/test_core.py::TestSession::test_multiple_undo PASSED
+cli_anything/drawio/tests/test_core.py::TestSession::test_save_and_open PASSED
+cli_anything/drawio/tests/test_core.py::TestSession::test_save_no_project PASSED
+cli_anything/drawio/tests/test_core.py::TestSession::test_open_nonexistent PASSED
+cli_anything/drawio/tests/test_core.py::TestSession::test_status PASSED
+cli_anything/drawio/tests/test_core.py::TestProject::test_new_project PASSED
+cli_anything/drawio/tests/test_core.py::TestProject::test_new_project_all_presets PASSED
+cli_anything/drawio/tests/test_core.py::TestProject::test_new_project_invalid_preset PASSED
+cli_anything/drawio/tests/test_core.py::TestProject::test_new_project_custom_size PASSED
+cli_anything/drawio/tests/test_core.py::TestProject::test_save_and_open PASSED
+cli_anything/drawio/tests/test_core.py::TestProject::test_project_info PASSED
+cli_anything/drawio/tests/test_core.py::TestProject::test_project_info_no_project PASSED
+cli_anything/drawio/tests/test_core.py::TestProject::test_list_presets PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_add_shape PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_add_shape_no_project PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_list_shapes PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_remove_shape PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_remove_shape_not_found PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_update_label PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_move_shape PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_resize_shape PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_set_style PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_get_shape_info PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_list_shape_types PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[rectangle] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[rounded] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[ellipse] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[diamond] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[triangle] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[hexagon] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[cylinder] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[cloud] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[parallelogram] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[process] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[document] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[callout] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[note] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[actor] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_all_shape_types_via_module[text] PASSED
+cli_anything/drawio/tests/test_core.py::TestShapes::test_undo_add_shape PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_add_connector PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_add_connector_invalid_source PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_add_connector_invalid_target PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_list_connectors PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_remove_connector PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_update_connector_label PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_set_connector_style PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_list_edge_styles PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_all_edge_styles_via_module[straight] PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_all_edge_styles_via_module[orthogonal] PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_all_edge_styles_via_module[curved] PASSED
+cli_anything/drawio/tests/test_core.py::TestConnectors::test_all_edge_styles_via_module[entity-relation] PASSED
+cli_anything/drawio/tests/test_core.py::TestPagesModule::test_list_pages PASSED
+cli_anything/drawio/tests/test_core.py::TestPagesModule::test_add_page PASSED
+cli_anything/drawio/tests/test_core.py::TestPagesModule::test_remove_page PASSED
+cli_anything/drawio/tests/test_core.py::TestPagesModule::test_rename_page PASSED
+cli_anything/drawio/tests/test_core.py::TestExport::test_list_formats PASSED
+cli_anything/drawio/tests/test_core.py::TestExport::test_export_xml_direct PASSED
+cli_anything/drawio/tests/test_core.py::TestExport::test_render_or_save_propagates_backend_errors PASSED
+cli_anything/drawio/tests/test_core.py::TestExport::test_export_no_project PASSED
+cli_anything/drawio/tests/test_core.py::TestExport::test_export_invalid_format PASSED
+cli_anything/drawio/tests/test_core.py::TestExport::test_export_file_exists PASSED
+cli_anything/drawio/tests/test_core.py::TestWorkflows::test_flowchart PASSED
+cli_anything/drawio/tests/test_core.py::TestWorkflows::test_styled_diagram PASSED
+cli_anything/drawio/tests/test_core.py::TestWorkflows::test_multi_page_workflow PASSED
+cli_anything/drawio/tests/test_core.py::TestWorkflows::test_undo_redo_workflow PASSED
+cli_anything/drawio/tests/test_core.py::TestWorkflows::test_export_xml_workflow PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestFileRoundtrip::test_empty_diagram_roundtrip PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestFileRoundtrip::test_complex_diagram_roundtrip PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestFileRoundtrip::test_multi_page_roundtrip PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestXmlExport::test_export_xml_valid_structure PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestXmlExport::test_export_xml_preserves_styles PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestRealExport::test_export_png SKIPPED
+cli_anything/drawio/tests/test_full_e2e.py::TestRealExport::test_export_svg SKIPPED
+cli_anything/drawio/tests/test_full_e2e.py::TestRealExport::test_export_pdf SKIPPED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_help PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_module_help PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_project_new_json PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_project_info_json PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_shape_add_json PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_shape_list_json PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_connect_add_json PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_shape_types PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_connect_styles PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_export_formats PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_page_list PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_session_status PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_project_presets PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestCLISubprocess::test_export_xml_subprocess PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestRealWorldWorkflows::test_architecture_diagram PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestRealWorldWorkflows::test_er_diagram PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestRealWorldWorkflows::test_decision_tree PASSED
+cli_anything/drawio/tests/test_full_e2e.py::TestRealWorldWorkflows::test_multi_page_documentation PASSED
+
+======================= 141 passed, 3 skipped in 12.55s =======================
+```

--- a/drawio/agent-harness/cli_anything/drawio/tests/test_core.py
+++ b/drawio/agent-harness/cli_anything/drawio/tests/test_core.py
@@ -54,6 +54,14 @@ class TestDrawioXml:
         assert cells[0].get("value") == "Test"
         assert cells[0].get("vertex") == "1"
 
+    def test_generated_ids_are_unique(self):
+        root = drawio_xml.create_blank_diagram()
+        ids = {
+            drawio_xml.add_vertex(root, "rectangle", i * 10, 0, 100, 50, f"Cell {i}")
+            for i in range(20)
+        }
+        assert len(ids) == 20
+
     def test_add_edge(self):
         root = drawio_xml.create_blank_diagram()
         v1 = drawio_xml.add_vertex(root, "rectangle", 10, 20, 120, 60, "A")
@@ -699,6 +707,18 @@ class TestExport:
             assert len(cells) == 1
         finally:
             os.unlink(path)
+
+    def test_render_or_save_propagates_backend_errors(self, monkeypatch):
+        s = Session()
+        proj_mod.new_project(s)
+
+        def _fail(*args, **kwargs):
+            raise RuntimeError("draw.io desktop app is not installed")
+
+        monkeypatch.setattr(export_mod, "render", _fail)
+
+        with pytest.raises(RuntimeError, match="not installed"):
+            export_mod.render_or_save(s, "missing.png", fmt="png")
 
     def test_export_no_project(self):
         s = Session()

--- a/drawio/agent-harness/cli_anything/drawio/tests/test_full_e2e.py
+++ b/drawio/agent-harness/cli_anything/drawio/tests/test_full_e2e.py
@@ -356,6 +356,17 @@ class TestCLISubprocess:
         assert result.returncode == 0
         assert "Draw.io" in result.stdout or "diagram" in result.stdout.lower()
 
+    def test_module_help(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "cli_anything.drawio", "--help"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "Draw.io" in result.stdout or "diagram" in result.stdout.lower()
+
     def test_project_new_json(self, tmp_path):
         out = str(tmp_path / "test.drawio")
         result = self._run(["--json", "project", "new", "-o", out])

--- a/drawio/agent-harness/cli_anything/drawio/utils/drawio_xml.py
+++ b/drawio/agent-harness/cli_anything/drawio/utils/drawio_xml.py
@@ -24,7 +24,7 @@ Structure:
 """
 
 import os
-import time
+import uuid
 from xml.etree import ElementTree as ET
 from typing import Optional
 
@@ -295,7 +295,7 @@ EDGE_STYLES = {
 
 def _new_id(prefix: str = "cell") -> str:
     """Generate a unique ID."""
-    return f"{prefix}_{int(time.time() * 1000000)}"
+    return f"{prefix}_{uuid.uuid4().hex}"
 
 
 def add_vertex(mxfile: ET.Element, shape_type: str,

--- a/drawio/agent-harness/cli_anything/drawio/utils/repl_skin.py
+++ b/drawio/agent-harness/cli_anything/drawio/utils/repl_skin.py
@@ -61,22 +61,22 @@ _MAGENTA = "\033[38;5;176m"
 # ── Brand icon ────────────────────────────────────────────────────────
 
 # The cli-anything icon: a small colored diamond/chevron mark
-_ICON = f"{_CYAN}{_BOLD}◆{_RESET}"
-_ICON_SMALL = f"{_CYAN}▸{_RESET}"
+_ICON = f"{_CYAN}{_BOLD}*{_RESET}"
+_ICON_SMALL = f"{_CYAN}>{_RESET}"
 
 # ── Box drawing characters ────────────────────────────────────────────
 
-_H_LINE = "─"
-_V_LINE = "│"
-_TL = "╭"
-_TR = "╮"
-_BL = "╰"
-_BR = "╯"
-_T_DOWN = "┬"
-_T_UP = "┴"
-_T_RIGHT = "├"
-_T_LEFT = "┤"
-_CROSS = "┼"
+_H_LINE = "-"
+_V_LINE = "|"
+_TL = "+"
+_TR = "+"
+_BL = "+"
+_BR = "+"
+_T_DOWN = "+"
+_T_UP = "+"
+_T_RIGHT = "+"
+_T_LEFT = "+"
+_CROSS = "+"
 
 
 def _strip_ansi(text: str) -> str:
@@ -155,10 +155,10 @@ class ReplSkin:
         top = self._c(_DARK_GRAY, f"{_TL}{_H_LINE * inner}{_TR}")
         bot = self._c(_DARK_GRAY, f"{_BL}{_H_LINE * inner}{_BR}")
 
-        # Title:  ◆  cli-anything · Shotcut
-        icon = self._c(_CYAN + _BOLD, "◆")
+        # Title:  *  cli-anything . Shotcut
+        icon = self._c(_CYAN + _BOLD, "*")
         brand = self._c(_CYAN + _BOLD, "cli-anything")
-        dot = self._c(_DARK_GRAY, "·")
+        dot = self._c(_DARK_GRAY, ".")
         name = self._c(self.accent + _BOLD, self.display_name)
         title = f" {icon}  {brand} {dot} {name}"
 
@@ -192,7 +192,7 @@ class ReplSkin:
 
         # Icon
         if self._color:
-            parts.append(f"{_CYAN}◆{_RESET} ")
+            parts.append(f"{_CYAN}*{_RESET} ")
         else:
             parts.append("> ")
 
@@ -207,7 +207,7 @@ class ReplSkin:
             parts.append(self._c(_LIGHT_GRAY, f"{ctx}{mod}"))
             parts.append(self._c(_DARK_GRAY, ']'))
 
-        parts.append(self._c(_GRAY, " ❯ "))
+        parts.append(self._c(_GRAY, " > "))
 
         return "".join(parts)
 
@@ -223,7 +223,7 @@ class ReplSkin:
         accent_hex = _ANSI_256_TO_HEX.get(self.accent, "#5fafff")
         tokens = []
 
-        tokens.append(("class:icon", "◆ "))
+        tokens.append(("class:icon", "* "))
         tokens.append(("class:software", self.software))
 
         if project_name or context:
@@ -233,7 +233,7 @@ class ReplSkin:
             tokens.append(("class:context", f"{ctx}{mod}"))
             tokens.append(("class:bracket", "]"))
 
-        tokens.append(("class:arrow", " ❯ "))
+        tokens.append(("class:arrow", " > "))
 
         return tokens
 
@@ -272,22 +272,22 @@ class ReplSkin:
 
     def success(self, message: str):
         """Print a success message with green checkmark."""
-        icon = self._c(_GREEN + _BOLD, "✓")
+        icon = self._c(_GREEN + _BOLD, "OK")
         print(f"  {icon} {self._c(_GREEN, message)}")
 
     def error(self, message: str):
         """Print an error message with red cross."""
-        icon = self._c(_RED + _BOLD, "✗")
+        icon = self._c(_RED + _BOLD, "!!")
         print(f"  {icon} {self._c(_RED, message)}", file=sys.stderr)
 
     def warning(self, message: str):
         """Print a warning message with yellow triangle."""
-        icon = self._c(_YELLOW + _BOLD, "⚠")
+        icon = self._c(_YELLOW + _BOLD, "!")
         print(f"  {icon} {self._c(_YELLOW, message)}")
 
     def info(self, message: str):
         """Print an info message with blue dot."""
-        icon = self._c(_BLUE, "●")
+        icon = self._c(_BLUE, "i")
         print(f"  {icon} {self._c(_LIGHT_GRAY, message)}")
 
     def hint(self, message: str):
@@ -335,7 +335,7 @@ class ReplSkin:
         pct = int(current / total * 100) if total > 0 else 0
         bar_width = 20
         filled = int(bar_width * current / total) if total > 0 else 0
-        bar = "█" * filled + "░" * (bar_width - filled)
+        bar = "=" * filled + "." * (bar_width - filled)
         text = f"  {self._c(_CYAN, bar)} {self._c(_GRAY, f'{pct:3d}%')}"
         if label:
             text += f" {self._c(_LIGHT_GRAY, label)}"
@@ -379,7 +379,7 @@ class ReplSkin:
 
         # Separator
         sep_parts = [self._c(_DARK_GRAY, _H_LINE * w) for w in col_widths]
-        sep_line = self._c(_DARK_GRAY, f"  {'───'.join([_H_LINE * w for w in col_widths])}")
+        sep_line = self._c(_DARK_GRAY, f"  {'---'.join([_H_LINE * w for w in col_widths])}")
         print(sep_line)
 
         # Rows
@@ -476,7 +476,7 @@ class ReplSkin:
             parts = []
             for i, (k, v) in enumerate(items.items()):
                 if i > 0:
-                    parts.append(("class:bottom-toolbar.text", "  │  "))
+                    parts.append(("class:bottom-toolbar.text", "  |  "))
                 parts.append(("class:bottom-toolbar.text", f" {k}: "))
                 parts.append(("class:bottom-toolbar", v))
             return FormattedText(parts)

--- a/drawio/agent-harness/setup.py
+++ b/drawio/agent-harness/setup.py
@@ -45,7 +45,7 @@ setup(
     },
     entry_points={
         "console_scripts": [
-            "cli-anything-drawio=cli_anything.drawio.drawio_cli:cli",
+            "cli-anything-drawio=cli_anything.drawio.drawio_cli:main",
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
## Summary
- harden the draw.io harness for Windows-friendly CLI usage
- add a module entry point and remove non-compliant export fallback behavior
- add regression coverage and refresh TEST.md with the passing test run

## Validation
- python -m pip install -e .
- python -m pytest cli_anything/drawio/tests/ -v --tb=no