### PR TITLE
fix: extract_system_package returns wrong command for apt-get matches

### DIFF
--- a/cli-anything-plugin/skill_generator.py
+++ b/cli-anything-plugin/skill_generator.py
@@ -159,14 +159,16 @@ def extract_system_package(content: str) -> Optional[str]:
     patterns = [
         r"`apt install ([\w\-]+)`",
         r"`brew install ([\w\-]+)`",
-        r"apt-get install ([\w\-]+)",
+        r"`apt-get install ([\w\-]+)`",
     ]
 
     for pattern in patterns:
         match = re.search(pattern, content)
         if match:
             package = match.group(1)
-            if "apt" in pattern:
+            if "apt-get" in pattern:
+                return f"apt-get install {package}"
+            elif "apt" in pattern:
                 return f"apt install {package}"
             elif "brew" in pattern:
                 return f"brew install {package}"

--- a/cli-anything-plugin/tests/test_skill_generator.py
+++ b/cli-anything-plugin/tests/test_skill_generator.py
@@ -30,6 +30,7 @@ from skill_generator import (
     generate_skill_md_simple,
     generate_skill_file,
     extract_intro_from_readme,
+    extract_system_package,
     extract_version_from_setup,
     SkillMetadata,
     CommandInfo,
@@ -205,6 +206,35 @@ class TestExtractIntroFromReadme:
         assert "Line one" in intro
         assert "Line two" in intro
 
+
+
+# ─── extract_system_package Tests ─────────────────────
+
+
+class TestExtractSystemPackage:
+    def test_apt_install(self):
+        content = "Install with `apt install mytool`."
+        result = extract_system_package(content)
+        assert result == "apt install mytool"
+
+    def test_brew_install(self):
+        content = "Install with `brew install mytool`."
+        result = extract_system_package(content)
+        assert result == "brew install mytool"
+
+    def test_apt_get_install_returns_apt_get_command(self):
+        # Regression: apt-get pattern contains "apt" as a substring, so the
+        # condition must check "apt-get" before "apt" to avoid returning the
+        # wrong command ("apt install" instead of "apt-get install").
+        content = "Install with `apt-get install mytool`."
+        result = extract_system_package(content)
+        assert result == "apt-get install mytool", (
+            f"Expected 'apt-get install mytool', got {result!r}"
+        )
+
+    def test_returns_none_when_no_match(self):
+        content = "No installation instructions here."
+        assert extract_system_package(content) is None
 
 # ─── generate_skill_md Tests ───────────────────────────────────────────
 

--- a/mubu/agent-harness/skill_generator.py
+++ b/mubu/agent-harness/skill_generator.py
@@ -76,13 +76,15 @@ def extract_system_package(content: str) -> Optional[str]:
     patterns = [
         r"`apt install ([\w\-]+)`",
         r"`brew install ([\w\-]+)`",
-        r"apt-get install ([\w\-]+)",
+        r"`apt-get install ([\w\-]+)`",
     ]
 
     for pattern in patterns:
         match = re.search(pattern, content)
         if match:
             package = match.group(1)
+            if "apt-get" in pattern:
+                return f"apt-get install {package}"
             if "apt" in pattern:
                 return f"apt install {package}"
             if "brew" in pattern:

--- a/mubu/agent-harness/skill_generator.py
+++ b/mubu/agent-harness/skill_generator.py
@@ -85,9 +85,9 @@ def extract_system_package(content: str) -> Optional[str]:
             package = match.group(1)
             if "apt-get" in pattern:
                 return f"apt-get install {package}"
-            if "apt" in pattern:
+            elif "apt" in pattern:
                 return f"apt install {package}"
-            if "brew" in pattern:
+            elif "brew" in pattern:
                 return f"brew install {package}"
     return None
 


### PR DESCRIPTION
## Problem

`extract_system_package()` in `cli-anything-plugin/skill_generator.py` (and its duplicate in `mubu/agent-harness/skill_generator.py`) uses three regex patterns to detect package managers:

```python
patterns = [
    r"`apt install ([\w\-]+)`",
    r"`brew install ([\w\-]+)`",
    r"apt-get install ([\w\-]+)",   # ← bug here
]
```

After a match, the command is selected by substring check:

```python
if "apt" in pattern:          # matches BOTH apt and apt-get patterns
    return f"apt install {package}"
```

Because `"apt"` is a substring of `"apt-get"`, the third pattern (`apt-get install`) incorrectly returns `"apt install <pkg>"` instead of `"apt-get install <pkg>"`.

## Fix

1. **Check `"apt-get" in pattern` before `"apt" in pattern`** so the more specific string wins.
2. **Add backtick delimiters to the `apt-get` pattern** (`r"\`apt-get install ...\`"`) for consistency with the other two patterns.

### Before
```python
r"apt-get install ([\w\-]+)",   # no backticks
...
if "apt" in pattern:            # catches apt-get too
    return f"apt install {package}"
```

### After
```python
r"`apt-get install ([\w\-]+)`",  # consistent backticks
...
if "apt-get" in pattern:         # checked first, specific match
    return f"apt-get install {package}"
elif "apt" in pattern:
    return f"apt install {package}"
```

## Changes

- `cli-anything-plugin/skill_generator.py` — fix condition order + add backtick delimiters
- `mubu/agent-harness/skill_generator.py` — same fix (duplicate function)
- `cli-anything-plugin/tests/test_skill_generator.py` — add `TestExtractSystemPackage` with regression test for the `apt-get` case

🤖 Generated with [Claude Code](https://claude.com/claude-code)