### PR TITLE
feat: add missing SKILL.md for adguardhome, comfyui, mermaid + fix setup.py + expand test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@
 !/zoom/
 !/drawio/
 !/mermaid/
+!/comfyui/
 !/adguardhome/
 !/novita/
 !/ollama/
@@ -74,6 +75,8 @@
 /drawio/.*
 /mermaid/*
 /mermaid/.*
+/comfyui/*
+/comfyui/.*
 /adguardhome/*
 /adguardhome/.*
 /ollama/*
@@ -93,6 +96,7 @@
 !/zoom/agent-harness/
 !/drawio/agent-harness/
 !/mermaid/agent-harness/
+!/comfyui/agent-harness/
 !/adguardhome/agent-harness/
 !/novita/agent-harness/
 !/ollama/agent-harness/

--- a/adguardhome/agent-harness/cli_anything/adguardhome/skills/SKILL.md
+++ b/adguardhome/agent-harness/cli_anything/adguardhome/skills/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: >-
+  cli-anything-adguardhome
+description: >-
+  Command-line interface for AdGuard Home - Network-wide ad blocking and DNS management via AdGuard Home REST API. Designed for AI agents and power users who need to manage filtering, DNS rewrites, clients, DHCP, and query logs without a GUI.
+---
+
+# cli-anything-adguardhome
+
+Network-wide ad blocking and DNS management via the AdGuard Home REST API. Designed for AI agents and power users who need to manage filtering, DNS rewrites, clients, DHCP, and query logs without a GUI.
+
+## Installation
+
+This CLI is installed as part of the cli-anything-adguardhome package:
+
+```bash
+pip install cli-anything-adguardhome
+```
+
+**Prerequisites:**
+- Python 3.10+
+- AdGuard Home must be installed and running
+- Install AdGuard Home: `curl -s -S -L https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/master/scripts/install.sh | sh -s -- -v`
+
+## Usage
+
+### Basic Commands
+
+```bash
+# Show help
+cli-anything-adguardhome --help
+
+# Start interactive REPL mode
+cli-anything-adguardhome
+
+# Check server status
+cli-anything-adguardhome server status
+
+# Run with JSON output (for agent consumption)
+cli-anything-adguardhome --json server status
+```
+
+### REPL Mode
+
+When invoked without a subcommand, the CLI enters an interactive REPL session:
+
+```bash
+cli-anything-adguardhome
+# Enter commands interactively with tab-completion and history
+```
+
+## Command Groups
+
+### Config
+
+Connection and configuration management.
+
+| Command | Description |
+|---------|-------------|
+| `show` | Show current connection configuration |
+| `save` | Save connection settings to a config file |
+| `test` | Test the connection to AdGuard Home |
+
+### Server
+
+Server status and control commands.
+
+| Command | Description |
+|---------|-------------|
+| `status` | Show server protection status |
+| `version` | Show AdGuard Home version |
+| `restart` | Restart the AdGuard Home server |
+
+### Filter
+
+DNS filter list management.
+
+| Command | Description |
+|---------|-------------|
+| `list` | List all configured filter lists |
+| `status` | Show filtering status |
+| `toggle` | Enable or disable filtering globally |
+| `add` | Add a new filter list by URL |
+| `remove` | Remove a filter list |
+| `enable` | Enable a specific filter list |
+| `disable` | Disable a specific filter list |
+| `refresh` | Force-refresh all filter lists |
+
+### Blocking
+
+Parental control, safe browsing, and safe search settings.
+
+| Command | Description |
+|---------|-------------|
+| `parental status` | Show parental control status |
+| `parental enable` | Enable parental control |
+| `parental disable` | Disable parental control |
+| `safebrowsing status` | Show safe browsing status |
+| `safebrowsing enable` | Enable safe browsing |
+| `safebrowsing disable` | Disable safe browsing |
+| `safesearch status` | Show safe search status |
+| `safesearch enable` | Enable safe search |
+| `safesearch disable` | Disable safe search |
+
+### Blocked-Services
+
+Manage blocked internet services.
+
+| Command | Description |
+|---------|-------------|
+| `list` | List currently blocked services |
+| `set` | Set the list of blocked services |
+
+### Clients
+
+Client device management.
+
+| Command | Description |
+|---------|-------------|
+| `list` | List all configured clients |
+| `add` | Add a new client by name and IP |
+| `remove` | Remove a client |
+| `show` | Show details for a specific client |
+
+### Stats
+
+Query statistics.
+
+| Command | Description |
+|---------|-------------|
+| `show` | Show DNS query statistics |
+| `reset` | Reset all statistics |
+| `config` | View or update statistics retention interval |
+
+### Log
+
+DNS query log management.
+
+| Command | Description |
+|---------|-------------|
+| `show` | Show recent DNS query log entries |
+| `config` | View or update query log settings |
+| `clear` | Clear the query log |
+
+### Rewrite
+
+DNS rewrite rules.
+
+| Command | Description |
+|---------|-------------|
+| `list` | List all DNS rewrite rules |
+| `add` | Add a DNS rewrite rule |
+| `remove` | Remove a DNS rewrite rule |
+
+### DHCP
+
+DHCP server management.
+
+| Command | Description |
+|---------|-------------|
+| `status` | Show DHCP server status |
+| `leases` | List active DHCP leases |
+| `add-static` | Add a static DHCP lease |
+| `remove-static` | Remove a static DHCP lease |
+
+### TLS
+
+TLS/HTTPS configuration.
+
+| Command | Description |
+|---------|-------------|
+| `status` | Show TLS configuration status |
+
+## Examples
+
+### Check Server Status
+
+```bash
+cli-anything-adguardhome server status
+cli-anything-adguardhome server version
+```
+
+### Manage Filter Lists
+
+```bash
+# List current filters
+cli-anything-adguardhome filter list
+
+# Add a new blocklist
+cli-anything-adguardhome filter add --url https://somehost.com/list.txt --name "My List"
+
+# Refresh all filters
+cli-anything-adguardhome filter refresh
+```
+
+### DNS Rewrites
+
+```bash
+# Add a local DNS entry
+cli-anything-adguardhome rewrite add --domain "myserver.local" --answer "192.168.1.50"
+
+# List all rewrites
+cli-anything-adguardhome rewrite list
+```
+
+### Client Management
+
+```bash
+cli-anything-adguardhome clients add --name "My PC" --ip 192.168.1.100
+cli-anything-adguardhome clients list
+```
+
+### Query Statistics
+
+```bash
+# Show stats (human-readable)
+cli-anything-adguardhome stats show
+
+# Show stats (JSON for agents)
+cli-anything-adguardhome --json stats show
+```
+
+## Output Formats
+
+All commands support dual output modes:
+
+- **Human-readable** (default): Tables, colors, formatted text
+- **Machine-readable** (`--json` flag): Structured JSON for agent consumption
+
+```bash
+# Human output
+cli-anything-adguardhome filter list
+
+# JSON output for agents
+cli-anything-adguardhome --json filter list
+```
+
+## For AI Agents
+
+When using this CLI programmatically:
+
+1. **Always use `--json` flag** for parseable output
+2. **Check return codes** - 0 for success, non-zero for errors
+3. **Parse stderr** for error messages on failure
+4. **Use absolute paths** for all file operations
+5. **Test connection first** with `config test` before other commands
+
+## More Information
+
+- Full documentation: See README.md in the package
+- Test coverage: See TEST.md in the package
+- Methodology: See HARNESS.md in the cli-anything-plugin
+
+## Version
+
+1.0.0

--- a/adguardhome/agent-harness/setup.py
+++ b/adguardhome/agent-harness/setup.py
@@ -15,5 +15,9 @@ setup(
             "cli-anything-adguardhome=cli_anything.adguardhome.adguardhome_cli:main",
         ],
     },
+    package_data={
+        "cli_anything.adguardhome": ["skills/*.md"],
+    },
+    include_package_data=True,
     python_requires=">=3.10",
 )

--- a/comfyui/agent-harness/cli_anything/comfyui/skills/SKILL.md
+++ b/comfyui/agent-harness/cli_anything/comfyui/skills/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: >-
+  cli-anything-comfyui
+description: >-
+  Command-line interface for ComfyUI - AI image generation workflow management via ComfyUI REST API. Designed for AI agents and power users who need to queue workflows, manage models, download generated images, and monitor the generation queue without a GUI.
+---
+
+# cli-anything-comfyui
+
+AI image generation workflow management via the ComfyUI REST API. Designed for AI agents and power users who need to queue workflows, manage models, download generated images, and monitor the generation queue without a GUI.
+
+## Installation
+
+This CLI is installed as part of the cli-anything-comfyui package:
+
+```bash
+pip install cli-anything-comfyui
+```
+
+**Prerequisites:**
+- Python 3.10+
+- ComfyUI must be installed and running at http://localhost:8188
+
+## Usage
+
+### Basic Commands
+
+```bash
+# Show help
+cli-anything-comfyui --help
+
+# Start interactive REPL mode
+cli-anything-comfyui repl
+
+# Check server stats
+cli-anything-comfyui system stats
+
+# Run with JSON output (for agent consumption)
+cli-anything-comfyui --json system stats
+```
+
+### REPL Mode
+
+Start an interactive session for exploratory use:
+
+```bash
+cli-anything-comfyui repl
+# Enter commands interactively with tab-completion and history
+```
+
+## Command Groups
+
+### Workflow
+
+Workflow management commands.
+
+| Command | Description |
+|---------|-------------|
+| `list` | List saved workflows |
+| `load` | Load a workflow from a JSON file |
+| `validate` | Validate a workflow JSON against the ComfyUI node graph |
+
+### Queue
+
+Generation queue management.
+
+| Command | Description |
+|---------|-------------|
+| `prompt` | Queue a workflow for execution |
+| `status` | Show current queue status (running and pending) |
+| `clear` | Clear the generation queue |
+| `history` | Show prompt execution history |
+| `interrupt` | Interrupt the currently running generation |
+
+### Models
+
+Model discovery commands.
+
+| Command | Description |
+|---------|-------------|
+| `checkpoints` | List available checkpoint models |
+| `loras` | List available LoRA models |
+| `vaes` | List available VAE models |
+| `controlnets` | List available ControlNet models |
+| `node-info` | Show detailed info for a specific node type |
+| `list-nodes` | List all available node types |
+
+### Images
+
+Generated image management.
+
+| Command | Description |
+|---------|-------------|
+| `list` | List generated images on the server |
+| `download` | Download a specific generated image |
+| `download-all` | Download all images from a prompt execution |
+
+### System
+
+Server status and information.
+
+| Command | Description |
+|---------|-------------|
+| `stats` | Show ComfyUI system statistics (GPU, CPU, memory) |
+| `info` | Show ComfyUI server info and extensions |
+
+## Examples
+
+### Check System Status
+
+```bash
+# Server stats
+cli-anything-comfyui system stats
+
+# Server info
+cli-anything-comfyui system info
+```
+
+### Discover Available Models
+
+```bash
+# List checkpoints
+cli-anything-comfyui models checkpoints
+
+# List LoRAs
+cli-anything-comfyui models loras
+
+# List all node types
+cli-anything-comfyui models list-nodes
+```
+
+### Queue and Monitor Generation
+
+```bash
+# Queue a workflow
+cli-anything-comfyui queue prompt --workflow my_workflow.json
+
+# Check queue status
+cli-anything-comfyui queue status
+
+# View execution history
+cli-anything-comfyui --json queue history
+```
+
+### Download Generated Images
+
+```bash
+# List generated images
+cli-anything-comfyui images list
+
+# Download a specific image
+cli-anything-comfyui images download --filename ComfyUI_00001_.png --output ./out.png
+
+# Download all images from a prompt
+cli-anything-comfyui images download-all --prompt-id <id> --output-dir ./outputs
+```
+
+## Output Formats
+
+All commands support dual output modes:
+
+- **Human-readable** (default): Tables, colors, formatted text
+- **Machine-readable** (`--json` flag): Structured JSON for agent consumption
+
+```bash
+# Human output
+cli-anything-comfyui system stats
+
+# JSON output for agents
+cli-anything-comfyui --json system stats
+```
+
+## For AI Agents
+
+When using this CLI programmatically:
+
+1. **Always use `--json` flag** for parseable output
+2. **Check return codes** - 0 for success, non-zero for errors
+3. **Parse stderr** for error messages on failure
+4. **Use absolute paths** for all file operations
+5. **Verify ComfyUI is running** with `system stats` before other commands
+
+## More Information
+
+- Full documentation: See README.md in the package
+- Test coverage: See TEST.md in the package
+- Methodology: See HARNESS.md in the cli-anything-plugin
+
+## Version
+
+1.0.0

--- a/comfyui/agent-harness/setup.py
+++ b/comfyui/agent-harness/setup.py
@@ -46,6 +46,9 @@ setup(
             "cli-anything-comfyui=cli_anything.comfyui.comfyui_cli:main",
         ],
     },
+    package_data={
+        "cli_anything.comfyui": ["skills/*.md"],
+    },
     include_package_data=True,
     zip_safe=False,
 )

--- a/mermaid/agent-harness/cli_anything/mermaid/skills/SKILL.md
+++ b/mermaid/agent-harness/cli_anything/mermaid/skills/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: >-
+  cli-anything-mermaid
+description: >-
+  Command-line interface for Mermaid Live Editor - Create, edit, and render Mermaid diagrams via stateful project files and mermaid.ink renderer URLs. Designed for AI agents and power users who need to generate flowcharts, sequence diagrams, and other visualizations without a GUI.
+---
+
+# cli-anything-mermaid
+
+Create, edit, and render Mermaid diagrams via stateful project files and the mermaid.ink renderer. Designed for AI agents and power users who need to generate flowcharts, sequence diagrams, and other visualizations without a GUI.
+
+## Installation
+
+This CLI is installed as part of the cli-anything-mermaid package:
+
+```bash
+pip install cli-anything-mermaid
+```
+
+**Prerequisites:**
+- Python 3.10+
+- No external software required (rendering uses mermaid.ink cloud service)
+
+## Usage
+
+### Basic Commands
+
+```bash
+# Show help
+cli-anything-mermaid --help
+
+# Start interactive REPL mode
+cli-anything-mermaid
+
+# Create a new project
+cli-anything-mermaid project new -o diagram.json
+
+# Run with JSON output (for agent consumption)
+cli-anything-mermaid --json project info
+```
+
+### REPL Mode
+
+When invoked without a subcommand, the CLI enters an interactive REPL session:
+
+```bash
+cli-anything-mermaid
+# Enter commands interactively with tab-completion and history
+```
+
+## Command Groups
+
+### Project
+
+Project lifecycle commands.
+
+| Command | Description |
+|---------|-------------|
+| `new` | Create a new Mermaid project with optional sample preset and theme |
+| `open` | Open an existing Mermaid project file |
+| `save` | Save the current project to a file |
+| `info` | Show current project information |
+| `samples` | List available sample diagram presets |
+
+### Diagram
+
+Diagram source manipulation commands.
+
+| Command | Description |
+|---------|-------------|
+| `set` | Replace the Mermaid source text (inline or from file) |
+| `show` | Print the current Mermaid source code |
+
+### Export
+
+Render and share commands.
+
+| Command | Description |
+|---------|-------------|
+| `render` | Render the diagram to SVG or PNG via mermaid.ink |
+| `share` | Generate a Mermaid Live Editor URL for sharing |
+
+### Session
+
+Session state commands.
+
+| Command | Description |
+|---------|-------------|
+| `status` | Show current session state |
+| `undo` | Undo the last diagram source change |
+| `redo` | Redo the last undone change |
+
+## Examples
+
+### Create and Render a Flowchart
+
+```bash
+# Create a project with flowchart sample
+cli-anything-mermaid project new --sample flowchart -o flow.json
+
+# Replace diagram source
+cli-anything-mermaid --project flow.json diagram set --text "graph TD; A-->B; B-->C;"
+
+# Render to SVG
+cli-anything-mermaid --project flow.json export render output.svg --format svg
+```
+
+### Create a Sequence Diagram
+
+```bash
+# Create project with sequence sample
+cli-anything-mermaid project new --sample sequence -o seq.json
+
+# Set diagram from file
+cli-anything-mermaid --project seq.json diagram set --file my_diagram.mmd
+
+# Render to PNG
+cli-anything-mermaid --project seq.json export render output.png --format png
+```
+
+### Share a Diagram
+
+```bash
+# Generate an editable Mermaid Live URL
+cli-anything-mermaid --project flow.json export share --mode edit
+
+# Generate a view-only URL
+cli-anything-mermaid --project flow.json export share --mode view
+```
+
+### Interactive REPL Session
+
+```bash
+cli-anything-mermaid
+# new flowchart
+# set graph TD; A-->B; B-->C;
+# render output.svg
+# share
+# quit
+```
+
+## State Management
+
+The CLI maintains session state with:
+
+- **Undo/Redo**: Revert or replay diagram source changes
+- **Project persistence**: Save/load project state as JSON
+- **Session tracking**: Track modifications and changes
+
+## Output Formats
+
+All commands support dual output modes:
+
+- **Human-readable** (default): Tables, colors, formatted text
+- **Machine-readable** (`--json` flag): Structured JSON for agent consumption
+
+```bash
+# Human output
+cli-anything-mermaid project info
+
+# JSON output for agents
+cli-anything-mermaid --json project info
+```
+
+## For AI Agents
+
+When using this CLI programmatically:
+
+1. **Always use `--json` flag** for parseable output
+2. **Check return codes** - 0 for success, non-zero for errors
+3. **Parse stderr** for error messages on failure
+4. **Use absolute paths** for all file operations
+5. **Verify outputs exist** after render operations
+
+## More Information
+
+- Full documentation: See README.md in the package
+- Test coverage: See TEST.md in the package
+- Methodology: See HARNESS.md in the cli-anything-plugin
+
+## Version
+
+1.0.0

--- a/mermaid/agent-harness/setup.py
+++ b/mermaid/agent-harness/setup.py
@@ -25,5 +25,9 @@ setup(
             "cli-anything-mermaid=cli_anything.mermaid.mermaid_cli:main",
         ]
     },
+    package_data={
+        "cli_anything.mermaid": ["skills/*.md"],
+    },
+    include_package_data=True,
     python_requires=">=3.10",
 )

--- a/skill_generation/tests/test_skill_path.py
+++ b/skill_generation/tests/test_skill_path.py
@@ -143,17 +143,24 @@ class TestInstalledHarnesses:
     """Verify each real harness has SKILL.md in the correct package location."""
 
     HARNESSES = [
-        ("gimp", "gimp"),
-        ("blender", "blender"),
-        ("inkscape", "inkscape"),
+        ("adguardhome", "adguardhome"),
+        ("anygen", "anygen"),
         ("audacity", "audacity"),
-        ("libreoffice", "libreoffice"),
-        ("obs-studio", "obs_studio"),
+        ("blender", "blender"),
+        ("comfyui", "comfyui"),
+        ("drawio", "drawio"),
+        ("gimp", "gimp"),
+        ("inkscape", "inkscape"),
         ("kdenlive", "kdenlive"),
+        ("libreoffice", "libreoffice"),
+        ("mermaid", "mermaid"),
+        ("mubu", "mubu"),
+        ("notebooklm", "notebooklm"),
+        ("novita", "novita"),
+        ("obs-studio", "obs_studio"),
+        ("ollama", "ollama"),
         ("shotcut", "shotcut"),
         ("zoom", "zoom"),
-        ("drawio", "drawio"),
-        ("anygen", "anygen"),
     ]
 
     @pytest.mark.parametrize("dir_name,pkg_name", HARNESSES)
@@ -186,4 +193,6 @@ class TestInstalledHarnesses:
         setup_path = repo_root / dir_name / "agent-harness" / "setup.py"
         content = setup_path.read_text()
         assert "package_data" in content, f"Missing package_data in {setup_path}"
-        assert "skills/*.md" in content, f"Missing skills/*.md in package_data: {setup_path}"
+        # Accept both glob style ("skills/*.md") and explicit style ("SKILL.md" in a .skills key)
+        has_skill_ref = "skills/*.md" in content or ("skills" in content and "SKILL.md" in content)
+        assert has_skill_ref, f"Missing skills/*.md or SKILL.md in package_data: {setup_path}"


### PR DESCRIPTION
## Summary

Three harnesses — **adguardhome**, **comfyui**, and **mermaid** — shipped without the `SKILL.md` skill definition introduced in Phase 6.5. Their `setup.py` files also lacked the `package_data` entry needed for `pip install` to include the skill file. This means agents cannot discover these CLIs through the standard skill system.

Additionally, the existing `test_skill_path.py` only covered 11 of the 18 registered harnesses — the test fixture was never updated when later harnesses were added.

## Changes

### New SKILL.md files (3)
- **adguardhome** — 12 command groups (config, server, filter, blocking, blocked-services, clients, stats, log, rewrite, dhcp, tls), 36+ commands documented
- **comfyui** — 5 command groups (workflow, queue, models, images, system)
- **mermaid** — 4 command groups (project, diagram, export, session)

All follow the established convention: YAML frontmatter with name/description, command group tables with pipe-delimited rows, usage examples, and agent-specific guidance.

### setup.py fixes (3)
- **adguardhome**: add `package_data` and `include_package_data=True`
- **mermaid**: add `package_data` and `include_package_data=True`
- **comfyui**: add `package_data` for `skills/*.md` (had `include_package_data=True` but no `package_data` key)

### .gitignore fix (1)
- Add **comfyui** to the allow-list at Steps 4/5/6. The comfyui harness was tracked before the gitignore was tightened, but new files (like `skills/SKILL.md`) could not be added because the directory was blocked by `/*`.

### Test expansion
- Expand `test_skill_path.py` `HARNESSES` list from 11 to all **18** registered harnesses
- Fix `test_setup_py_includes_package_data` assertion to accept mubu's explicit `"SKILL.md"` reference alongside the glob pattern used by other harnesses

## Test Results

```
79 passed in 0.12s
```

All 79 tests pass (was 51 tests covering only 11 harnesses).