### PR TITLE
fix: add x-exa-integration header for Exa usage tracking

### DIFF
--- a/exa/agent-harness/cli_anything/exa/utils/exa_backend.py
+++ b/exa/agent-harness/cli_anything/exa/utils/exa_backend.py
@@ -30,10 +30,12 @@ def get_client() -> Exa:
             "EXA_API_KEY environment variable is not set.\n"
             "Get a free key at https://dashboard.exa.ai/api-keys"
         )
-    return Exa(
+    client = Exa(
         api_key=api_key,
         user_agent="cli-anything",
     )
+    client.headers["x-exa-integration"] = "cli-anything"
+    return client
 
 
 def check_connectivity() -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- Adds the `x-exa-integration: cli-anything` header to all Exa API requests
- This header is required by Exa for integration-level usage tracking (extracted by Vulcan's `extractIntegrationFromRequest`)
- One-line addition after client initialization

## Context

The Exa CLI harness (added in #172) uses the `exa-py` SDK but was missing the `x-exa-integration` header. The SDK doesn't expose a constructor param for it, but `self.headers` is a plain dict, so we can set it directly after initialization.

## Test plan

- [ ] Verify `x-exa-integration: cli-anything` appears in outgoing request headers (e.g. via `--verbose` or proxy inspection)
- [ ] Existing unit tests still pass (`pytest cli_anything/exa/tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)