### PR TITLE
fix: missing closing brace in registry.json breaks CLI-Hub

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -354,6 +354,8 @@
       "category": "network",
       "contributor": "galke",
       "contributor_url": "https://github.com/galke7"
+    },
+    {
       "name": "renderdoc",
       "display_name": "RenderDoc",
       "version": "0.1.0",


### PR DESCRIPTION
## Summary

- The `rms` entry in `registry.json` is missing its closing `}` delimiter before the `renderdoc` entry, causing a JSON parse error
- This prevents the [CLI-Hub website](https://hkuds.github.io/CLI-Anything/) from loading the registry, showing "Failed to load registry" instead of the 26 CLI cards
- Fix: add the missing `},` and `{` between the two entries (2-line diff)

## Verified

Served the hub locally with the fix applied and confirmed all 26 CLIs load correctly in the browser.

## Test plan

- [ ] `python3 -c "import json; json.load(open('registry.json'))"` passes
- [ ] CLI-Hub website loads and displays all 26 CLI cards


🤖 Generated with [Claude Code](https://claude.com/claude-code)