### PR TITLE
docs: sync README counts and CONTRIBUTING paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ We welcome three main categories of contributions:
 Adding a new CLI harness is the most impactful contribution. Before submitting a PR, ensure the following are in place:
 
 1. **`<SOFTWARE>.md`** — the SOP document exists at `<software>/agent-harness/<SOFTWARE>.md` describing the harness architecture.
-2. **`SKILL.md`** — the AI-discoverable skill definition exists inside the Python package at `cli_anything/<software>/SKILL.md`.
-3. **Tests** — unit tests (`test_core.py`, passable without backend) and E2E tests (`test_full_e2e.py`) are present and passing.
+2. **`SKILL.md`** — the AI-discoverable skill definition exists inside the Python package at `cli_anything/<software>/skills/SKILL.md`.
+3. **Tests** — unit tests (`test_core.py`) and E2E tests (`test_full_e2e.py`) are present and passing, with backend or credential requirements documented in the harness README or `TEST.md`.
 4. **`README.md`** — the project README includes the new software with a link to its harness directory.
 5. **`registry.json`** — add an entry for the new software so it appears on the [CLI-Hub](https://hkuds.github.io/CLI-Anything/hub/).
 6. **`repl_skin.py`** — an unmodified copy from the plugin exists in `utils/`.

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ AI agents are great at reasoning but terrible at using real professional softwar
 | 💸 "UI automation breaks constantly" | No screenshots, no clicking, no RPA fragility. Pure command-line reliability with structured interfaces |
 | 📊 "Agents need structured data" | Built-in JSON output for seamless agent consumption + human-readable formats for debugging |
 | 🔧 "Custom integrations are expensive" | One Claude plugin auto-generates CLIs for ANY codebase through proven 7-phase pipeline |
-| ⚡ "Prototype vs Production gap" | 1,839+ tests with real software validation. Battle-tested across 16 major applications |
+| ⚡ "Prototype vs Production gap" | 1,839+ tests with real software validation. Battle-tested across 17 major applications |
 
 ---
 
@@ -970,7 +970,7 @@ MIT License — free to use, modify, and distribute.
 
 **CLI-Anything** — *Make any software with a codebase Agent-native.*
 
-<sub>A methodology for the age of AI agents | 16 professional software demos | 1,839 passing tests</sub>
+<sub>A methodology for the age of AI agents | 17 professional software demos | 1,839 passing tests</sub>
 
 <br>
 


### PR DESCRIPTION
 ## Description

  This PR aligns repository docs with the current project structure.

  - update README counts from 16 to 17 to match `registry.json`
  - fix the `SKILL.md` path in `CONTRIBUTING.md` to `cli_anything/<software>/skills/SKILL.md`
  - clarify test wording in `CONTRIBUTING.md` so backend or credential requirements are documented more accurately

  Fixes #<!-- issue number -->
  N/A

  ## Type of Change

  - [ ] **New Software CLI** — adds a CLI harness for a new application
  - [ ] **New Feature** — adds new functionality to an existing harness or the plugin
  - [ ] **Bug Fix** — fixes incorrect behavior
  - [x] **Documentation** — updates docs only
  - [ ] **Other** — please describe:

  ## Why

  These doc updates make contributor guidance match the current repository layout and reduce confusion for new contributors.