### PR TITLE
fix: persist session state in CLI mode and handle quoted text in REPL

### DIFF
--- a/gimp/agent-harness/cli_anything/gimp/gimp_cli.py
+++ b/gimp/agent-harness/cli_anything/gimp/gimp_cli.py
@@ -18,6 +18,7 @@ Usage:
 import sys
 import os
 import json
+import shlex
 import click
 from typing import Optional
 
@@ -134,6 +135,15 @@ def cli(ctx, use_json, project_path):
 
     if ctx.invoked_subcommand is None:
         ctx.invoke(repl, project_path=None)
+
+
+@cli.result_callback()
+def auto_save_on_cli(result, **kwargs):
+    """Auto-save project after CLI commands when --project is specified."""
+    if not _repl_mode:
+        sess = get_session()
+        if sess.has_project() and sess._modified and sess.project_path:
+            proj_mod.save_project(sess.get_project(), sess.project_path)
 
 
 # ── Project Commands ─────────────────────────────────────────────
@@ -761,8 +771,11 @@ def repl(project_path):
                 skin.help(_repl_commands)
                 continue
 
-            # Parse and execute command
-            args = line.split()
+            # Parse and execute command (shlex handles quoted strings with spaces)
+            try:
+                args = shlex.split(line)
+            except ValueError:
+                args = line.split()
             try:
                 cli.main(args, standalone_mode=False)
             except SystemExit:


### PR DESCRIPTION
## Description

Fix two bugs in the GIMP CLI harness that break non-REPL (one-shot) workflows and text input with spaces:

1. **CLI mode does not persist session state:** Each CLI invocation modifies the in-memory project but never writes it back to disk, so consecutive commands like `layer new` followed by `draw text` fail because the JSON file remains stale.
2. **REPL cannot handle text with spaces:** The REPL uses `str.split()` which breaks quoted arguments like `--text "Summer Sale"` into separate tokens.

Fixes #111

## Type of Change

- [x] **Bug Fix** — fixes incorrect behavior

---

### For Existing CLI Modifications

- [x] All unit tests pass: `python3 -m pytest cli_anything/gimp/tests/test_core.py -v`
- [x] All E2E tests pass: `python3 -m pytest cli_anything/gimp/tests/test_full_e2e.py -v`
- [x] No test regressions — no previously passing tests were removed or weakened
- [x] `registry.json` entry is updated if version, description, or requirements changed

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands
- [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
- [x] I have tested my changes locally

## Test Results

```
============================= test session starts =============================
platform win32 -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0

cli_anything/gimp/tests/test_core.py  ............ 69 passed
cli_anything/gimp/tests/test_full_e2e.py  ........ 39 passed (4 deselected - require GIMP binary)

====================== 108 passed, 4 deselected in 1.73s ======================
```