### PR TITLE
fix(repl): use shlex.split for REPL input parsing across 9 harnesses

### DIFF
--- a/audacity/agent-harness/cli_anything/audacity/audacity_cli.py
+++ b/audacity/agent-harness/cli_anything/audacity/audacity_cli.py
@@ -19,6 +19,7 @@ Usage:
 import sys
 import os
 import json
+import shlex
 import click
 from typing import Optional
 
@@ -759,7 +760,10 @@ def repl(project_path):
                 _repl_help(skin)
                 continue
 
-            args = line.split()
+            try:
+                args = shlex.split(line)
+            except ValueError:
+                args = line.split()
             try:
                 cli.main(args, standalone_mode=False)
             except SystemExit:

--- a/blender/agent-harness/cli_anything/blender/blender_cli.py
+++ b/blender/agent-harness/cli_anything/blender/blender_cli.py
@@ -17,6 +17,7 @@ Usage:
 import sys
 import os
 import json
+import shlex
 import click
 from typing import Optional
 
@@ -896,8 +897,11 @@ def repl(project_path):
                 skin.help(_repl_commands)
                 continue
 
-            # Parse and execute command
-            args = line.split()
+            # Parse and execute command (shlex handles quoted strings with spaces)
+            try:
+                args = shlex.split(line)
+            except ValueError:
+                args = line.split()
             try:
                 cli.main(args, standalone_mode=False)
             except SystemExit:

--- a/comfyui/agent-harness/cli_anything/comfyui/comfyui_cli.py
+++ b/comfyui/agent-harness/cli_anything/comfyui/comfyui_cli.py
@@ -27,6 +27,7 @@ Usage:
 import sys
 import os
 import json
+import shlex
 import click
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -385,7 +386,10 @@ def repl():
                     click.echo(f"  {cmd:<12} {subs}")
                 continue
 
-            args = line.split()
+            try:
+                args = shlex.split(line)
+            except ValueError:
+                args = line.split()
             try:
                 cli.main(args, standalone_mode=False)
             except SystemExit:

--- a/inkscape/agent-harness/cli_anything/inkscape/inkscape_cli.py
+++ b/inkscape/agent-harness/cli_anything/inkscape/inkscape_cli.py
@@ -17,6 +17,7 @@ Usage:
 import sys
 import os
 import json
+import shlex
 import click
 from typing import Optional
 
@@ -1006,7 +1007,10 @@ def repl(project_path):
                 _repl_help(skin)
                 continue
 
-            args = line.split()
+            try:
+                args = shlex.split(line)
+            except ValueError:
+                args = line.split()
             try:
                 cli.main(args, standalone_mode=False)
             except SystemExit:

--- a/kdenlive/agent-harness/cli_anything/kdenlive/kdenlive_cli.py
+++ b/kdenlive/agent-harness/cli_anything/kdenlive/kdenlive_cli.py
@@ -17,6 +17,7 @@ Usage:
 import sys
 import os
 import json
+import shlex
 import click
 from typing import Optional
 
@@ -712,7 +713,10 @@ def repl(project_path):
                 skin.help(commands_dict)
                 continue
 
-            args = line.split()
+            try:
+                args = shlex.split(line)
+            except ValueError:
+                args = line.split()
             try:
                 cli.main(args, standalone_mode=False)
             except SystemExit:

--- a/libreoffice/agent-harness/cli_anything/libreoffice/libreoffice_cli.py
+++ b/libreoffice/agent-harness/cli_anything/libreoffice/libreoffice_cli.py
@@ -17,6 +17,7 @@ Usage:
 import sys
 import os
 import json
+import shlex
 import click
 from typing import Optional
 
@@ -703,7 +704,10 @@ def repl(project_path):
                 _repl_help(skin)
                 continue
 
-            args = line.split()
+            try:
+                args = shlex.split(line)
+            except ValueError:
+                args = line.split()
             try:
                 cli.main(args, standalone_mode=False)
             except SystemExit:

--- a/obs-studio/agent-harness/cli_anything/obs_studio/obs_studio_cli.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/obs_studio_cli.py
@@ -17,6 +17,7 @@ Usage:
 import sys
 import os
 import json
+import shlex
 import click
 from typing import Optional
 
@@ -800,7 +801,10 @@ def repl(project_path):
                 _repl_help(skin)
                 continue
 
-            args = line.split()
+            try:
+                args = shlex.split(line)
+            except ValueError:
+                args = line.split()
             try:
                 cli.main(args, standalone_mode=False)
             except SystemExit:

--- a/ollama/agent-harness/cli_anything/ollama/ollama_cli.py
+++ b/ollama/agent-harness/cli_anything/ollama/ollama_cli.py
@@ -17,6 +17,7 @@ Usage:
 import sys
 import os
 import json
+import shlex
 import click
 from typing import Optional
 
@@ -467,8 +468,11 @@ def repl():
                 skin.help(_repl_commands)
                 continue
 
-            # Parse and execute command
-            args = line.split()
+            # Parse and execute command (shlex handles quoted strings with spaces)
+            try:
+                args = shlex.split(line)
+            except ValueError:
+                args = line.split()
             try:
                 cli.main(args, standalone_mode=False)
             except SystemExit:

--- a/zoom/agent-harness/cli_anything/zoom/zoom_cli.py
+++ b/zoom/agent-harness/cli_anything/zoom/zoom_cli.py
@@ -25,6 +25,7 @@ Usage:
 import sys
 import os
 import json
+import shlex
 import webbrowser
 import click
 from typing import Optional
@@ -486,8 +487,11 @@ def repl():
                 skin.help(_repl_commands)
                 continue
 
-            # Parse and execute command
-            args = line.split()
+            # Parse and execute command (shlex handles quoted strings with spaces)
+            try:
+                args = shlex.split(line)
+            except ValueError:
+                args = line.split()
             try:
                 cli.main(args, standalone_mode=False)
             except SystemExit:


### PR DESCRIPTION
## Summary

Fixes #127

The REPL in 9 harnesses uses `str.split()` to parse user input, which breaks any command argument containing spaces — even when properly quoted. This affects object names, file paths, text content, and any string value with spaces.

The GIMP harness already handles this correctly with `shlex.split()` + a `ValueError` fallback. This PR applies the same pattern to the remaining 9 harnesses.

## Changes

For each affected harness:
1. Add `import shlex` at the top of the file
2. Replace `args = line.split()` with:
```python
try:
    args = shlex.split(line)
except ValueError:
    args = line.split()
```

### Affected files
- `blender/agent-harness/cli_anything/blender/blender_cli.py`
- `audacity/agent-harness/cli_anything/audacity/audacity_cli.py`
- `inkscape/agent-harness/cli_anything/inkscape/inkscape_cli.py`
- `kdenlive/agent-harness/cli_anything/kdenlive/kdenlive_cli.py`
- `libreoffice/agent-harness/cli_anything/libreoffice/libreoffice_cli.py`
- `obs-studio/agent-harness/cli_anything/obs_studio/obs_studio_cli.py`
- `ollama/agent-harness/cli_anything/ollama/ollama_cli.py`
- `zoom/agent-harness/cli_anything/zoom/zoom_cli.py`
- `comfyui/agent-harness/cli_anything/comfyui/comfyui_cli.py`

## Example

Before fix:
```
> object add cube --name "My Cube"
Error: No such option "Cube"
```

After fix:
```
> object add cube --name "My Cube"
Added cube 'My Cube' at (0.0, 0.0, 0.0)
```