### PR TITLE
fix(browser): fix DOMShell MCP parameter mismatches and connection model

### DIFF
--- a/browser/agent-harness/cli_anything/browser/core/fs.py
+++ b/browser/agent-harness/cli_anything/browser/core/fs.py
@@ -111,5 +111,18 @@ def grep_elements(session: "Session", pattern: str, path: str = "") -> dict:
         >>> grep_elements(session, "Login")
         {"matches": ["/main/button[0]", "/main/link[1]"]}
     """
+    target_path = path if path else session.working_dir
     use_daemon = session.daemon_mode
-    return backend.grep(pattern, use_daemon=use_daemon)
+
+    # DOMShell's grep searches from the server-side CWD. To root the search
+    # at the requested path, cd there first, grep, then restore.
+    if target_path and target_path != "/":
+        cd_result = backend.cd(target_path, use_daemon=use_daemon)
+        if hasattr(cd_result, 'isError') and cd_result.isError:
+            return cd_result
+
+    try:
+        return backend.grep(pattern, use_daemon=use_daemon)
+    finally:
+        if target_path and target_path != "/":
+            backend.cd(session.working_dir or "/", use_daemon=use_daemon)

--- a/browser/agent-harness/cli_anything/browser/tests/test_core.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_core.py
@@ -343,15 +343,20 @@ class TestFsModule:
             mock_grep.assert_called_once_with("Login", use_daemon=False)
 
     def test_grep_elements_with_path(self):
-        """Grepping with path still calls backend (path not forwarded to DOMShell)."""
+        """Grepping with path cds to that path first, then restores."""
         sess = Session()
 
-        with patch("cli_anything.browser.core.fs.backend.grep") as mock_grep:
+        with patch("cli_anything.browser.core.fs.backend.grep") as mock_grep, \
+             patch("cli_anything.browser.core.fs.backend.cd") as mock_cd:
             mock_grep.return_value = {"matches": ["/main/button[0]"]}
+            mock_cd.return_value = {"path": "/main"}
 
             result = fs.grep_elements(sess, "Login", "/main")
 
             mock_grep.assert_called_once_with("Login", use_daemon=False)
+            assert mock_cd.call_count == 2
+            mock_cd.assert_any_call("/main", use_daemon=False)
+            mock_cd.assert_any_call("/", use_daemon=False)
 
 
 # ── Daemon Mode Tests ────────────────────────────────────────────

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -26,12 +26,24 @@ from mcp.client.stdio import stdio_client
 #   DOMSHELL_TOKEN  — auth token (required, must match the running server)
 #   DOMSHELL_PORT   — MCP HTTP port of the running server (default: 3001)
 DEFAULT_SERVER_CMD = "npx"
-DEFAULT_SERVER_ARGS = [
-    "-p", "@apireno/domshell",
-    "domshell-proxy",
-    "--port", os.environ.get("DOMSHELL_PORT", "3001"),
-    "--token", os.environ.get("DOMSHELL_TOKEN", ""),
-]
+
+
+def _build_server_args() -> list[str]:
+    """Build server args at call time so env var changes are honored."""
+    token = os.environ.get("DOMSHELL_TOKEN", "")
+    if not token:
+        raise RuntimeError(
+            "DOMSHELL_TOKEN environment variable is required.\n"
+            "Set it to the auth token of your running DOMShell server.\n"
+            "Example: export DOMSHELL_TOKEN=<token from DOMShell startup>"
+        )
+    port = os.environ.get("DOMSHELL_PORT", "3001")
+    return [
+        "-p", "@apireno/domshell",
+        "domshell-proxy",
+        "--port", port,
+        "--token", token,
+    ]
 
 # Daemon mode: persistent MCP connection
 _daemon_session: Optional[ClientSession] = None
@@ -130,7 +142,7 @@ async def _call_tool(
     # Spawn new MCP server process
     server_params = StdioServerParameters(
         command=DEFAULT_SERVER_CMD,
-        args=DEFAULT_SERVER_ARGS
+        args=_build_server_args()
     )
 
     try:
@@ -167,7 +179,7 @@ async def _start_daemon() -> bool:
 
     server_params = StdioServerParameters(
         command=DEFAULT_SERVER_CMD,
-        args=DEFAULT_SERVER_ARGS
+        args=_build_server_args()
     )
 
     try:
@@ -388,7 +400,7 @@ def type_text(path: str, text: str, use_daemon: bool = False) -> dict:
 
         server_params = StdioServerParameters(
             command=DEFAULT_SERVER_CMD,
-            args=DEFAULT_SERVER_ARGS
+            args=_build_server_args()
         )
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:


### PR DESCRIPTION
## Summary

- Switch from `domshell` to `domshell-proxy` (stdio bridge) to match how MCP clients like Claude Desktop integrate with DOMShell
- Add `DOMSHELL_TOKEN` / `DOMSHELL_PORT` env var support for auth
- Fix MCP tool parameter names: `ls` (options), `cat` (name), `click` (name)
- Remove unsupported `path` param from `grep`
- Fix `type_text` to focus (`domshell_focus`) then type in single MCP session
- Add `--allow-write --no-confirm` flags for write commands

Fixes issues reported in PR #118.

## Type of Change

- [ ] **New Software CLI** — adds a CLI harness for a new application
- [ ] **New Feature** — adds new functionality to an existing harness or the plugin
- [x] **Bug Fix** — fixes incorrect behavior
- [ ] **Documentation** — updates docs only
- [ ] **Other** — please describe:

---

### For Existing CLI Modifications

- [x] All unit tests pass: `python3 -m pytest cli_anything/browser/tests/test_core.py -v`
- [x] All E2E tests pass: `python3 -m pytest cli_anything/browser/tests/test_full_e2e.py -v`
- [x] No test regressions — no previously passing tests were removed or weakened
- [ ] `registry.json` entry is updated if version, description, or requirements changed

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands
- [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
- [x] I have tested my changes locally

## Test Results

```
============================= 31 passed in 0.23s ==============================
```

```
cli_anything/browser/tests/test_full_e2e.py::TestDependencyChecks::test_cli_starts_when_domshell_available PASSED [ 10%]
cli_anything/browser/tests/test_full_e2e.py::TestPageCommands::test_page_info_empty PASSED [ 20%]
cli_anything/browser/tests/test_full_e2e.py::TestFilesystemCommands::test_fs_pwd PASSED [ 30%]
cli_anything/browser/tests/test_full_e2e.py::TestSessionCommands::test_session_status PASSED [ 40%]
cli_anything/browser/tests/test_full_e2e.py::TestDaemonMode::test_daemon_lifecycle PASSED [ 50%]
cli_anything/browser/tests/test_full_e2e.py::TestDaemonMode::test_daemon_start_with_json PASSED [ 60%]
cli_anything/browser/tests/test_full_e2e.py::TestErrorHandling::test_invalid_path_gives_error PASSED [ 70%]
cli_anything/browser/tests/test_full_e2e.py::TestErrorHandling::test_empty_page_info PASSED [ 80%]
cli_anything/browser/tests/test_full_e2e.py::TestJSONOutput::test_json_output_is_valid PASSED [ 90%]
cli_anything/browser/tests/test_full_e2e.py::TestCleanup::test_stop_daemon_if_running PASSED [100%]
======================== 10 passed, 1 warning in 7.35s =========================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)