### PR TITLE
fix(shotcut): set tractor out= before melt render to avoid 4-hour output

### DIFF
--- a/shotcut/agent-harness/.gitignore
+++ b/shotcut/agent-harness/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/

--- a/shotcut/agent-harness/cli_anything/shotcut/core/export.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/export.py
@@ -6,6 +6,7 @@ import shutil
 from typing import Optional
 
 from ..utils import mlt_xml
+from ..utils.time import timecode_to_frames, frames_to_timecode
 from .session import Session
 
 
@@ -411,12 +412,67 @@ def render(session: Session, output_path: str,
                                    width, height)
 
 
+def _set_tractor_out(session: Session) -> None:
+    """Set tractor out= to actual timeline duration before passing to melt.
+
+    The tractor is created with out="00:00:00.000" and never updated as clips
+    are added. Without this fix, melt falls back to the longest track in the
+    multitrack — the 4-hour black background — and renders a 4-hour file.
+    """
+    profile = session.get_profile()
+    fps_num = int(profile.get("frame_rate_num", 30000))
+    fps_den = int(profile.get("frame_rate_den", 1001))
+
+    tractor = mlt_xml.get_main_tractor(session.root)
+    if tractor is None:
+        return
+
+    tracks = mlt_xml.get_tractor_tracks(tractor)
+    max_frames = 0
+    for te in tracks:
+        prod_id = te.get("producer", "")
+        if prod_id == "background":
+            continue
+        playlist = mlt_xml.find_element_by_id(session.root, prod_id)
+        if playlist is None:
+            continue
+        total = 0
+        for child in playlist:
+            if child.tag == "entry":
+                in_f = timecode_to_frames(child.get("in", "0"), fps_num, fps_den)
+                out_f = timecode_to_frames(child.get("out", "0"), fps_num, fps_den)
+                total += max(0, out_f - in_f + 1)
+            elif child.tag == "blank":
+                try:
+                    total += timecode_to_frames(child.get("length", "0"), fps_num, fps_den)
+                except Exception:
+                    pass
+        max_frames = max(max_frames, total)
+
+    if max_frames > 0:
+        out_tc = frames_to_timecode(max_frames - 1, fps_num, fps_den)
+        tractor.set("out", out_tc)
+        # Cap the background track to the same duration so melt doesn't
+        # extend the render to the 4-hour background default.
+        bg_playlist = mlt_xml.find_element_by_id(session.root, "background")
+        if bg_playlist is not None:
+            for entry in bg_playlist.findall("entry"):
+                entry.set("out", out_tc)
+        black_producer = session.root.find(".//producer[@id='black']")
+        if black_producer is not None:
+            black_producer.set("out", out_tc)
+
+
 def _render_with_melt(session: Session, output_path: str,
                       preset: dict, melt_path: str,
                       width: Optional[int], height: Optional[int],
                       extra_args: Optional[list[str]]) -> dict:
     """Render using melt command."""
     import tempfile
+
+    # Fix tractor out before rendering — without this melt renders the full
+    # 4-hour background track instead of the actual content duration.
+    _set_tractor_out(session)
 
     # Save project to temp file
     with tempfile.NamedTemporaryFile(suffix=".mlt", delete=False, mode="w") as f:

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_core.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_core.py
@@ -25,8 +25,10 @@ from cli_anything.shotcut.utils.mlt_xml import (
     create_blank_project, mlt_to_string, parse_mlt, write_mlt,
     get_property, set_property, get_main_tractor, get_tractor_tracks,
     get_all_producers, get_playlist_entries, find_element_by_id,
-    add_filter_to_element,
+    add_filter_to_element, add_track_to_tractor, add_entry_to_playlist,
+    add_blank_to_playlist,
 )
+from cli_anything.shotcut.utils.time import frames_to_timecode as _ftc
 
 
 # ============================================================================
@@ -688,6 +690,70 @@ class TestExport:
                 export_mod.render(s, tmpfile)
         finally:
             os.unlink(tmpfile)
+
+    def test_set_tractor_out_single_clip(self):
+        """_set_tractor_out sets tractor out to match a single clip duration."""
+        s = Session()
+        proj_mod.new_project(s, "hd1080p30")
+        tractor = get_main_tractor(s.root)
+        playlist_id, _ = add_track_to_tractor(s.root, tractor, "video", "V1")
+        playlist = find_element_by_id(s.root, playlist_id)
+
+        # Add a 6-second clip (frames 0–179 at 29.97fps ≈ 180 frames)
+        prod = s.root.makeelement("producer", {"id": "clip1"})
+        s.root.insert(0, prod)
+        add_entry_to_playlist(playlist, "clip1", "00:00:00.000", "00:00:05.999")
+
+        # Before fix: tractor out is still the initial value
+        assert tractor.get("out") == "00:00:00.000"
+
+        export_mod._set_tractor_out(s)
+
+        # After fix: tractor out should reflect the clip duration
+        assert tractor.get("out") != "00:00:00.000"
+        assert tractor.get("out") != "04:00:00.000"
+        # Background entry should be capped too
+        bg = find_element_by_id(s.root, "background")
+        bg_entry = bg.find("entry")
+        assert bg_entry.get("out") == tractor.get("out")
+        # Black producer should be capped
+        black = s.root.find(".//producer[@id='black']")
+        assert black.get("out") == tractor.get("out")
+
+    def test_set_tractor_out_multi_segment(self):
+        """_set_tractor_out sums entry spans and blanks across segments."""
+        s = Session()
+        proj_mod.new_project(s, "hd1080p30")
+        tractor = get_main_tractor(s.root)
+        pid, _ = add_track_to_tractor(s.root, tractor, "video", "V1")
+        playlist = find_element_by_id(s.root, pid)
+
+        # Two 3-second clips with a 1-second blank between
+        prod1 = s.root.makeelement("producer", {"id": "seg1"})
+        prod2 = s.root.makeelement("producer", {"id": "seg2"})
+        s.root.insert(0, prod1)
+        s.root.insert(0, prod2)
+        add_entry_to_playlist(playlist, "seg1", "00:00:00.000", "00:00:02.999")
+        add_blank_to_playlist(playlist, "00:00:01.000")
+        add_entry_to_playlist(playlist, "seg2", "00:00:00.000", "00:00:02.999")
+
+        export_mod._set_tractor_out(s)
+
+        # Tractor out should cover all segments + blank (~7 seconds)
+        out_tc = tractor.get("out")
+        assert out_tc != "00:00:00.000"
+        assert out_tc != "04:00:00.000"
+
+    def test_set_tractor_out_empty_timeline(self):
+        """_set_tractor_out is a no-op on a blank project with no clips."""
+        s = Session()
+        proj_mod.new_project(s, "hd1080p30")
+        tractor = get_main_tractor(s.root)
+
+        export_mod._set_tractor_out(s)
+
+        # No clips → tractor out should stay unchanged
+        assert tractor.get("out") == "00:00:00.000"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- When clips are added to the timeline, the MLT `<tractor>` element is created with `out="00:00:00.000"` and never updated
- The background track defaults to `out="04:00:00.000"` (a Shotcut convention for an open-ended timeline)
- Without an explicit tractor `out`, `melt` falls back to the longest track and renders a ~4-hour file instead of the actual content duration

## Fix

Added `_set_tractor_out()` helper in `export.py` that runs before writing the temp MLT file for melt rendering:

1. Calculates real content duration by summing `entry` in/out spans and `blank` lengths across all non-background playlists
2. Sets `out=` on the tractor element
3. Caps the background playlist entry and black producer to the same duration so melt doesn't extend the render to the 4-hour default

## Test Plan

- [ ] 110 unit tests passing (`uv run --with pytest python -m pytest cli_anything/shotcut/tests/test_core.py`)
- [ ] `export render` on a project with a 6-second clip produces a 6-second output (previously produced ~500s)
- [ ] Multi-segment projects: tractor out = sum of all clip durations

🤖 Generated with [Claude Code](https://claude.com/claude-code)