### PR TITLE
fix: handle empty skill_intro in skill_description generation

### DIFF
--- a/cli-anything-plugin/skill_generator.py
+++ b/cli-anything-plugin/skill_generator.py
@@ -164,16 +164,14 @@ def extract_system_package(content: str) -> Optional[str]:
     patterns = [
         r"`apt install ([\w\-]+)`",
         r"`brew install ([\w\-]+)`",
-        r"`apt-get install ([\w\-]+)`",
+        r"apt-get install ([\w\-]+)",
     ]
 
     for pattern in patterns:
         match = re.search(pattern, content)
         if match:
             package = match.group(1)
-            if "apt-get" in pattern:
-                return f"apt-get install {package}"
-            elif "apt" in pattern:
+            if "apt" in pattern:
                 return f"apt install {package}"
             elif "brew" in pattern:
                 return f"brew install {package}"

--- a/cli-anything-plugin/skill_generator.py
+++ b/cli-anything-plugin/skill_generator.py
@@ -115,7 +115,12 @@ def extract_cli_metadata(harness_path: str) -> SkillMetadata:
 
     # Build skill name and description
     skill_name = f"cli-anything-{software_name}"
-    skill_description = f"Command-line interface for {_format_display_name(software_name)} - {skill_intro[:100]}..."
+    if skill_intro:
+        intro_snippet = skill_intro[:100]
+        suffix = "..." if len(skill_intro) > 100 else ""
+        skill_description = f"Command-line interface for {_format_display_name(software_name)} - {intro_snippet}{suffix}"
+    else:
+        skill_description = f"Command-line interface for {_format_display_name(software_name)}"
 
     return SkillMetadata(
         skill_name=skill_name,
@@ -159,14 +164,16 @@ def extract_system_package(content: str) -> Optional[str]:
     patterns = [
         r"`apt install ([\w\-]+)`",
         r"`brew install ([\w\-]+)`",
-        r"apt-get install ([\w\-]+)",
+        r"`apt-get install ([\w\-]+)`",
     ]
 
     for pattern in patterns:
         match = re.search(pattern, content)
         if match:
             package = match.group(1)
-            if "apt" in pattern:
+            if "apt-get" in pattern:
+                return f"apt-get install {package}"
+            elif "apt" in pattern:
                 return f"apt install {package}"
             elif "brew" in pattern:
                 return f"brew install {package}"

--- a/cli-anything-plugin/tests/test_skill_generator.py
+++ b/cli-anything-plugin/tests/test_skill_generator.py
@@ -326,6 +326,9 @@ class TestEdgeCases:
         assert metadata.skill_intro == ""  # No README → empty intro
         assert metadata.version == "1.0.0"
         assert metadata.command_groups == []
+        # skill_description must not contain trailing " - ..." when intro is empty
+        assert " - " not in metadata.skill_description
+        assert not metadata.skill_description.endswith("...")
 
     def test_harness_with_system_package(self, tmp_path):
         """README with apt install instructions should extract system_package."""

--- a/mubu/agent-harness/skill_generator.py
+++ b/mubu/agent-harness/skill_generator.py
@@ -76,15 +76,13 @@ def extract_system_package(content: str) -> Optional[str]:
     patterns = [
         r"`apt install ([\w\-]+)`",
         r"`brew install ([\w\-]+)`",
-        r"`apt-get install ([\w\-]+)`",
+        r"apt-get install ([\w\-]+)",
     ]
 
     for pattern in patterns:
         match = re.search(pattern, content)
         if match:
             package = match.group(1)
-            if "apt-get" in pattern:
-                return f"apt-get install {package}"
             if "apt" in pattern:
                 return f"apt install {package}"
             if "brew" in pattern:

--- a/mubu/agent-harness/skill_generator.py
+++ b/mubu/agent-harness/skill_generator.py
@@ -76,13 +76,15 @@ def extract_system_package(content: str) -> Optional[str]:
     patterns = [
         r"`apt install ([\w\-]+)`",
         r"`brew install ([\w\-]+)`",
-        r"apt-get install ([\w\-]+)",
+        r"`apt-get install ([\w\-]+)`",
     ]
 
     for pattern in patterns:
         match = re.search(pattern, content)
         if match:
             package = match.group(1)
+            if "apt-get" in pattern:
+                return f"apt-get install {package}"
             if "apt" in pattern:
                 return f"apt install {package}"
             if "brew" in pattern:
@@ -235,7 +237,12 @@ def extract_cli_metadata(harness_path: str) -> SkillMetadata:
     command_groups = extract_commands_from_cli(cli_file) if cli_file.exists() else []
     examples = generate_examples(software_name, command_groups)
     skill_name = f"cli-anything-{software_name}"
-    skill_description = f"Command-line interface for {_format_display_name(software_name)} - {skill_intro[:100]}..."
+    if skill_intro:
+        intro_snippet = skill_intro[:100]
+        suffix = "..." if len(skill_intro) > 100 else ""
+        skill_description = f"Command-line interface for {_format_display_name(software_name)} - {intro_snippet}{suffix}"
+    else:
+        skill_description = f"Command-line interface for {_format_display_name(software_name)}"
 
     return SkillMetadata(
         skill_name=skill_name,


### PR DESCRIPTION
## Summary

Fixes `skill_description` generation when `skill_intro` is empty.

**Problem:** When a harness has no README.md, `skill_intro` is empty, producing malformed YAML like `description: Command-line interface for TestApp - ...` with a trailing ` - ...` and no content.

**Fix:** Add conditional handling — if `skill_intro` is empty, generate just `"Command-line interface for {name}"` without the dash separator. Also only append `...` when `skill_intro` actually exceeds 100 characters.

Note: The `extract_system_package` apt-get fix has been split into its own PR (#204) as requested.