### PR TITLE
feat(zotero): update registry to v0.4.1 — standalone repo with 52 MCP tools

### DIFF
--- a/docs/hub/index.html
+++ b/docs/hub/index.html
@@ -1002,7 +1002,7 @@
           ? `<div class="card-requires"><strong>Requires</strong> ${esc(c.requires)}</div>`
           : '';
         const skillLink = c.skill_md
-          ? `<a href="${REPO}/blob/main/${c.skill_md}" target="_blank">Skill</a>`
+          ? `<a href="${c.skill_md.startsWith('http') ? c.skill_md : `${REPO}/blob/main/${c.skill_md}`}" target="_blank">Skill</a>`
           : '';
         const sourceLink = `<a href="${REPO}/tree/main/${c.name}/agent-harness" target="_blank">Source</a>`;
         const titleHtml = c.homepage

--- a/registry.json
+++ b/registry.json
@@ -196,7 +196,7 @@
       "homepage": "https://github.com/PiaoyangGuohai1/cli-anything-zotero",
       "install_cmd": "pip install cli-anything-zotero",
       "entry_point": "cli-anything-zotero",
-      "skill_md": "zotero/agent-harness/cli_anything/zotero/skills/SKILL.md",
+      "skill_md": null,
       "category": "office",
       "contributor": "PiaoyangGuohai1",
       "contributor_url": "https://github.com/PiaoyangGuohai1"

--- a/registry.json
+++ b/registry.json
@@ -196,7 +196,7 @@
       "homepage": "https://github.com/PiaoyangGuohai1/cli-anything-zotero",
       "install_cmd": "pip install cli-anything-zotero",
       "entry_point": "cli-anything-zotero",
-      "skill_md": null,
+      "skill_md": "https://github.com/PiaoyangGuohai1/cli-anything-zotero/blob/main/cli_anything/zotero/skills/SKILL.md",
       "category": "office",
       "contributor": "PiaoyangGuohai1",
       "contributor_url": "https://github.com/PiaoyangGuohai1"

--- a/registry.json
+++ b/registry.json
@@ -190,16 +190,16 @@
     {
       "name": "zotero",
       "display_name": "Zotero",
-      "version": "0.1.0",
-      "description": "Reference management via local Zotero SQLite, connector, and Local API",
-      "requires": "Zotero desktop app",
-      "homepage": "https://www.zotero.org",
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=zotero/agent-harness",
+      "version": "0.4.1",
+      "description": "CLI & MCP server for Zotero 7/8 — 52 MCP tools + 70+ CLI commands for search, import, PDF, BibTeX, notes, and more",
+      "requires": "Zotero 7/8 desktop app (running), Python 3.10+",
+      "homepage": "https://github.com/PiaoyangGuohai1/cli-anything-zotero",
+      "install_cmd": "pip install cli-anything-zotero",
       "entry_point": "cli-anything-zotero",
       "skill_md": "zotero/agent-harness/cli_anything/zotero/skills/SKILL.md",
       "category": "office",
-      "contributor": "zhiwuyazhe_fjr",
-      "contributor_url": "https://github.com/zhiwuyazhe_fjr"
+      "contributor": "PiaoyangGuohai1",
+      "contributor_url": "https://github.com/PiaoyangGuohai1"
     },
     {
       "name": "mubu",


### PR DESCRIPTION
## Description

Updates the Zotero CLI registry entry to v0.4.1, pointing to the standalone PyPI package with significantly expanded capabilities.

## Type of Change

- [ ] **New Software CLI** — adds a CLI harness for a new application
- [ ] **New Feature** — adds new functionality to an existing harness or the plugin
- [ ] **Bug Fix** — fixes incorrect behavior
- [ ] **Documentation** — updates docs only
- [x] **Other** — registry.json update for existing CLI that moved to standalone repo

---

### For Existing CLI Modifications

- [x] All unit tests pass: `python3 -m pytest cli_anything/zotero/tests/test_core.py -v`
- [x] All E2E tests pass: `python3 -m pytest cli_anything/zotero/tests/test_full_e2e.py -v`
- [x] No test regressions — no previously passing tests were removed or weakened
- [x] `registry.json` entry is updated if version, description, or requirements changed

### General Checklist

- [x] Code follows existing patterns and conventions
- [ ] `--json` flag is supported on any new commands
- [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
- [x] I have tested my changes locally

## What Changed in registry.json

| Field | Before | After |
|-------|--------|-------|
| version | 0.1.0 | 0.4.1 |
| description | Reference management via local Zotero SQLite... | CLI & MCP server for Zotero 7/8 — 52 MCP tools + 70+ CLI commands... |
| requires | Zotero desktop app | Zotero 7/8 desktop app (running), Python 3.10+ |
| homepage | zotero.org | Standalone repo |
| install_cmd | pip install git+...CLI-Anything.git#subdirectory=... | `pip install cli-anything-zotero` (PyPI) |
| contributor | zhiwuyazhe_fjr | PiaoyangGuohai1 |

## What's in v0.4.1

- **JS Bridge plugin** — lightweight Zotero plugin for privileged operations
- **70+ CLI commands** across 12 groups with recursive `--help`
- **52 MCP tools** for Claude Desktop, Cursor, Claude Code, LM Studio
- **Semantic search** with local embeddings (Ollama / LM Studio)
- **AI analysis** via any OpenAI-compatible API
- PyPI: https://pypi.org/project/cli-anything-zotero/
- GitHub: https://github.com/PiaoyangGuohai1/cli-anything-zotero

The standalone repo is fully compatible with the CLI-Anything ecosystem — same `cli-anything-zotero` entry point.

> **Note on `skill_md`**: set to `null` since development has moved to the standalone repo and CLI-Hub does not yet support remote URLs. Will restore once remote URL support lands.

## Test Results

```
75 passed in 14.78s
```