### PR TITLE
Make codex-skill self-contained

### DIFF
--- a/codex-skill/SKILL.md
+++ b/codex-skill/SKILL.md
@@ -1,13 +1,40 @@
 ---
 name: cli-anything
-description: Use when the user wants Codex to build, refine, test, or validate a CLI-Anything harness for a GUI application or source repository. Adapts the CLI-Anything methodology to Codex without changing the generated Python harness format.
+description: Use when the user wants Codex to build, refine, test, or validate a CLI-Anything harness for a GUI application or source repository. This self-contained Codex edition vendors the official HARNESS, REPL skin, skill generator, and template so it remains usable even when the full CLI-Anything repository is unavailable.
 ---
 
 # CLI-Anything for Codex
 
-Use this skill when the user wants Codex to act like the `CLI-Anything` builder.
+Act as the CLI-Anything builder for Codex.
 
-If this skill is being used from inside the `CLI-Anything` repository, read `../cli-anything-plugin/HARNESS.md` before implementation. That file is the full methodology source of truth. If it is not available, follow the condensed rules below.
+This package is intentionally self-contained. Prefer repo-local official plugin files when they
+exist in the target source tree; otherwise use the bundled files in this skill.
+
+## Resource Map
+
+- `references/HARNESS.md`
+  - Canonical methodology and hard requirements for Codex usage.
+  - Read this before substantial implementation work.
+- `assets/cli_anything_plugin/repl_skin.py`
+  - Copy into generated harnesses as `cli_anything/<software>/utils/repl_skin.py`.
+- `assets/cli_anything_plugin/skill_generator.py`
+  - Use to generate the installed `skills/SKILL.md` for the produced CLI package.
+- `assets/cli_anything_plugin/templates/SKILL.md.template`
+  - Template used by the skill generator.
+- `scripts/sync_from_repo.ps1` / `scripts/sync_from_repo.sh`
+  - Refresh bundled files from an official CLI-Anything repository clone.
+
+## Source Selection
+
+When the target path is itself a CLI-Anything repository or already contains the official plugin files,
+prefer these repo-local sources:
+
+- `cli-anything-plugin/HARNESS.md`
+- `cli-anything-plugin/repl_skin.py`
+- `cli-anything-plugin/skill_generator.py`
+- `cli-anything-plugin/templates/SKILL.md.template`
+
+Otherwise, use the bundled copies in this skill.
 
 ## Inputs
 
@@ -18,93 +45,139 @@ Accept either:
 
 Derive the software name from the local directory name after cloning if needed.
 
+## Always-Read Rules
+
+Before substantial implementation, read `references/HARNESS.md` or the repo-local
+`cli-anything-plugin/HARNESS.md`. Do not rely on this file alone for detailed build and test behavior.
+
+At minimum, load the sections covering:
+
+- Purpose and general SOP
+- Relevant implementation phases
+- Test planning and execution
+- SKILL generation
+- Summary requirements near the end of the file
+
+## Hard Requirements
+
+These rules are mandatory even if you do not reread the full HARNESS immediately:
+
+- Prefer the real software backend over reimplementation.
+- Build a stateful Click CLI with subcommands, `--json`, and REPL as the default path.
+- Write `tests/TEST.md` before writing test code.
+- E2E tests must invoke the real software and produce real output artifacts.
+- Do not gracefully degrade to fallback libraries when the real software is missing.
+- Subprocess tests must exercise the installed `cli-anything-<software>` command.
+- Use `_resolve_cli()` in subprocess tests rather than hardcoding module execution.
+- Copy and use `repl_skin.py` for the interactive REPL.
+- Generate a package-local `skills/SKILL.md` using `skill_generator.py`.
+- If session state is saved to JSON, use safe locked writes instead of bare truncating writes.
+- Report whether bundled or repo-local official resources were used.
+
 ## Modes
 
 ### Build
 
 Use when the user wants a new harness.
 
-Produce this structure:
+Read the HARNESS sections for:
+
+- Phase 1: Codebase Analysis
+- Phase 2: CLI Architecture Design
+- Phase 3: Implementation
+- Phase 4-6.5: Testing, documentation, and generated skill packaging
+
+Target structure:
 
 ```text
 <software>/
-└── agent-harness/
-    ├── <SOFTWARE>.md
-    ├── setup.py
-    └── cli_anything/
-        └── <software>/
-            ├── README.md
-            ├── __init__.py
-            ├── __main__.py
-            ├── <software>_cli.py
-            ├── core/
-            ├── utils/
-            └── tests/
+`-- agent-harness/
+    |-- <SOFTWARE>.md
+    |-- setup.py
+    `-- cli_anything/
+        `-- <software>/
+            |-- README.md
+            |-- __init__.py
+            |-- __main__.py
+            |-- <software>_cli.py
+            |-- core/
+            |-- utils/
+            |-- tests/
+            `-- skills/
+                `-- SKILL.md
 ```
-
-Implement a stateful Click CLI with:
-
-- one-shot subcommands
-- REPL mode as the default when no subcommand is given
-- `--json` machine-readable output
-- session state with undo/redo where the target software supports it
 
 ### Refine
 
 Use when the harness already exists.
 
-First inventory current commands and tests, then do gap analysis against the target software. Prefer:
+First inventory current commands, test coverage, backend wiring, REPL behavior, generated skill
+files, and missing output verification. Then do gap analysis against the target software.
 
-- high-impact missing features
-- easy wrappers around existing backend APIs or CLIs
-- additions that compose well with existing commands
+Prefer:
+
+- High-impact missing features
+- Easy wrappers around existing backend APIs or CLIs
+- Additions that compose with the current command model
+- Missing real-backend tests and output verification
 
 Do not remove existing commands unless the user explicitly asks for a breaking change.
 
 ### Test
 
-Plan tests before writing them. Keep both:
+Use when the user wants to create or improve tests.
 
-- `test_core.py` for unit coverage
-- `test_full_e2e.py` for workflow and backend validation
+Required flow:
 
-When possible, test the installed command via subprocess using `cli-anything-<software>` rather than only module imports.
+1. Write or update `tests/TEST.md` first.
+2. Add `test_core.py`.
+3. Add `test_full_e2e.py`.
+4. Run tests against real software.
+5. Append results back into `TEST.md`.
 
 ### Validate
 
 Check that the harness:
 
-- uses the `cli_anything.<software>` namespace package layout
-- has an installable `setup.py` entry point
-- supports JSON output
-- has a REPL default path
-- documents usage and tests
+- Uses the `cli_anything.<software>` namespace package layout
+- Has an installable `setup.py` entry point
+- Supports JSON output
+- Enters REPL when invoked without a subcommand
+- Uses the unified REPL skin
+- Ships `tests/TEST.md`
+- Ships a generated `skills/SKILL.md`
+- Verifies real outputs rather than trusting exit codes
 
-## Backend Rules
+## Implementation Guidance
 
-Prefer the real software backend over reimplementation. Wrap the actual executable or scripting interface in `utils/<software>_backend.py` when possible. Use synthetic reimplementation only when the project explicitly requires it or no viable native backend exists.
-
-## Packaging Rules
-
-- Use `find_namespace_packages(include=["cli_anything.*"])`
-- Keep `cli_anything/` as a namespace package without a top-level `__init__.py`
-- Expose `cli-anything-<software>` through `console_scripts`
-
-## Workflow
+When building or refining a harness:
 
 1. Acquire the source tree locally.
 2. Analyze architecture, data model, existing CLIs, and GUI-to-API mappings.
-3. Design command groups and state model.
+3. Design command groups and the session state model.
 4. Implement the harness.
-5. Write `TEST.md`, then tests, then run them.
-6. Update README usage docs.
-7. Verify local installation with `pip install -e .`
+5. Copy `assets/cli_anything_plugin/repl_skin.py` into `utils/repl_skin.py` if no repo-local source is available.
+6. Use `assets/cli_anything_plugin/skill_generator.py` and `assets/cli_anything_plugin/templates/SKILL.md.template` to generate the package skill when no repo-local source is available.
+7. Write `tests/TEST.md`, then tests, then run them.
+8. Update README usage docs.
+9. Verify local installation with `pip install -e .`.
 
 ## Output Expectations
 
 When reporting progress or final results, include:
 
-- target software and source path
-- files added or changed
-- validation commands run
-- open risks or backend limitations
+- Target software and source path
+- Whether bundled or repo-local official resources were used
+- Files added or changed
+- Validation commands run
+- Open risks, backend limitations, or missing dependencies
+
+## Syncing Bundled Files
+
+To refresh this skill from an official CLI-Anything clone, run one of:
+
+- `scripts/sync_from_repo.ps1 -RepoRoot <path>`
+- `scripts/sync_from_repo.sh <path>`
+
+This updates the bundled HARNESS, REPL skin, skill generator, and template without changing
+the Codex-specific `SKILL.md`.

--- a/codex-skill/agents/openai.yaml
+++ b/codex-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "CLI-Anything"
-  short_description: "Build or refine CLI-Anything harnesses from Codex."
-  default_prompt: "Use CLI-Anything to build, refine, test, or validate a harness for the user's target software or source repository."
+  short_description: "Build, refine, test, and validate self-contained CLI-Anything harnesses from Codex."
+  default_prompt: "Use CLI-Anything to build, refine, test, or validate a CLI-Anything harness for the user's target software or source repository. Prefer repo-local official plugin files when available; otherwise use the bundled HARNESS, REPL skin, skill generator, and template."

--- a/codex-skill/assets/cli_anything_plugin/repl_skin.py
+++ b/codex-skill/assets/cli_anything_plugin/repl_skin.py
@@ -1,0 +1,521 @@
+"""cli-anything REPL Skin — Unified terminal interface for all CLI harnesses.
+
+Copy this file into your CLI package at:
+    cli_anything/<software>/utils/repl_skin.py
+
+Usage:
+    from cli_anything.<software>.utils.repl_skin import ReplSkin
+
+    skin = ReplSkin("shotcut", version="1.0.0")
+    skin.print_banner()  # auto-detects skills/SKILL.md inside the package
+    prompt_text = skin.prompt(project_name="my_video.mlt", modified=True)
+    skin.success("Project saved")
+    skin.error("File not found")
+    skin.warning("Unsaved changes")
+    skin.info("Processing 24 clips...")
+    skin.status("Track 1", "3 clips, 00:02:30")
+    skin.table(headers, rows)
+    skin.print_goodbye()
+"""
+
+import os
+import sys
+
+# ── ANSI color codes (no external deps for core styling) ──────────────
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_ITALIC = "\033[3m"
+_UNDERLINE = "\033[4m"
+
+# Brand colors
+_CYAN = "\033[38;5;80m"       # cli-anything brand cyan
+_CYAN_BG = "\033[48;5;80m"
+_WHITE = "\033[97m"
+_GRAY = "\033[38;5;245m"
+_DARK_GRAY = "\033[38;5;240m"
+_LIGHT_GRAY = "\033[38;5;250m"
+
+# Software accent colors — each software gets a unique accent
+_ACCENT_COLORS = {
+    "gimp":        "\033[38;5;214m",   # warm orange
+    "blender":     "\033[38;5;208m",   # deep orange
+    "inkscape":    "\033[38;5;39m",    # bright blue
+    "audacity":    "\033[38;5;33m",    # navy blue
+    "libreoffice": "\033[38;5;40m",    # green
+    "obs_studio":  "\033[38;5;55m",    # purple
+    "kdenlive":    "\033[38;5;69m",    # slate blue
+    "shotcut":     "\033[38;5;35m",    # teal green
+}
+_DEFAULT_ACCENT = "\033[38;5;75m"      # default sky blue
+
+# Status colors
+_GREEN = "\033[38;5;78m"
+_YELLOW = "\033[38;5;220m"
+_RED = "\033[38;5;196m"
+_BLUE = "\033[38;5;75m"
+_MAGENTA = "\033[38;5;176m"
+
+# ── Brand icon ────────────────────────────────────────────────────────
+
+# The cli-anything icon: a small colored diamond/chevron mark
+_ICON = f"{_CYAN}{_BOLD}◆{_RESET}"
+_ICON_SMALL = f"{_CYAN}▸{_RESET}"
+
+# ── Box drawing characters ────────────────────────────────────────────
+
+_H_LINE = "─"
+_V_LINE = "│"
+_TL = "╭"
+_TR = "╮"
+_BL = "╰"
+_BR = "╯"
+_T_DOWN = "┬"
+_T_UP = "┴"
+_T_RIGHT = "├"
+_T_LEFT = "┤"
+_CROSS = "┼"
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes for length calculation."""
+    import re
+    return re.sub(r"\033\[[^m]*m", "", text)
+
+
+def _visible_len(text: str) -> int:
+    """Get visible length of text (excluding ANSI codes)."""
+    return len(_strip_ansi(text))
+
+
+class ReplSkin:
+    """Unified REPL skin for cli-anything CLIs.
+
+    Provides consistent branding, prompts, and message formatting
+    across all CLI harnesses built with the cli-anything methodology.
+    """
+
+    def __init__(self, software: str, version: str = "1.0.0",
+                 history_file: str | None = None, skill_path: str | None = None):
+        """Initialize the REPL skin.
+
+        Args:
+            software: Software name (e.g., "gimp", "shotcut", "blender").
+            version: CLI version string.
+            history_file: Path for persistent command history.
+                         Defaults to ~/.cli-anything-<software>/history
+            skill_path: Path to the SKILL.md file for agent discovery.
+                        Auto-detected from the package's skills/ directory if not provided.
+                        Displayed in banner for AI agents to know where to read skill info.
+        """
+        self.software = software.lower().replace("-", "_")
+        self.display_name = software.replace("_", " ").title()
+        self.version = version
+
+        # Auto-detect skill path from package layout:
+        #   cli_anything/<software>/utils/repl_skin.py  (this file)
+        #   cli_anything/<software>/skills/SKILL.md     (target)
+        if skill_path is None:
+            from pathlib import Path
+            _auto = Path(__file__).resolve().parent.parent / "skills" / "SKILL.md"
+            if _auto.is_file():
+                skill_path = str(_auto)
+        self.skill_path = skill_path
+        self.accent = _ACCENT_COLORS.get(self.software, _DEFAULT_ACCENT)
+
+        # History file
+        if history_file is None:
+            from pathlib import Path
+            hist_dir = Path.home() / f".cli-anything-{self.software}"
+            hist_dir.mkdir(parents=True, exist_ok=True)
+            self.history_file = str(hist_dir / "history")
+        else:
+            self.history_file = history_file
+
+        # Detect terminal capabilities
+        self._color = self._detect_color_support()
+
+    def _detect_color_support(self) -> bool:
+        """Check if terminal supports color."""
+        if os.environ.get("NO_COLOR"):
+            return False
+        if os.environ.get("CLI_ANYTHING_NO_COLOR"):
+            return False
+        if not hasattr(sys.stdout, "isatty"):
+            return False
+        return sys.stdout.isatty()
+
+    def _c(self, code: str, text: str) -> str:
+        """Apply color code if colors are supported."""
+        if not self._color:
+            return text
+        return f"{code}{text}{_RESET}"
+
+    # ── Banner ────────────────────────────────────────────────────────
+
+    def print_banner(self):
+        """Print the startup banner with branding."""
+        inner = 54
+
+        def _box_line(content: str) -> str:
+            """Wrap content in box drawing, padding to inner width."""
+            pad = inner - _visible_len(content)
+            vl = self._c(_DARK_GRAY, _V_LINE)
+            return f"{vl}{content}{' ' * max(0, pad)}{vl}"
+
+        top = self._c(_DARK_GRAY, f"{_TL}{_H_LINE * inner}{_TR}")
+        bot = self._c(_DARK_GRAY, f"{_BL}{_H_LINE * inner}{_BR}")
+
+        # Title:  ◆  cli-anything · Shotcut
+        icon = self._c(_CYAN + _BOLD, "◆")
+        brand = self._c(_CYAN + _BOLD, "cli-anything")
+        dot = self._c(_DARK_GRAY, "·")
+        name = self._c(self.accent + _BOLD, self.display_name)
+        title = f" {icon}  {brand} {dot} {name}"
+
+        ver = f" {self._c(_DARK_GRAY, f'   v{self.version}')}"
+        tip = f" {self._c(_DARK_GRAY, '   Type help for commands, quit to exit')}"
+        empty = ""
+
+        # Skill path for agent discovery
+        skill_line = None
+        if self.skill_path:
+            skill_icon = self._c(_MAGENTA, "◇")
+            skill_label = self._c(_DARK_GRAY, "   Skill:")
+            skill_path_display = self._c(_LIGHT_GRAY, self.skill_path)
+            skill_line = f" {skill_icon} {skill_label} {skill_path_display}"
+
+        print(top)
+        print(_box_line(title))
+        print(_box_line(ver))
+        if skill_line:
+            print(_box_line(skill_line))
+        print(_box_line(empty))
+        print(_box_line(tip))
+        print(bot)
+        print()
+
+    # ── Prompt ────────────────────────────────────────────────────────
+
+    def prompt(self, project_name: str = "", modified: bool = False,
+               context: str = "") -> str:
+        """Build a styled prompt string for prompt_toolkit or input().
+
+        Args:
+            project_name: Current project name (empty if none open).
+            modified: Whether the project has unsaved changes.
+            context: Optional extra context to show in prompt.
+
+        Returns:
+            Formatted prompt string.
+        """
+        parts = []
+
+        # Icon
+        if self._color:
+            parts.append(f"{_CYAN}◆{_RESET} ")
+        else:
+            parts.append("> ")
+
+        # Software name
+        parts.append(self._c(self.accent + _BOLD, self.software))
+
+        # Project context
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            parts.append(f" {self._c(_DARK_GRAY, '[')}")
+            parts.append(self._c(_LIGHT_GRAY, f"{ctx}{mod}"))
+            parts.append(self._c(_DARK_GRAY, ']'))
+
+        parts.append(self._c(_GRAY, " ❯ "))
+
+        return "".join(parts)
+
+    def prompt_tokens(self, project_name: str = "", modified: bool = False,
+                      context: str = ""):
+        """Build prompt_toolkit formatted text tokens for the prompt.
+
+        Use with prompt_toolkit's FormattedText for proper ANSI handling.
+
+        Returns:
+            list of (style, text) tuples for prompt_toolkit.
+        """
+        accent_hex = _ANSI_256_TO_HEX.get(self.accent, "#5fafff")
+        tokens = []
+
+        tokens.append(("class:icon", "◆ "))
+        tokens.append(("class:software", self.software))
+
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            tokens.append(("class:bracket", " ["))
+            tokens.append(("class:context", f"{ctx}{mod}"))
+            tokens.append(("class:bracket", "]"))
+
+        tokens.append(("class:arrow", " ❯ "))
+
+        return tokens
+
+    def get_prompt_style(self):
+        """Get a prompt_toolkit Style object matching the skin.
+
+        Returns:
+            prompt_toolkit.styles.Style
+        """
+        try:
+            from prompt_toolkit.styles import Style
+        except ImportError:
+            return None
+
+        accent_hex = _ANSI_256_TO_HEX.get(self.accent, "#5fafff")
+
+        return Style.from_dict({
+            "icon": "#5fdfdf bold",     # cyan brand color
+            "software": f"{accent_hex} bold",
+            "bracket": "#585858",
+            "context": "#bcbcbc",
+            "arrow": "#808080",
+            # Completion menu
+            "completion-menu.completion": "bg:#303030 #bcbcbc",
+            "completion-menu.completion.current": f"bg:{accent_hex} #000000",
+            "completion-menu.meta.completion": "bg:#303030 #808080",
+            "completion-menu.meta.completion.current": f"bg:{accent_hex} #000000",
+            # Auto-suggest
+            "auto-suggest": "#585858",
+            # Bottom toolbar
+            "bottom-toolbar": "bg:#1c1c1c #808080",
+            "bottom-toolbar.text": "#808080",
+        })
+
+    # ── Messages ──────────────────────────────────────────────────────
+
+    def success(self, message: str):
+        """Print a success message with green checkmark."""
+        icon = self._c(_GREEN + _BOLD, "✓")
+        print(f"  {icon} {self._c(_GREEN, message)}")
+
+    def error(self, message: str):
+        """Print an error message with red cross."""
+        icon = self._c(_RED + _BOLD, "✗")
+        print(f"  {icon} {self._c(_RED, message)}", file=sys.stderr)
+
+    def warning(self, message: str):
+        """Print a warning message with yellow triangle."""
+        icon = self._c(_YELLOW + _BOLD, "⚠")
+        print(f"  {icon} {self._c(_YELLOW, message)}")
+
+    def info(self, message: str):
+        """Print an info message with blue dot."""
+        icon = self._c(_BLUE, "●")
+        print(f"  {icon} {self._c(_LIGHT_GRAY, message)}")
+
+    def hint(self, message: str):
+        """Print a subtle hint message."""
+        print(f"  {self._c(_DARK_GRAY, message)}")
+
+    def section(self, title: str):
+        """Print a section header."""
+        print()
+        print(f"  {self._c(self.accent + _BOLD, title)}")
+        print(f"  {self._c(_DARK_GRAY, _H_LINE * len(title))}")
+
+    # ── Status display ────────────────────────────────────────────────
+
+    def status(self, label: str, value: str):
+        """Print a key-value status line."""
+        lbl = self._c(_GRAY, f"  {label}:")
+        val = self._c(_WHITE, f" {value}")
+        print(f"{lbl}{val}")
+
+    def status_block(self, items: dict[str, str], title: str = ""):
+        """Print a block of status key-value pairs.
+
+        Args:
+            items: Dict of label -> value pairs.
+            title: Optional title for the block.
+        """
+        if title:
+            self.section(title)
+
+        max_key = max(len(k) for k in items) if items else 0
+        for label, value in items.items():
+            lbl = self._c(_GRAY, f"  {label:<{max_key}}")
+            val = self._c(_WHITE, f"  {value}")
+            print(f"{lbl}{val}")
+
+    def progress(self, current: int, total: int, label: str = ""):
+        """Print a simple progress indicator.
+
+        Args:
+            current: Current step number.
+            total: Total number of steps.
+            label: Optional label for the progress.
+        """
+        pct = int(current / total * 100) if total > 0 else 0
+        bar_width = 20
+        filled = int(bar_width * current / total) if total > 0 else 0
+        bar = "█" * filled + "░" * (bar_width - filled)
+        text = f"  {self._c(_CYAN, bar)} {self._c(_GRAY, f'{pct:3d}%')}"
+        if label:
+            text += f" {self._c(_LIGHT_GRAY, label)}"
+        print(text)
+
+    # ── Table display ─────────────────────────────────────────────────
+
+    def table(self, headers: list[str], rows: list[list[str]],
+              max_col_width: int = 40):
+        """Print a formatted table with box-drawing characters.
+
+        Args:
+            headers: Column header strings.
+            rows: List of rows, each a list of cell strings.
+            max_col_width: Maximum column width before truncation.
+        """
+        if not headers:
+            return
+
+        # Calculate column widths
+        col_widths = [min(len(h), max_col_width) for h in headers]
+        for row in rows:
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    col_widths[i] = min(
+                        max(col_widths[i], len(str(cell))), max_col_width
+                    )
+
+        def pad(text: str, width: int) -> str:
+            t = str(text)[:width]
+            return t + " " * (width - len(t))
+
+        # Header
+        header_cells = [
+            self._c(_CYAN + _BOLD, pad(h, col_widths[i]))
+            for i, h in enumerate(headers)
+        ]
+        sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+        header_line = f"  {sep.join(header_cells)}"
+        print(header_line)
+
+        # Separator
+        sep_parts = [self._c(_DARK_GRAY, _H_LINE * w) for w in col_widths]
+        sep_line = self._c(_DARK_GRAY, f"  {'───'.join([_H_LINE * w for w in col_widths])}")
+        print(sep_line)
+
+        # Rows
+        for row in rows:
+            cells = []
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    cells.append(self._c(_LIGHT_GRAY, pad(str(cell), col_widths[i])))
+            row_sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+            print(f"  {row_sep.join(cells)}")
+
+    # ── Help display ──────────────────────────────────────────────────
+
+    def help(self, commands: dict[str, str]):
+        """Print a formatted help listing.
+
+        Args:
+            commands: Dict of command -> description pairs.
+        """
+        self.section("Commands")
+        max_cmd = max(len(c) for c in commands) if commands else 0
+        for cmd, desc in commands.items():
+            cmd_styled = self._c(self.accent, f"  {cmd:<{max_cmd}}")
+            desc_styled = self._c(_GRAY, f"  {desc}")
+            print(f"{cmd_styled}{desc_styled}")
+        print()
+
+    # ── Goodbye ───────────────────────────────────────────────────────
+
+    def print_goodbye(self):
+        """Print a styled goodbye message."""
+        print(f"\n  {_ICON_SMALL} {self._c(_GRAY, 'Goodbye!')}\n")
+
+    # ── Prompt toolkit session factory ────────────────────────────────
+
+    def create_prompt_session(self):
+        """Create a prompt_toolkit PromptSession with skin styling.
+
+        Returns:
+            A configured PromptSession, or None if prompt_toolkit unavailable.
+        """
+        try:
+            from prompt_toolkit import PromptSession
+            from prompt_toolkit.history import FileHistory
+            from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+            from prompt_toolkit.formatted_text import FormattedText
+
+            style = self.get_prompt_style()
+
+            session = PromptSession(
+                history=FileHistory(self.history_file),
+                auto_suggest=AutoSuggestFromHistory(),
+                style=style,
+                enable_history_search=True,
+            )
+            return session
+        except ImportError:
+            return None
+
+    def get_input(self, pt_session, project_name: str = "",
+                  modified: bool = False, context: str = "") -> str:
+        """Get input from user using prompt_toolkit or fallback.
+
+        Args:
+            pt_session: A prompt_toolkit PromptSession (or None).
+            project_name: Current project name.
+            modified: Whether project has unsaved changes.
+            context: Optional context string.
+
+        Returns:
+            User input string (stripped).
+        """
+        if pt_session is not None:
+            from prompt_toolkit.formatted_text import FormattedText
+            tokens = self.prompt_tokens(project_name, modified, context)
+            return pt_session.prompt(FormattedText(tokens)).strip()
+        else:
+            raw_prompt = self.prompt(project_name, modified, context)
+            return input(raw_prompt).strip()
+
+    # ── Toolbar builder ───────────────────────────────────────────────
+
+    def bottom_toolbar(self, items: dict[str, str]):
+        """Create a bottom toolbar callback for prompt_toolkit.
+
+        Args:
+            items: Dict of label -> value pairs to show in toolbar.
+
+        Returns:
+            A callable that returns FormattedText for the toolbar.
+        """
+        def toolbar():
+            from prompt_toolkit.formatted_text import FormattedText
+            parts = []
+            for i, (k, v) in enumerate(items.items()):
+                if i > 0:
+                    parts.append(("class:bottom-toolbar.text", "  │  "))
+                parts.append(("class:bottom-toolbar.text", f" {k}: "))
+                parts.append(("class:bottom-toolbar", v))
+            return FormattedText(parts)
+        return toolbar
+
+
+# ── ANSI 256-color to hex mapping (for prompt_toolkit styles) ─────────
+
+_ANSI_256_TO_HEX = {
+    "\033[38;5;33m":  "#0087ff",  # audacity navy blue
+    "\033[38;5;35m":  "#00af5f",  # shotcut teal
+    "\033[38;5;39m":  "#00afff",  # inkscape bright blue
+    "\033[38;5;40m":  "#00d700",  # libreoffice green
+    "\033[38;5;55m":  "#5f00af",  # obs purple
+    "\033[38;5;69m":  "#5f87ff",  # kdenlive slate blue
+    "\033[38;5;75m":  "#5fafff",  # default sky blue
+    "\033[38;5;80m":  "#5fd7d7",  # brand cyan
+    "\033[38;5;208m": "#ff8700",  # blender deep orange
+    "\033[38;5;214m": "#ffaf00",  # gimp warm orange
+}

--- a/codex-skill/assets/cli_anything_plugin/skill_generator.py
+++ b/codex-skill/assets/cli_anything_plugin/skill_generator.py
@@ -1,0 +1,527 @@
+"""
+SKILL.md Generator for CLI-Anything
+
+This module extracts metadata from CLI-Anything harnesses and generates
+SKILL.md files following the skill-creator methodology.
+
+The generated SKILL.md files contain:
+- YAML frontmatter with name and description (triggering metadata)
+- Markdown body with usage instructions
+- Command documentation
+- Examples for AI agents
+"""
+
+import re
+from pathlib import Path
+from typing import Optional
+from dataclasses import dataclass, field
+
+
+def _format_display_name(name: str) -> str:
+    """Format software name for display (replace underscores/hyphens with spaces, then title)."""
+    return name.replace("_", " ").replace("-", " ").title()
+
+
+@dataclass
+class CommandInfo:
+    """Information about a CLI command."""
+    name: str
+    description: str
+
+
+@dataclass
+class CommandGroup:
+    """A group of related CLI commands."""
+    name: str
+    description: str
+    commands: list[CommandInfo] = field(default_factory=list)
+
+
+@dataclass
+class Example:
+    """An example of CLI usage."""
+    title: str
+    description: str
+    code: str
+
+
+@dataclass
+class SkillMetadata:
+    """Metadata extracted from a CLI-Anything harness."""
+    skill_name: str
+    skill_description: str
+    software_name: str
+    skill_intro: str
+    version: str
+    system_package: Optional[str] = None
+    command_groups: list[CommandGroup] = field(default_factory=list)
+    examples: list[Example] = field(default_factory=list)
+
+
+def extract_cli_metadata(harness_path: str) -> SkillMetadata:
+    """
+    Extract metadata from a CLI-Anything harness directory.
+
+    Args:
+        harness_path: Path to the agent-harness directory
+
+    Returns:
+        SkillMetadata containing extracted information
+    """
+    harness_path = Path(harness_path)
+
+    # Find the cli_anything/<software> directory
+    cli_anything_dir = harness_path / "cli_anything"
+    if not cli_anything_dir.exists():
+        raise ValueError(
+            f"cli_anything directory not found in {harness_path}. "
+            "Ensure the harness structure includes cli_anything/<software>/"
+        )
+    software_dirs = [d for d in cli_anything_dir.iterdir()
+                     if d.is_dir() and (d / "__init__.py").exists()]
+
+    if not software_dirs:
+        raise ValueError(f"No CLI package found in {harness_path}")
+
+    software_dir = software_dirs[0]
+    software_name = software_dir.name
+
+    # Extract metadata from README.md
+    readme_path = software_dir / "README.md"
+    skill_intro = ""
+    system_package = None
+
+    if readme_path.exists():
+        readme_content = readme_path.read_text(encoding="utf-8")
+        skill_intro = extract_intro_from_readme(readme_content)
+        system_package = extract_system_package(readme_content)
+
+    # Extract version from setup.py
+    setup_path = harness_path / "setup.py"
+    version = "1.0.0"
+
+    if setup_path.exists():
+        version = extract_version_from_setup(setup_path)
+
+    # Extract commands from CLI file
+    cli_file = software_dir / f"{software_name}_cli.py"
+    command_groups = []
+
+    if cli_file.exists():
+        command_groups = extract_commands_from_cli(cli_file)
+
+    # Generate examples based on software type
+    examples = generate_examples(software_name, command_groups)
+
+    # Build skill name and description
+    skill_name = f"cli-anything-{software_name}"
+    skill_description = f"Command-line interface for {_format_display_name(software_name)} - {skill_intro[:100]}..."
+
+    return SkillMetadata(
+        skill_name=skill_name,
+        skill_description=skill_description,
+        software_name=software_name,
+        skill_intro=skill_intro,
+        version=version,
+        system_package=system_package,
+        command_groups=command_groups,
+        examples=examples
+    )
+
+
+def extract_intro_from_readme(content: str) -> str:
+    """Extract introduction text from README content."""
+    # Find the first paragraph after the title
+    lines = content.split("\n")
+    intro_lines = []
+    in_intro = False
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            if in_intro and intro_lines:
+                break
+            continue
+        if line.startswith("# "):
+            in_intro = True
+            continue
+        if line.startswith("##"):
+            break
+        if in_intro:
+            intro_lines.append(line)
+
+    return " ".join(intro_lines) or f"CLI interface for the software."
+
+
+def extract_system_package(content: str) -> Optional[str]:
+    """Extract system package installation command from README."""
+    # Look for apt/brew install patterns
+    patterns = [
+        r"`apt install ([\w\-]+)`",
+        r"`brew install ([\w\-]+)`",
+        r"apt-get install ([\w\-]+)",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, content)
+        if match:
+            package = match.group(1)
+            if "apt" in pattern:
+                return f"apt install {package}"
+            elif "brew" in pattern:
+                return f"brew install {package}"
+
+    return None
+
+
+def extract_version_from_setup(setup_path: Path) -> str:
+    """Extract version from setup.py."""
+    content = setup_path.read_text(encoding="utf-8")
+    match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
+    if match:
+        return match.group(1)
+    return "1.0.0"
+
+
+def extract_commands_from_cli(cli_path: Path) -> list[CommandGroup]:
+    """Extract command groups and commands from CLI file."""
+    content = cli_path.read_text(encoding="utf-8")
+    groups = []
+
+    # Find Click group decorators
+    # Pattern handles:
+    # - Multi-line decorators (decorators on separate lines)
+    # - Docstrings on the same line or following line after function definition
+    # - Various Click decorator patterns like @click.option(), @click.argument()
+    # Uses re.DOTALL to match across newlines between decorator and def
+    group_pattern = (
+        r'@(\w+)\.group\([^)]*\)'                          # @xxx.group(...)
+        r'(?:\s*@[\w.]+\([^)]*\))*'                         # optional additional decorators
+        r'\s*def\s+(\w+)\([^)]*\)'                          # def xxx(...):
+        r':\s*'                                             # colon with optional whitespace
+        r'(?:"""([\s\S]*?)"""|\'\'\'([\s\S]*?)\'\'\')?'      # optional docstring (""" or ''')
+    )
+
+    for match in re.finditer(group_pattern, content):
+        group_func = match.group(2)
+        # Docstring can be in group 3 (triple-double) or group 4 (triple-single)
+        group_doc = (match.group(3) or match.group(4) or "").strip()
+
+        group_name = group_func.replace("_", " ").title()
+        if not group_name:
+            group_name = group_func.title()
+
+        groups.append(CommandGroup(
+            name=group_name,
+            description=group_doc or f"Commands for {group_name.lower()} operations.",
+            commands=[]
+        ))
+
+    # Find Click command decorators
+    # Pattern handles:
+    # - Multi-line decorators (decorators on separate lines)
+    # - Docstrings on the same line or following line after function definition
+    # - Various Click decorator patterns like @click.option(), @click.argument()
+    command_pattern = (
+        r'@(\w+)\.command\([^)]*\)'                         # @xxx.command(...)
+        r'(?:\s*@[\w.]+\([^)]*\))*'                          # optional additional decorators
+        r'\s*def\s+(\w+)\([^)]*\)'                           # def xxx(...):
+        r':\s*'                                              # colon with optional whitespace
+        r'(?:"""([\s\S]*?)"""|\'\'\'([\s\S]*?)\'\'\')?'       # optional docstring (""" or ''')
+    )
+
+    for match in re.finditer(command_pattern, content):
+        group_name = match.group(1)
+        cmd_name = match.group(2)
+        # Docstring can be in group 3 (triple-double) or group 4 (triple-single)
+        cmd_doc = (match.group(3) or match.group(4) or "").strip()
+
+        # Find the matching group
+        for group in groups:
+            if group.name.lower().replace(" ", "_") == group_name.lower():
+                group.commands.append(CommandInfo(
+                    name=cmd_name.replace("_", "-"),
+                    description=cmd_doc or f"Execute {cmd_name} operation."
+                ))
+
+    # If no groups found, create a default one with all commands
+    if not groups:
+        default_group = CommandGroup(
+            name="General",
+            description="General commands for the CLI.",
+            commands=[]
+        )
+
+        for match in re.finditer(command_pattern, content):
+            cmd_name = match.group(2)
+            # Docstring can be in group 3 (triple-double) or group 4 (triple-single)
+            cmd_doc = (match.group(3) or match.group(4) or "").strip()
+            default_group.commands.append(CommandInfo(
+                name=cmd_name.replace("_", "-"),
+                description=cmd_doc or f"Execute {cmd_name} operation."
+            ))
+
+        if default_group.commands:
+            groups.append(default_group)
+
+    return groups
+
+
+def generate_examples(software_name: str, command_groups: list[CommandGroup]) -> list[Example]:
+    """Generate usage examples based on software type and available commands."""
+    examples = []
+
+    # Basic project creation example
+    examples.append(Example(
+        title="Create a New Project",
+        description=f"Create a new {software_name} project file.",
+        code=f"""cli-anything-{software_name} project new -o myproject.json
+# Or with JSON output for programmatic use
+cli-anything-{software_name} --json project new -o myproject.json"""
+    ))
+
+    # REPL usage example
+    examples.append(Example(
+        title="Interactive REPL Session",
+        description="Start an interactive session with undo/redo support.",
+        code=f"""cli-anything-{software_name}
+# Enter commands interactively
+# Use 'help' to see available commands
+# Use 'undo' and 'redo' for history navigation"""
+    ))
+
+    # Export example if export commands exist
+    for group in command_groups:
+        if "export" in group.name.lower():
+            examples.append(Example(
+                title="Export Project",
+                description="Export the project to a final output format.",
+                code=f"""cli-anything-{software_name} --project myproject.json export render output.pdf --overwrite"""
+            ))
+            break
+
+    return examples
+
+
+def generate_skill_md(metadata: SkillMetadata, template_path: Optional[str] = None) -> str:
+    """
+    Generate SKILL.md content from metadata using Jinja2 template.
+
+    Args:
+        metadata: SkillMetadata containing CLI information
+        template_path: Optional path to custom template file
+
+    Returns:
+        Generated SKILL.md content as string
+    """
+    try:
+        from jinja2 import Environment, FileSystemLoader
+    except ImportError:
+        # Fallback to simple string formatting if Jinja2 not available
+        return generate_skill_md_simple(metadata)
+
+    # Load template
+    if template_path is None:
+        template_path = Path(__file__).parent / "templates" / "SKILL.md.template"
+    else:
+        template_path = Path(template_path)
+
+    if not template_path.exists():
+        return generate_skill_md_simple(metadata)
+
+    env = Environment(loader=FileSystemLoader(template_path.parent))
+    template = env.get_template(template_path.name)
+
+    # Render template
+    return template.render(
+        skill_name=metadata.skill_name,
+        skill_description=metadata.skill_description,
+        software_name=metadata.software_name,
+        skill_intro=metadata.skill_intro,
+        version=metadata.version,
+        system_package=metadata.system_package,
+        command_groups=[{
+            "name": g.name,
+            "description": g.description,
+            "commands": [{"name": c.name, "description": c.description} for c in g.commands]
+        } for g in metadata.command_groups],
+        examples=[{
+            "title": e.title,
+            "description": e.description,
+            "code": e.code
+        } for e in metadata.examples]
+    )
+
+
+def generate_skill_md_simple(metadata: SkillMetadata) -> str:
+    """Generate SKILL.md without Jinja2 dependency."""
+    lines = [
+        "---",
+        f'name: "{metadata.skill_name}"',
+        f'description: "{metadata.skill_description}"',
+        "---",
+        "",
+        f"# {metadata.skill_name}",
+        "",
+        metadata.skill_intro,
+        "",
+        "## Installation",
+        "",
+        f"This CLI is installed as part of the cli-anything-{metadata.software_name} package:",
+        "",
+        f"```bash",
+        f"pip install cli-anything-{metadata.software_name}",
+        f"```",
+        "",
+        "**Prerequisites:**",
+        "- Python 3.10+",
+        f"- {_format_display_name(metadata.software_name)} must be installed on your system",
+    ]
+
+    if metadata.system_package:
+        lines.extend([
+            f"- Install {metadata.software_name}: `{metadata.system_package}`"
+        ])
+
+    lines.extend([
+        "",
+        "## Usage",
+        "",
+        "### Basic Commands",
+        "",
+        "```bash",
+        "# Show help",
+        f"cli-anything-{metadata.software_name} --help",
+        "",
+        "# Start interactive REPL mode",
+        f"cli-anything-{metadata.software_name}",
+        "",
+        "# Create a new project",
+        f"cli-anything-{metadata.software_name} project new -o project.json",
+        "",
+        "# Run with JSON output (for agent consumption)",
+        f"cli-anything-{metadata.software_name} --json project info -p project.json",
+        "```",
+        "",
+    ])
+
+    # Add command groups
+    if metadata.command_groups:
+        lines.append("## Command Groups")
+        lines.append("")
+
+        for group in metadata.command_groups:
+            lines.append(f"### {group.name}")
+            lines.append("")
+            lines.append(group.description)
+            lines.append("")
+
+            if group.commands:
+                lines.append("| Command | Description |")
+                lines.append("|---------|-------------|")
+                for cmd in group.commands:
+                    lines.append(f"| `{cmd.name}` | {cmd.description} |")
+                lines.append("")
+
+    # Add examples
+    if metadata.examples:
+        lines.append("## Examples")
+        lines.append("")
+
+        for example in metadata.examples:
+            lines.append(f"### {example.title}")
+            lines.append("")
+            lines.append(example.description)
+            lines.append("")
+            lines.append("```bash")
+            lines.append(example.code)
+            lines.append("```")
+            lines.append("")
+
+    # Add AI agent guidance
+    lines.extend([
+        "## For AI Agents",
+        "",
+        "When using this CLI programmatically:",
+        "",
+        "1. **Always use `--json` flag** for parseable output",
+        "2. **Check return codes** - 0 for success, non-zero for errors",
+        "3. **Parse stderr** for error messages on failure",
+        "4. **Use absolute paths** for all file operations",
+        "5. **Verify outputs exist** after export operations",
+        "",
+        "## Version",
+        "",
+        metadata.version,
+    ])
+
+    return "\n".join(lines)
+
+
+def generate_skill_file(harness_path: str, output_path: Optional[str] = None,
+                        template_path: Optional[str] = None) -> str:
+    """
+    Generate a SKILL.md file for a CLI-Anything harness.
+
+    Args:
+        harness_path: Path to the agent-harness directory
+        output_path: Optional output path for SKILL.md (default: cli_anything/<software>/skills/SKILL.md)
+        template_path: Optional path to custom Jinja2 template
+
+    Returns:
+        Path to the generated SKILL.md file
+    """
+    # Extract metadata
+    metadata = extract_cli_metadata(harness_path)
+
+    # Generate content
+    content = generate_skill_md(metadata, template_path)
+
+    # Determine output path
+    if output_path is None:
+        # Default to skills/ directory under harness_path
+        harness_path_obj = Path(harness_path)
+        output_path = harness_path_obj / "cli_anything" / metadata.software_name / "skills" / "SKILL.md"
+    else:
+        output_path = Path(output_path)
+
+    # Ensure output directory exists
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write file
+    output_path.write_text(content, encoding="utf-8")
+
+    return str(output_path)
+
+
+# CLI interface for standalone usage
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Generate SKILL.md for CLI-Anything harnesses"
+    )
+    parser.add_argument(
+        "harness_path",
+        help="Path to the agent-harness directory"
+    )
+    parser.add_argument(
+        "-o", "--output",
+        help="Output path for SKILL.md (default: cli_anything/<software>/skills/SKILL.md)",
+        default=None
+    )
+    parser.add_argument(
+        "-t", "--template",
+        help="Path to custom Jinja2 template",
+        default=None
+    )
+
+    args = parser.parse_args()
+
+    output_file = generate_skill_file(
+        args.harness_path,
+        args.output,
+        args.template
+    )
+
+    print(f"Generated: {output_file}")

--- a/codex-skill/assets/cli_anything_plugin/templates/SKILL.md.template
+++ b/codex-skill/assets/cli_anything_plugin/templates/SKILL.md.template
@@ -1,0 +1,123 @@
+---
+name: >-
+  {{ skill_name }}
+description: >-
+  {{ skill_description }}
+---
+
+# {{ skill_name }}
+
+{{ skill_intro }}
+
+## Installation
+
+This CLI is installed as part of the cli-anything-{{ software_name }} package:
+
+```bash
+pip install cli-anything-{{ software_name }}
+```
+
+**Prerequisites:**
+- Python 3.10+
+- {{ software_name }} must be installed on your system
+{% if system_package %}
+- Install {{ software_name }}: `{{ system_package }}`
+{% endif %}
+
+## Usage
+
+### Basic Commands
+
+```bash
+# Show help
+cli-anything-{{ software_name }} --help
+
+# Start interactive REPL mode
+cli-anything-{{ software_name }}
+
+# Create a new project
+cli-anything-{{ software_name }} project new -o project.json
+
+# Run with JSON output (for agent consumption)
+cli-anything-{{ software_name }} --json project info -p project.json
+```
+
+### REPL Mode
+
+When invoked without a subcommand, the CLI enters an interactive REPL session:
+
+```bash
+cli-anything-{{ software_name }}
+# Enter commands interactively with tab-completion and history
+```
+
+{% if command_groups %}
+## Command Groups
+
+{% for group in command_groups %}
+### {{ group.name }}
+
+{{ group.description }}
+
+| Command | Description |
+|---------|-------------|
+{% for cmd in group.commands %}
+| `{{ cmd.name }}` | {{ cmd.description }} |
+{% endfor %}
+
+{% endfor %}
+{% endif %}
+## Examples
+
+{% for example in examples %}
+### {{ example.title }}
+
+{{ example.description }}
+
+```bash
+{{ example.code }}
+```
+
+{% endfor %}
+## State Management
+
+The CLI maintains session state with:
+
+- **Undo/Redo**: Up to 50 levels of history
+- **Project persistence**: Save/load project state as JSON
+- **Session tracking**: Track modifications and changes
+
+## Output Formats
+
+All commands support dual output modes:
+
+- **Human-readable** (default): Tables, colors, formatted text
+- **Machine-readable** (`--json` flag): Structured JSON for agent consumption
+
+```bash
+# Human output
+cli-anything-{{ software_name }} project info -p project.json
+
+# JSON output for agents
+cli-anything-{{ software_name }} --json project info -p project.json
+```
+
+## For AI Agents
+
+When using this CLI programmatically:
+
+1. **Always use `--json` flag** for parseable output
+2. **Check return codes** - 0 for success, non-zero for errors
+3. **Parse stderr** for error messages on failure
+4. **Use absolute paths** for all file operations
+5. **Verify outputs exist** after export operations
+
+## More Information
+
+- Full documentation: See README.md in the package
+- Test coverage: See TEST.md in the package
+- Methodology: See HARNESS.md in the cli-anything-plugin
+
+## Version
+
+{{ version }}

--- a/codex-skill/references/HARNESS.md
+++ b/codex-skill/references/HARNESS.md
@@ -1,0 +1,821 @@
+# Agent Harness: GUI-to-CLI for Open Source Software
+
+## Purpose
+
+This harness provides a standard operating procedure (SOP) and toolkit for coding
+agents (Claude Code, Codex, etc.) to build powerful, stateful CLI interfaces for
+open-source GUI applications. The goal: let AI agents operate software that was
+designed for humans, without needing a display or mouse.
+
+## General SOP: Turning Any GUI App into an Agent-Usable CLI
+
+### Phase 1: Codebase Analysis
+
+1. **Identify the backend engine** — Most GUI apps separate presentation from logic.
+   Find the core library/framework (e.g., MLT for Shotcut, ImageMagick for GIMP).
+2. **Map GUI actions to API calls** — Every button click, drag, and menu item
+   corresponds to a function call. Catalog these mappings.
+3. **Identify the data model** — What file formats does it use? How is project state
+   represented? (XML, JSON, binary, database?)
+4. **Find existing CLI tools** — Many backends ship their own CLI (`melt`, `ffmpeg`,
+   `convert`). These are building blocks.
+5. **Catalog the command/undo system** — If the app has undo/redo, it likely uses a
+   command pattern. These commands are your CLI operations.
+
+### Phase 2: CLI Architecture Design
+
+1. **Choose the interaction model**:
+   - **Stateful REPL** for interactive sessions (agents that maintain context)
+   - **Subcommand CLI** for one-shot operations (scripting, pipelines)
+   - **Both** (recommended) — a CLI that works in both modes
+
+2. **Define command groups** matching the app's logical domains:
+   - Project management (new, open, save, close)
+   - Core operations (the app's primary purpose)
+   - Import/Export (file I/O, format conversion)
+   - Configuration (settings, preferences, profiles)
+   - Session/State management (undo, redo, history, status)
+
+3. **Design the state model**:
+   - What must persist between commands? (open project, cursor position, selection)
+   - Where is state stored? (in-memory for REPL, file-based for CLI)
+   - How does state serialize? (JSON session files)
+
+4. **Plan the output format**:
+   - Human-readable (tables, colors) for interactive use
+   - Machine-readable (JSON) for agent consumption
+   - Both, controlled by `--json` flag
+
+### Phase 3: Implementation
+
+1. **Start with the data layer** — XML/JSON manipulation of project files
+2. **Add probe/info commands** — Let agents inspect before they modify
+3. **Add mutation commands** — One command per logical operation
+4. **Add the backend integration** — A `utils/<software>_backend.py` module that
+   wraps the real software's CLI. This module handles:
+   - Finding the software executable (`shutil.which()`)
+   - Invoking it with proper arguments (`subprocess.run()`)
+   - Error handling with clear install instructions if not found
+   - Example (LibreOffice):
+     ```python
+     # utils/lo_backend.py
+     def convert_odf_to(odf_path, output_format, output_path=None, overwrite=False):
+         lo = find_libreoffice()  # raises RuntimeError with install instructions
+         subprocess.run([lo, "--headless", "--convert-to", output_format, ...])
+         return {"output": final_path, "format": output_format, "method": "libreoffice-headless"}
+     ```
+5. **Add rendering/export** — The export pipeline calls the backend module.
+   Generate valid intermediate files, then invoke the real software for conversion.
+6. **Add session management** — State persistence, undo/redo
+
+   **Session file locking** — When saving session JSON, use exclusive file locking
+   to prevent concurrent writes from corrupting data. Never use bare
+   `open("w") + json.dump()` — `open("w")` truncates the file before any lock
+   can be acquired. Instead, open with `"r+"`, lock, then truncate inside the lock:
+   ```python
+   def _locked_save_json(path, data, **dump_kwargs) -> None:
+       """Atomically write JSON with exclusive file locking."""
+       try:
+           f = open(path, "r+")            # no truncation on open
+       except FileNotFoundError:
+           os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+           f = open(path, "w")             # first save — file doesn't exist yet
+       with f:
+           _locked = False
+           try:
+               import fcntl
+               fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+               _locked = True
+           except (ImportError, OSError):
+               pass                        # Windows / unsupported FS — proceed unlocked
+           try:
+               f.seek(0)
+               f.truncate()                # truncate INSIDE the lock
+               json.dump(data, f, **dump_kwargs)
+               f.flush()
+           finally:
+               if _locked:
+                   fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+   ```
+7. **Add the REPL with unified skin** — Interactive mode wrapping the subcommands.
+   - Copy `repl_skin.py` from the plugin (`cli-anything-plugin/repl_skin.py`) into
+     `utils/repl_skin.py` in your CLI package
+   - Import and use `ReplSkin` for the REPL interface:
+     ```python
+     from cli_anything.<software>.utils.repl_skin import ReplSkin
+
+     skin = ReplSkin("<software>", version="1.0.0")
+     skin.print_banner()          # Branded startup box (auto-detects skills/SKILL.md)
+     pt_session = skin.create_prompt_session()  # prompt_toolkit with history + styling
+     line = skin.get_input(pt_session, project_name="my_project", modified=True)
+     skin.help(commands_dict)     # Formatted help listing
+     skin.success("Saved")        # ✓ green message
+     skin.error("Not found")      # ✗ red message
+     skin.warning("Unsaved")      # ⚠ yellow message
+     skin.info("Processing...")   # ● blue message
+     skin.status("Key", "value")  # Key-value status line
+     skin.table(headers, rows)    # Formatted table
+     skin.progress(3, 10, "...")  # Progress bar
+     skin.print_goodbye()         # Styled exit message
+     ```
+   - ReplSkin auto-detects `skills/SKILL.md` inside the package directory and displays
+     it in the banner. AI agents can read the skill file at the displayed absolute path.
+   - Make REPL the default behavior: use `invoke_without_command=True` on the main
+     Click group, and invoke the `repl` command when no subcommand is given:
+     ```python
+     @click.group(invoke_without_command=True)
+     @click.pass_context
+     def cli(ctx, ...):
+         ...
+         if ctx.invoked_subcommand is None:
+             ctx.invoke(repl, project_path=None)
+     ```
+   - This ensures `cli-anything-<software>` with no arguments enters the REPL
+
+### Phase 4: Test Planning (TEST.md - Part 1)
+
+**BEFORE writing any test code**, create a `TEST.md` file in the
+`agent-harness/cli_anything/<software>/tests/` directory. This file serves as your test plan and
+MUST contain:
+
+1. **Test Inventory Plan** — List planned test files and estimated test counts:
+   - `test_core.py`: XX unit tests planned
+   - `test_full_e2e.py`: XX E2E tests planned
+
+2. **Unit Test Plan** — For each core module, describe what will be tested:
+   - Module name (e.g., `project.py`)
+   - Functions to test
+   - Edge cases to cover (invalid inputs, boundary conditions, error handling)
+   - Expected test count
+
+3. **E2E Test Plan** — Describe the real-world scenarios to test:
+   - What workflows will be simulated?
+   - What real files will be generated/processed?
+   - What output properties will be verified?
+   - What format validations will be performed?
+
+4. **Realistic Workflow Scenarios** — Detail each multi-step workflow:
+   - **Workflow name**: Brief title
+   - **Simulates**: What real-world task (e.g., "photo editing pipeline",
+     "podcast production", "product render setup")
+   - **Operations chained**: Step-by-step operations
+   - **Verified**: What output properties will be checked
+
+This planning document ensures comprehensive test coverage before writing code.
+
+### Phase 5: Test Implementation
+
+Now write the actual test code based on the TEST.md plan:
+
+1. **Unit tests** (`test_core.py`) — Every core function tested in isolation with
+   synthetic data. No external dependencies.
+2. **E2E tests — intermediate files** (`test_full_e2e.py`) — Verify the project files
+   your CLI generates are structurally correct (valid XML, correct ZIP structure, etc.)
+3. **E2E tests — true backend** (`test_full_e2e.py`) — **MUST invoke the real software.**
+   Create a project, export via the actual software backend, and verify the output:
+   - File exists and size > 0
+   - Correct format (PDF magic bytes `%PDF-`, DOCX/XLSX/PPTX is valid ZIP/OOXML, etc.)
+   - Content verification where possible (CSV contains expected data, etc.)
+   - **Print artifact paths** so users can manually inspect: `print(f"\n  PDF: {path} ({size:,} bytes)")`
+   - **No graceful degradation** — if the software isn't installed, tests fail, not skip
+4. **Output verification** — **Don't trust that export works just because it exits
+   successfully.** Verify outputs programmatically:
+   - Magic bytes / file format validation
+   - ZIP structure for OOXML formats (DOCX, XLSX, PPTX)
+   - Pixel-level analysis for video/images (probe frames, compare brightness)
+   - Audio analysis (RMS levels, spectral comparison)
+   - Duration/format checks against expected values
+5. **CLI subprocess tests** — Test the installed CLI command as a real user/agent would.
+   The subprocess tests MUST also produce real final output (not just ODF intermediate).
+   Use the `_resolve_cli` helper to run the installed `cli-anything-<software>` command:
+   ```python
+   def _resolve_cli(name):
+       """Resolve installed CLI command; falls back to python -m for dev.
+
+       Set env CLI_ANYTHING_FORCE_INSTALLED=1 to require the installed command.
+       """
+       import shutil
+       force = os.environ.get("CLI_ANYTHING_FORCE_INSTALLED", "").strip() == "1"
+       path = shutil.which(name)
+       if path:
+           print(f"[_resolve_cli] Using installed command: {path}")
+           return [path]
+       if force:
+           raise RuntimeError(f"{name} not found in PATH. Install with: pip install -e .")
+       module = name.replace("cli-anything-", "cli_anything.") + "." + name.split("-")[-1] + "_cli"
+       print(f"[_resolve_cli] Falling back to: {sys.executable} -m {module}")
+       return [sys.executable, "-m", module]
+
+
+   class TestCLISubprocess:
+       CLI_BASE = _resolve_cli("cli-anything-<software>")
+
+       def _run(self, args, check=True):
+           return subprocess.run(
+               self.CLI_BASE + args,
+               capture_output=True, text=True,
+               check=check,
+           )
+
+       def test_help(self):
+           result = self._run(["--help"])
+           assert result.returncode == 0
+
+       def test_project_new_json(self, tmp_dir):
+           out = os.path.join(tmp_dir, "test.json")
+           result = self._run(["--json", "project", "new", "-o", out])
+           assert result.returncode == 0
+           data = json.loads(result.stdout)
+           # ... verify structure
+   ```
+
+   **Key rules for subprocess tests:**
+   - Always use `_resolve_cli("cli-anything-<software>")` — never hardcode
+     `sys.executable` or module paths directly
+   - Do NOT set `cwd` — installed commands must work from any directory
+   - Use `CLI_ANYTHING_FORCE_INSTALLED=1` in CI/release testing to ensure the
+     installed command (not a fallback) is being tested
+   - Test `--help`, `--json`, project creation, key commands, and full workflows
+
+6. **Round-trip test** — Create project via CLI, open in GUI, verify correctness
+7. **Agent test** — Have an AI agent complete a real task using only the CLI
+
+### Phase 6: Test Documentation (TEST.md - Part 2)
+
+After running all tests successfully, **append** to the existing TEST.md:
+
+1. **Test Results** — Paste the full `pytest -v --tb=no` output showing all tests
+   passing with their names and status
+2. **Summary Statistics** — Total tests, pass rate, execution time
+3. **Coverage Notes** — Any gaps or areas not covered by tests
+
+The TEST.md now serves as both the test plan (written before implementation) and
+the test results documentation (appended after execution), providing a complete
+record of the testing process.
+
+### Phase 6.5: SKILL.md Generation
+
+Generate a SKILL.md file that makes the CLI discoverable and usable by AI agents
+through the skill-creator methodology. This file serves as a self-contained skill
+definition that can be loaded by Claude Code or other AI assistants.
+
+**Purpose:** SKILL.md files follow a standard format that enables AI agents to:
+- Discover the CLI's capabilities
+- Understand command structure and usage
+- Generate correct command invocations
+- Handle output programmatically
+
+**SKILL.md Structure:**
+
+1. **YAML Frontmatter** — Triggering metadata for skill discovery:
+   ```yaml
+   ---
+   name: "cli-anything-<software>"
+   description: "Brief description of what the CLI does"
+   ---
+   ```
+
+2. **Markdown Body** — Usage instructions including:
+   - Installation prerequisites
+   - Basic command syntax
+   - Command groups and their functions
+   - Usage examples
+   - Agent-specific guidance (JSON output, error handling)
+
+**Generation Process:**
+
+1. **Extract CLI metadata** using `skill_generator.py`:
+   ```python
+   from skill_generator import generate_skill_file
+
+   skill_path = generate_skill_file(
+       harness_path="/path/to/agent-harness"
+   )
+   # Default output: cli_anything/<software>/skills/SKILL.md
+   ```
+
+2. **The generator automatically extracts:**
+   - Software name and version from setup.py
+   - Command groups from the CLI file (Click decorators)
+   - Documentation from README.md
+   - System package requirements
+
+3. **Customize the template** (optional):
+   - Default template: `templates/SKILL.md.template`
+   - Uses Jinja2 placeholders for dynamic content
+   - Can be extended for software-specific sections
+
+**Output Location:**
+
+SKILL.md is generated inside the Python package so it is installed with `pip install`:
+```
+<software>/
+└── agent-harness/
+    └── cli_anything/
+        └── <software>/
+            └── skills/
+                └── SKILL.md
+```
+
+**Manual Generation:**
+
+```bash
+cd cli-anything-plugin
+python skill_generator.py /path/to/software/agent-harness
+```
+
+**Integration with CLI Build:**
+
+The SKILL.md generation should be run after Phase 6 (Test Documentation) completes
+successfully, ensuring the CLI is fully documented and tested before creating the
+skill definition.
+
+**Key Principles:**
+
+- SKILL.md must be self-contained (no external dependencies for understanding)
+- Include agent-specific guidance for programmatic usage
+- Document `--json` flag usage for machine-readable output
+- List all command groups with brief descriptions
+- Provide realistic examples that demonstrate common workflows
+
+**Skill Path in CLI Banner:**
+
+ReplSkin auto-detects `skills/SKILL.md` inside the package and displays the absolute
+path in the startup banner. AI agents can read the file at the displayed path:
+
+```python
+# In the REPL initialization (e.g., shotcut_cli.py)
+from cli_anything.<software>.utils.repl_skin import ReplSkin
+
+skin = ReplSkin("<software>", version="1.0.0")
+skin.print_banner()  # Auto-detects and displays: ◇ Skill: /path/to/cli_anything/<software>/skills/SKILL.md
+```
+
+**Package Data:**
+
+Ensure `setup.py` includes the skill file as package data so it is installed with pip:
+
+```python
+package_data={
+    "cli_anything.<software>": ["skills/*.md"],
+},
+```
+
+## Critical Lessons Learned
+
+### Use the Real Software — Don't Reimplement It
+
+**This is the #1 rule.** The CLI MUST call the actual software for rendering and
+export — not reimplement the software's functionality in Python.
+
+**The anti-pattern:** Building a Pillow-based image compositor to replace GIMP,
+or generating bpy scripts without ever calling Blender. This produces a toy that
+can't handle real workloads and diverges from the actual software's behavior.
+
+**The correct approach:**
+1. **Use the software's CLI/scripting interface** as the backend:
+   - LibreOffice: `libreoffice --headless --convert-to pdf/docx/xlsx/pptx`
+   - Blender: `blender --background --python script.py`
+   - GIMP: `gimp -i -b '(script-fu-console-eval ...)'`
+   - Inkscape: `inkscape --actions="..." --export-filename=...`
+   - Shotcut/Kdenlive: `melt project.mlt -consumer avformat:output.mp4`
+   - Audacity: `sox` for effects processing
+   - OBS: `obs-websocket` protocol
+
+2. **The software is a required dependency**, not optional. Add it to installation
+   instructions. The CLI is useless without the actual software.
+
+3. **Generate valid project/intermediate files** (ODF, MLT XML, .blend, SVG, etc.)
+   then hand them to the real software for rendering. Your CLI is a structured
+   command-line interface to the software, not a replacement for it.
+
+**Example — LibreOffice CLI export pipeline:**
+```python
+# 1. Build the document as a valid ODF file (our XML builder)
+odf_path = write_odf(tmp_path, doc_type, project)
+
+# 2. Convert via the REAL LibreOffice (not a reimplementation)
+subprocess.run([
+    "libreoffice", "--headless",
+    "--convert-to", "pdf",
+    "--outdir", output_dir,
+    odf_path,
+])
+# Result: a real PDF rendered by LibreOffice's full engine
+```
+
+### The Rendering Gap
+
+**This is the #2 pitfall.** Most GUI apps apply effects at render time via their
+engine. When you build a CLI that manipulates project files directly, you must also
+handle rendering — and naive approaches will silently drop effects.
+
+**The problem:** Your CLI adds filters/effects to the project file format. But when
+rendering, if you use a simple tool (e.g., ffmpeg concat demuxer), it reads raw
+media files and **ignores** all project-level effects. The output looks identical to
+the input. Users can't tell anything happened.
+
+**The solution — a filter translation layer:**
+1. **Best case:** Use the app's native renderer (`melt` for MLT projects). It reads
+   the project file and applies everything.
+2. **Fallback:** Build a translation layer that converts project-format effects into
+   the rendering tool's native syntax (e.g., MLT filters → ffmpeg `-filter_complex`).
+3. **Last resort:** Generate a render script the user can run manually.
+
+**Priority order for rendering:** native engine → translated filtergraph → script.
+
+### MCP Backend Pattern
+
+For services that expose an MCP (Model Context Protocol) server:
+
+**Use case:** When the software provides an MCP server instead of a traditional CLI.
+Example: DOMShell provides browser automation via MCP tools.
+
+**When to use:**
+- The software has an official or community MCP server
+- No native CLI exists, or MCP provides better functionality
+- You want to integrate AI/agent tools that speak MCP protocol
+
+**Backend wrapper** (`utils/<service>_backend.py`):
+```python
+import asyncio
+from typing import Any
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+async def _call_tool(tool_name: str, arguments: dict) -> Any:
+    """Call an MCP tool."""
+    server_params = StdioServerParameters(
+        command="npx",
+        args=["@apireno/domshell"]
+    )
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(tool_name, arguments)
+            return result
+
+def is_available() -> bool:
+    """Check if MCP server is available."""
+    # Try to spawn and verify
+    ...
+
+# Sync wrappers for each tool
+def ls(path: str = "/") -> dict:
+    """List directory contents."""
+    return asyncio.run(_call_tool("domshell_ls", {"path": path}))
+```
+
+**Session management:**
+- MCP server spawns per command (stateless from server perspective)
+- CLI maintains state (URL, working directory, navigation history)
+- Each command re-spawns the MCP server process
+
+**Daemon mode (optional):**
+- Spawn MCP server once, reuse connection for multiple commands
+- Reduces latency for interactive use
+- Requires explicit start/stop or `--daemon` flag
+
+**Dependencies:** Add `mcp>=0.1.0` to install_requires
+
+**Example implementations:**
+- `browser/agent-harness` — DOMShell MCP server for browser automation
+- See: https://github.com/HKUDS/CLI-Anything/tree/main/browser/agent-harness
+
+### Filter Translation Pitfalls
+
+When translating effects between formats (e.g., MLT → ffmpeg), watch for:
+
+- **Duplicate filter types:** Some tools (ffmpeg) don't allow the same filter twice
+  in a chain. If your project has both `brightness` and `saturation` filters, and
+  both map to ffmpeg's `eq=`, you must **merge** them into a single `eq=brightness=X:saturation=Y`.
+- **Ordering constraints:** ffmpeg's `concat` filter requires **interleaved** stream
+  ordering: `[v0][a0][v1][a1][v2][a2]`, NOT grouped `[v0][v1][v2][a0][a1][a2]`.
+  The error message ("media type mismatch") is cryptic if you don't know this.
+- **Parameter space differences:** Effect parameters often use different scales.
+  MLT brightness `1.15` = +15%, but ffmpeg `eq=brightness=0.06` on a -1..1 scale.
+  Document every mapping explicitly.
+- **Unmappable effects:** Some effects have no equivalent in the render tool. Handle
+  gracefully (warn, skip) rather than crash.
+
+### Timecode Precision
+
+Non-integer frame rates (29.97fps = 30000/1001) cause cumulative rounding errors:
+
+- **Use `round()`, not `int()`** for float-to-frame conversion. `int(9000 * 29.97)`
+  truncates and loses frames; `round()` gets the right answer.
+- **Use integer arithmetic for timecode display.** Convert frames → total milliseconds
+  via `round(frames * fps_den * 1000 / fps_num)`, then decompose with integer
+  division. Avoid intermediate floats that drift over long durations.
+- **Accept ±1 frame tolerance** in roundtrip tests at non-integer FPS. Exact equality
+  is mathematically impossible.
+
+### Output Verification Methodology
+
+Never assume an export is correct just because it ran without errors. Verify:
+
+```python
+# Video: probe specific frames with ffmpeg
+# Frame 0 for fade-in (should be near-black)
+# Middle frames for color effects (compare brightness/saturation vs source)
+# Last frame for fade-out (should be near-black)
+
+# When comparing pixel values between different resolutions,
+# exclude letterboxing/pillarboxing (black padding bars).
+# A vertical video in a horizontal frame will have ~40% black pixels.
+
+# Audio: check RMS levels at start/end for fades
+# Compare spectral characteristics against source
+```
+
+### Testing Strategy
+
+Four test layers with complementary purposes:
+
+1. **Unit tests** (`test_core.py`): Synthetic data, no external dependencies. Tests
+   every function in isolation. Fast, deterministic, good for CI.
+2. **E2E tests — native** (`test_full_e2e.py`): Tests the project file generation
+   pipeline (ODF structure, XML content, format validation). Verifies the
+   intermediate files your CLI produces are correct.
+3. **E2E tests — true backend** (`test_full_e2e.py`): Invokes the **real software**
+   (LibreOffice, Blender, melt, etc.) to produce final output files (PDF, DOCX,
+   rendered images, videos). Verifies the output files:
+   - Exist and have size > 0
+   - Have correct format (magic bytes, ZIP structure, etc.)
+   - Contain expected content where verifiable
+   - **Print artifact paths** so users can manually inspect results
+4. **CLI subprocess tests** (in `test_full_e2e.py`): Invokes the installed
+   `cli-anything-<software>` command via `subprocess.run` to run the full workflow
+   end-to-end: create project → add content → export via real software → verify output.
+
+**No graceful degradation.** The real software MUST be installed. Tests must NOT
+skip or fake results when the software is missing — the CLI is useless without it.
+The software is a hard dependency, not optional.
+
+**Example — true E2E test for LibreOffice:**
+```python
+class TestWriterToPDF:
+    def test_rich_writer_to_pdf(self, tmp_dir):
+        proj = create_document(doc_type="writer", name="Report")
+        add_heading(proj, text="Quarterly Report", level=1)
+        add_table(proj, rows=3, cols=3, data=[...])
+
+        pdf_path = os.path.join(tmp_dir, "report.pdf")
+        result = export(proj, pdf_path, preset="pdf", overwrite=True)
+
+        # Verify the REAL output file
+        assert os.path.exists(result["output"])
+        assert result["file_size"] > 1000  # Not suspiciously small
+        with open(result["output"], "rb") as f:
+            assert f.read(5) == b"%PDF-"  # Validate format magic bytes
+        print(f"\n  PDF: {result['output']} ({result['file_size']:,} bytes)")
+
+
+class TestCLISubprocessE2E:
+    CLI_BASE = _resolve_cli("cli-anything-libreoffice")
+
+    def test_full_writer_pdf_workflow(self, tmp_dir):
+        proj_path = os.path.join(tmp_dir, "test.json")
+        pdf_path = os.path.join(tmp_dir, "output.pdf")
+        self._run(["document", "new", "-o", proj_path, "--type", "writer"])
+        self._run(["--project", proj_path, "writer", "add-heading", "-t", "Title"])
+        self._run(["--project", proj_path, "export", "render", pdf_path, "-p", "pdf", "--overwrite"])
+        assert os.path.exists(pdf_path)
+        with open(pdf_path, "rb") as f:
+            assert f.read(5) == b"%PDF-"
+```
+
+   Run tests in force-installed mode to guarantee the real command is used:
+   ```bash
+   CLI_ANYTHING_FORCE_INSTALLED=1 python3 -m pytest cli_anything/<software>/tests/ -v -s
+   ```
+   The `-s` flag shows the `[_resolve_cli]` print output confirming which backend
+   is being used and **prints artifact paths** for manual inspection.
+
+Real-world workflow test scenarios should include:
+- Multi-segment editing (YouTube-style cut/trim)
+- Montage assembly (many short clips)
+- Picture-in-picture compositing
+- Color grading pipelines
+- Audio mixing (podcast-style)
+- Heavy undo/redo stress testing
+- Save/load round-trips of complex projects
+- Iterative refinement (add, modify, remove, re-add)
+
+## Key Principles
+
+- **Use the real software** — The CLI MUST invoke the actual application for rendering
+  and export. Generate valid intermediate files (ODF, MLT XML, .blend, SVG), then hand
+  them to the real software. Never reimplement the rendering engine in Python.
+- **The software is a hard dependency** — Not optional, not gracefully degraded. If
+  LibreOffice isn't installed, `cli-anything-libreoffice` must error clearly, not
+  silently produce inferior output with a fallback library.
+- **Manipulate the native format directly** — Parse and modify the app's native project
+  files (MLT XML, ODF, SVG, etc.) as the data layer.
+- **Leverage existing CLI tools** — Use `libreoffice --headless`, `blender --background`,
+  `melt`, `ffmpeg`, `inkscape --actions`, `sox` as subprocesses for rendering.
+- **Verify rendering produces correct output** — See "The Rendering Gap" above.
+- **E2E tests must produce real artifacts** — PDF, DOCX, rendered images, videos.
+  Print output paths so users can inspect. Never test only the intermediate format.
+- **Fail loudly and clearly** — Agents need unambiguous error messages to self-correct.
+- **Be idempotent where possible** — Running the same command twice should be safe.
+- **Provide introspection** — `info`, `list`, `status` commands are critical for agents
+  to understand current state before acting.
+- **JSON output mode** — Every command should support `--json` for machine parsing.
+
+## Rules
+
+- **The real software MUST be a hard dependency.** The CLI must invoke the actual
+  software (LibreOffice, Blender, GIMP, etc.) for rendering and export. Do NOT
+  reimplement rendering in Python. Do NOT gracefully degrade to a fallback library.
+  If the software is not installed, the CLI must error with clear install instructions.
+- **Every `cli_anything/<software>/` directory MUST contain a `README.md`** that explains how to
+  install the software dependency, install the CLI, run tests, and shows basic usage.
+- **E2E tests MUST invoke the real software** and produce real output files (PDF, DOCX,
+  rendered images, videos). Tests must verify output exists, has correct format, and
+  print artifact paths so users can inspect results. Never test only intermediate files.
+- **Every export/render function MUST be verified** with programmatic output analysis
+  before being marked as working. "It ran without errors" is not sufficient.
+- **Every filter/effect in the registry MUST have a corresponding render mapping**
+  or be explicitly documented as "project-only (not rendered)".
+- **Test suites MUST include real-file E2E tests**, not just unit tests with synthetic
+  data. Format assumptions break constantly with real media.
+- **E2E tests MUST include subprocess tests** that invoke the installed
+  `cli-anything-<software>` command via `_resolve_cli()`. Tests must work against
+  the actual installed package, not just source imports.
+- **Every `cli_anything/<software>/tests/` directory MUST contain a `TEST.md`** documenting what the tests
+  cover, what realistic workflows are tested, and the full test results output.
+- **Every CLI MUST use the unified REPL skin** (`repl_skin.py`) for the interactive mode.
+  Copy `cli-anything-plugin/repl_skin.py` to `utils/repl_skin.py` and use `ReplSkin`
+  for the banner, prompt, help, messages, and goodbye. REPL MUST be the default behavior
+  when the CLI is invoked without a subcommand (`invoke_without_command=True`).
+
+## Directory Structure
+
+```
+<software>/
+└── agent-harness/
+    ├── <SOFTWARE>.md          # Project-specific analysis and SOP
+    ├── setup.py               # PyPI package configuration (Phase 7)
+    ├── cli_anything/          # Namespace package (NO __init__.py here)
+    │   └── <software>/        # Sub-package for this CLI
+    │       ├── __init__.py
+    │       ├── __main__.py    # python3 -m cli_anything.<software>
+    │       ├── README.md      # HOW TO RUN — required
+    │       ├── <software>_cli.py  # Main CLI entry point (Click + REPL)
+    │       ├── core/          # Core modules (one per domain)
+    │       │   ├── __init__.py
+    │       │   ├── project.py     # Project create/open/save/info
+    │       │   ├── ...            # Domain-specific modules
+    │       │   ├── export.py      # Render pipeline + filter translation
+    │       │   └── session.py     # Stateful session, undo/redo
+    │       ├── utils/         # Shared utilities
+    │       │   ├── __init__.py
+    │       │   ├── <software>_backend.py  # Backend: invokes the real software
+    │       │   └── repl_skin.py  # Unified REPL skin (copy from plugin)
+    │       └── tests/         # Test suites
+    │           ├── TEST.md        # Test documentation and results — required
+    │           ├── test_core.py   # Unit tests (synthetic data)
+    │           └── test_full_e2e.py # E2E tests (real files)
+    └── examples/              # Example scripts and workflows
+```
+
+**Critical:** The `cli_anything/` directory must NOT contain an `__init__.py`.
+This is what makes it a PEP 420 namespace package — multiple separately-installed
+PyPI packages can each contribute a sub-package under `cli_anything/` without
+conflicting. For example, `cli-anything-gimp` adds `cli_anything/gimp/` and
+`cli-anything-blender` adds `cli_anything/blender/`, and both coexist in the
+same Python environment.
+
+Note: This HARNESS.md is part of the cli-anything-plugin. Individual software directories reference this file — do NOT duplicate it.
+
+## Applying This to Other Software
+
+This same SOP applies to any GUI application:
+
+| Software | Backend CLI | Native Format | System Package | How the CLI Uses It |
+|----------|-------------|---------------|----------------|-------------------|
+| LibreOffice | `libreoffice --headless` | .odt/.ods/.odp (ODF ZIP) | `apt install libreoffice` | Generate ODF → convert to PDF/DOCX/XLSX/PPTX |
+| Blender | `blender --background --python` | .blend-cli.json | `apt install blender` | Generate bpy script → Blender renders to PNG/MP4 |
+| GIMP | `gimp -i -b '(script-fu ...)'` | .xcf | `apt install gimp` | Script-Fu commands → GIMP processes & exports |
+| Inkscape | `inkscape --actions="..."` | .svg (XML) | `apt install inkscape` | Manipulate SVG → Inkscape exports to PNG/PDF |
+| Shotcut/Kdenlive | `melt` or `ffmpeg` | .mlt (XML) | `apt install melt ffmpeg` | Build MLT XML → melt/ffmpeg renders video |
+| Audacity | `sox` | .aup3 | `apt install sox` | Generate sox commands → sox processes audio |
+| OBS Studio | `obs-websocket` | scene.json | `apt install obs-studio` | WebSocket API → OBS captures/records |
+| Browser (DOMShell) | `npx @apireno/domshell` (MCP) | Accessibility Tree (virtual FS) | `npm install -g npx` (if needed) + Chrome ext | MCP SDK → DOMShell tools → filesystem navigation |
+
+**The software is a required dependency, not optional.** The CLI generates valid
+intermediate files (ODF, MLT XML, bpy scripts, SVG) and hands them to the real
+software for rendering. This is what makes the CLI actually useful — it's a
+command-line interface TO the software, not a replacement for it.
+
+The pattern is always the same: **build the data → call the real software → verify
+the output**.
+
+### Phase 7: PyPI Publishing and Installation
+
+After building and testing the CLI, make it installable and discoverable.
+
+All cli-anything CLIs use **PEP 420 namespace packages** under the shared
+`cli_anything` namespace. This allows multiple CLI packages to be installed
+side-by-side in the same Python environment without conflicts.
+
+1. **Structure the package** as a namespace package:
+   ```
+   agent-harness/
+   ├── setup.py
+   └── cli_anything/           # NO __init__.py here (namespace package)
+       └── <software>/         # e.g., gimp, blender, audacity
+           ├── __init__.py     # HAS __init__.py (regular sub-package)
+           ├── <software>_cli.py
+           ├── core/
+           ├── utils/
+           └── tests/
+   ```
+
+   The key rule: `cli_anything/` has **no** `__init__.py`. Each sub-package
+   (`gimp/`, `blender/`, etc.) **does** have `__init__.py`. This is what
+   enables multiple packages to contribute to the same namespace.
+
+2. **Create setup.py** in the `agent-harness/` directory:
+   ```python
+   from setuptools import setup, find_namespace_packages
+
+   setup(
+       name="cli-anything-<software>",
+       version="1.0.0",
+       packages=find_namespace_packages(include=["cli_anything.*"]),
+       install_requires=[
+           "click>=8.0.0",
+           "prompt-toolkit>=3.0.0",
+           # Add Python library dependencies here
+       ],
+       entry_points={
+           "console_scripts": [
+               "cli-anything-<software>=cli_anything.<software>.<software>_cli:main",
+           ],
+       },
+       python_requires=">=3.10",
+   )
+   ```
+
+   **Important details:**
+   - Use `find_namespace_packages`, NOT `find_packages`
+   - Use `include=["cli_anything.*"]` to scope discovery
+   - Entry point format: `cli_anything.<software>.<software>_cli:main`
+   - The **system package** (LibreOffice, Blender, etc.) is a **hard dependency**
+     that cannot be expressed in `install_requires`. Document it in README.md and
+     have the backend module raise a clear error with install instructions:
+     ```python
+     # In utils/<software>_backend.py
+     def find_<software>():
+         path = shutil.which("<software>")
+         if path:
+             return path
+         raise RuntimeError(
+             "<Software> is not installed. Install it with:\n"
+             "  apt install <software>   # Debian/Ubuntu\n"
+             "  brew install <software>  # macOS"
+         )
+     ```
+
+3. **All imports** use the `cli_anything.<software>` prefix:
+   ```python
+   from cli_anything.gimp.core.project import create_project
+   from cli_anything.gimp.core.session import Session
+   from cli_anything.blender.core.scene import create_scene
+   ```
+
+4. **Test local installation**:
+   ```bash
+   cd /root/cli-anything/<software>/agent-harness
+   pip install -e .
+   ```
+
+5. **Verify PATH installation**:
+   ```bash
+   which cli-anything-<software>
+   cli-anything-<software> --help
+   ```
+
+6. **Run tests against the installed command**:
+   ```bash
+   cd /root/cli-anything/<software>/agent-harness
+   CLI_ANYTHING_FORCE_INSTALLED=1 python3 -m pytest cli_anything/<software>/tests/ -v -s
+   ```
+   The output must show `[_resolve_cli] Using installed command: /path/to/cli-anything-<software>`
+   confirming subprocess tests ran against the real installed binary, not a module fallback.
+
+7. **Verify namespace works across packages** (when multiple CLIs installed):
+   ```python
+   import cli_anything.gimp
+   import cli_anything.blender
+   # Both resolve to their respective source directories
+   ```
+
+**Why namespace packages:**
+- Multiple CLIs coexist in the same Python environment without conflicts
+- Clean, organized imports under a single `cli_anything` namespace
+- Each CLI is independently installable/uninstallable via pip
+- Agents can discover all installed CLIs via `cli_anything.*`
+- Standard Python packaging — no hacks or workarounds

--- a/codex-skill/scripts/sync_from_repo.ps1
+++ b/codex-skill/scripts/sync_from_repo.ps1
@@ -1,0 +1,55 @@
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$RepoRoot = $env:CLI_ANYTHING_REPO
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$skillDir = Split-Path -Parent $scriptDir
+
+if (-not $RepoRoot -or [string]::IsNullOrWhiteSpace($RepoRoot)) {
+    throw "Provide -RepoRoot or set CLI_ANYTHING_REPO."
+}
+
+$RepoRoot = (Resolve-Path $RepoRoot).Path
+
+$sources = @{
+    "HARNESS"       = Join-Path $RepoRoot "cli-anything-plugin\\HARNESS.md"
+    "REPL"          = Join-Path $RepoRoot "cli-anything-plugin\\repl_skin.py"
+    "GENERATOR"     = Join-Path $RepoRoot "cli-anything-plugin\\skill_generator.py"
+    "TEMPLATE"      = Join-Path $RepoRoot "cli-anything-plugin\\templates\\SKILL.md.template"
+    "OPENAI_YAML"   = Join-Path $RepoRoot "codex-skill\\agents\\openai.yaml"
+    "INSTALL_PS1"   = Join-Path $RepoRoot "codex-skill\\scripts\\install.ps1"
+    "INSTALL_SH"    = Join-Path $RepoRoot "codex-skill\\scripts\\install.sh"
+}
+
+foreach ($entry in $sources.GetEnumerator()) {
+    if (-not (Test-Path $entry.Value)) {
+        throw "Missing required source file for $($entry.Key): $($entry.Value)"
+    }
+}
+
+$targets = @{
+    $sources["HARNESS"]     = Join-Path $skillDir "references\\HARNESS.md"
+    $sources["REPL"]        = Join-Path $skillDir "assets\\cli_anything_plugin\\repl_skin.py"
+    $sources["GENERATOR"]   = Join-Path $skillDir "assets\\cli_anything_plugin\\skill_generator.py"
+    $sources["TEMPLATE"]    = Join-Path $skillDir "assets\\cli_anything_plugin\\templates\\SKILL.md.template"
+    $sources["OPENAI_YAML"] = Join-Path $skillDir "agents\\openai.yaml"
+    $sources["INSTALL_PS1"] = Join-Path $skillDir "scripts\\install.ps1"
+    $sources["INSTALL_SH"]  = Join-Path $skillDir "scripts\\install.sh"
+}
+
+foreach ($target in $targets.Values) {
+    $parent = Split-Path -Parent $target
+    if (-not (Test-Path $parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+}
+
+foreach ($pair in $targets.GetEnumerator()) {
+    Copy-Item $pair.Key $pair.Value -Force
+    Write-Host ("Synced: {0}" -f $pair.Value)
+}
+
+Write-Host "Sync complete."

--- a/codex-skill/scripts/sync_from_repo.sh
+++ b/codex-skill/scripts/sync_from_repo.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="${1:-${CLI_ANYTHING_REPO:-}}"
+
+if [[ -z "${REPO_ROOT}" ]]; then
+  echo "Provide a repo root path as the first argument or set CLI_ANYTHING_REPO." >&2
+  exit 1
+fi
+
+REPO_ROOT="$(cd "${REPO_ROOT}" && pwd)"
+
+declare -A SOURCES=(
+  [HARNESS]="${REPO_ROOT}/cli-anything-plugin/HARNESS.md"
+  [REPL]="${REPO_ROOT}/cli-anything-plugin/repl_skin.py"
+  [GENERATOR]="${REPO_ROOT}/cli-anything-plugin/skill_generator.py"
+  [TEMPLATE]="${REPO_ROOT}/cli-anything-plugin/templates/SKILL.md.template"
+  [OPENAI_YAML]="${REPO_ROOT}/codex-skill/agents/openai.yaml"
+  [INSTALL_SH]="${REPO_ROOT}/codex-skill/scripts/install.sh"
+  [INSTALL_PS1]="${REPO_ROOT}/codex-skill/scripts/install.ps1"
+)
+
+for key in "${!SOURCES[@]}"; do
+  if [[ ! -f "${SOURCES[$key]}" ]]; then
+    echo "Missing required source file for ${key}: ${SOURCES[$key]}" >&2
+    exit 1
+  fi
+done
+
+mkdir -p \
+  "${SKILL_DIR}/references" \
+  "${SKILL_DIR}/agents" \
+  "${SKILL_DIR}/scripts" \
+  "${SKILL_DIR}/assets/cli_anything_plugin/templates"
+
+cp "${SOURCES[HARNESS]}" "${SKILL_DIR}/references/HARNESS.md"
+cp "${SOURCES[REPL]}" "${SKILL_DIR}/assets/cli_anything_plugin/repl_skin.py"
+cp "${SOURCES[GENERATOR]}" "${SKILL_DIR}/assets/cli_anything_plugin/skill_generator.py"
+cp "${SOURCES[TEMPLATE]}" "${SKILL_DIR}/assets/cli_anything_plugin/templates/SKILL.md.template"
+cp "${SOURCES[OPENAI_YAML]}" "${SKILL_DIR}/agents/openai.yaml"
+cp "${SOURCES[INSTALL_SH]}" "${SKILL_DIR}/scripts/install.sh"
+cp "${SOURCES[INSTALL_PS1]}" "${SKILL_DIR}/scripts/install.ps1"
+
+echo "Sync complete."


### PR DESCRIPTION
## Summary
- make the Codex CLI-Anything skill self-contained instead of depending on a separate plugin checkout
- vendor the official HARNESS, REPL skin, skill generator, and SKILL template into codex-skill
- add sync scripts to refresh bundled files from the main CLI-Anything repository
- tighten and align the Codex-facing SKILL.md and openai.yaml wording

## Scope
- only changes files under \\codex-skill/\\
- does not modify other harnesses or plugin packaging paths

## Notes
- this keeps the Codex skill usable even when the full CLI-Anything repository is not present
- repo-local official plugin files are still preferred when available in the target source tree