### PR TITLE
feat(ollama): support repeatable embed inputs

### DIFF
--- a/ollama/agent-harness/OLLAMA.md
+++ b/ollama/agent-harness/OLLAMA.md
@@ -65,7 +65,7 @@ Ollama already provides a clean REST API. Our CLI wraps it with:
 | `ollama ps` | `model ps` |
 | `ollama run <model> <prompt>` | `generate text --model <name> --prompt "..."` |
 | (no equivalent) | `generate chat --model <name> --message "..."` |
-| (no equivalent) | `embed text --model <name> --input "..."` |
+| (no equivalent) | `embed text --model <name> --input "..." [--input "..."]` |
 | `ollama serve` | (external — must be running) |
 
 ## Model Parameters (options)

--- a/ollama/agent-harness/cli_anything/ollama/README.md
+++ b/ollama/agent-harness/cli_anything/ollama/README.md
@@ -81,6 +81,7 @@ generate chat --model <name> --message "user:Hello" [--message "assistant:Hi"]
 
 ```bash
 embed text --model <name> --input "Text to embed"
+embed text --model <name> --input "First text" --input "Second text"
 ```
 
 ### Server

--- a/ollama/agent-harness/cli_anything/ollama/ollama_cli.py
+++ b/ollama/agent-harness/cli_anything/ollama/ollama_cli.py
@@ -340,11 +340,16 @@ def embed():
 
 @embed.command("text")
 @click.option("--model", "-m", "model_name", required=True, help="Model name")
-@click.option("--input", "-i", "input_text", required=True, help="Text to embed")
+@click.option(
+    "--input", "-i", "input_texts",
+    multiple=True, required=True,
+    help="Text to embed. Repeat for batch embeddings.",
+)
 @handle_error
-def embed_text(model_name, input_text):
+def embed_text(model_name, input_texts):
     """Generate embeddings for text."""
-    result = embed_mod.embed(_host, model_name, input_text)
+    payload = list(input_texts)
+    result = embed_mod.embed(_host, model_name, payload[0] if len(payload) == 1 else payload)
     if _json_output:
         output(result)
     else:

--- a/ollama/agent-harness/cli_anything/ollama/skills/SKILL.md
+++ b/ollama/agent-harness/cli_anything/ollama/skills/SKILL.md
@@ -155,6 +155,7 @@ cli-anything-ollama generate chat --model llama3.2 --file messages.json
 
 ```bash
 cli-anything-ollama embed text --model nomic-embed-text --input "Hello world"
+cli-anything-ollama embed text --model nomic-embed-text --input "Hello" --input "World"
 ```
 
 

--- a/ollama/agent-harness/cli_anything/ollama/tests/test_core.py
+++ b/ollama/agent-harness/cli_anything/ollama/tests/test_core.py
@@ -316,6 +316,19 @@ class TestEmbedCommands:
         assert "embeddings" in data
 
     @patch("cli_anything.ollama.core.embeddings.api_post")
+    def test_embed_text_multiple_inputs_json(self, mock_api, runner):
+        mock_api.return_value = {"embeddings": [[0.1, 0.2], [0.3, 0.4]]}
+        result = runner.invoke(cli, ["--json", "embed", "text",
+                                     "--model", "nomic-embed-text",
+                                     "--input", "Hello",
+                                     "--input", "World"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data["embeddings"]) == 2
+        call_data = mock_api.call_args[0][2]
+        assert call_data["input"] == ["Hello", "World"]
+
+    @patch("cli_anything.ollama.core.embeddings.api_post")
     def test_embed_text_human(self, mock_api, runner):
         mock_api.return_value = {"embeddings": [[0.1, 0.2, 0.3, 0.4, 0.5, 0.6]]}
         result = runner.invoke(cli, ["embed", "text",


### PR DESCRIPTION
## Description

  Support repeatable `--input` flags for `ollama embed text`.

  This keeps the existing single-input behavior unchanged while allowing multiple embedding inputs in
  one command. The PR also adds unit coverage and updates the Ollama docs/examples.

  ## Type of Change

  - [ ] **New Software CLI** — adds a CLI harness for a new application
  - [x] **New Feature** — adds new functionality to an existing harness or the plugin
  - [ ] **Bug Fix** — fixes incorrect behavior
  - [ ] **Documentation** — updates docs only
  - [ ] **Other** — please describe:

  ---

  ### For New Software CLIs

  - [ ] `<SOFTWARE>.md` SOP document exists at `<software>/agent-harness/<SOFTWARE>.md`
  - [ ] `SKILL.md` exists inside the Python package (`cli_anything/<software>/SKILL.md`)
  - [ ] Unit tests at `cli_anything/<software>/tests/test_core.py` are present and pass without
  backend
  - [ ] E2E tests at `cli_anything/<software>/tests/test_full_e2e.py` are present
  - [ ] `README.md` includes the new software (with link to harness directory)
  - [ ] `registry.json` includes an entry for the new software (for the [CLI-Hub](https://
  hkuds.github.io/CLI-Anything/hub/))
  - [ ] `repl_skin.py` in `utils/` is an unmodified copy from the plugin

  ### For Existing CLI Modifications

  - [x] All unit tests pass: `python3 -m pytest cli_anything/<software>/tests/test_core.py -v`
  - [ ] All E2E tests pass: `python3 -m pytest cli_anything/<software>/tests/test_full_e2e.py -v`
  - [x] No test regressions — no previously passing tests were removed or weakened
  - [ ] `registry.json` entry is updated if version, description, or requirements changed

  ### General Checklist

  - [x] Code follows existing patterns and conventions
  - [x] `--json` flag is supported on any new commands
  - [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
  - [x] I have tested my changes locally

  ## Test Results

  ```text
  cli_anything/ollama/tests/test_core.py
  88 passed in 0.37s

  cli_anything/ollama/tests/test_full_e2e.py
  10 passed, 1 skipped, 1 warning in 22.91s

  Note: the upstream E2E suite currently contains one skipped embed test. All runnable E2E tests
  passed locally against a running Ollama server with tinyllama.