### PR TITLE
docs: clarify CLI-Anything command syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ That's it. The plugin is now available in your Claude Code session.
 /cli-anything ./gimp
 ```
 
-Use `/cli-anything` for the main build command. Only the auxiliary commands use the `:subcommand` form, such as `/cli-anything:refine`, `/cli-anything:test`, and `/cli-anything:validate`.
+Use `/cli-anything` for the main build command in the current docs. Only the auxiliary commands use the `:subcommand` form, such as `/cli-anything:refine`, `/cli-anything:test`, and `/cli-anything:validate`. Some older Claude Code 2.x releases also accepted `/cli-anything:cli-anything`; this guide uses the current `/cli-anything` form so the primary examples stay consistent.
 
 This runs the full pipeline:
 1. 🔍 **Analyze** — Scans source code, maps GUI actions to APIs

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ That's it. The plugin is now available in your Claude Code session.
 /cli-anything ./gimp
 ```
 
-Use `/cli-anything` for the main build command in the current docs. Only the auxiliary commands use the `:subcommand` form, such as `/cli-anything:refine`, `/cli-anything:test`, and `/cli-anything:validate`. Some older Claude Code 2.x releases also accepted `/cli-anything:cli-anything`; this guide uses the current `/cli-anything` form so the primary examples stay consistent.
+Older Claude Code 2.x releases also accepted `/cli-anything:cli-anything`; auxiliary commands still use the `:subcommand` form (e.g. `/cli-anything:refine`).
 
 This runs the full pipeline:
 1. 🔍 **Analyze** — Scans source code, maps GUI actions to APIs

--- a/README.md
+++ b/README.md
@@ -158,12 +158,12 @@ That's it. The plugin is now available in your Claude Code session.
 **Step 3: Build a CLI in One Command**
 
 ```bash
-# /cli-anything:cli-anything <software-path-or-repo>
+# /cli-anything <software-path-or-repo>
 # Generate a complete CLI for GIMP (all 7 phases)
-/cli-anything:cli-anything ./gimp
-
-# Note: If your Claude Code is under 2.x, use "/cli-anything" instead.
+/cli-anything ./gimp
 ```
+
+Use `/cli-anything` for the main build command. Only the auxiliary commands use the `:subcommand` form, such as `/cli-anything:refine`, `/cli-anything:test`, and `/cli-anything:validate`.
 
 This runs the full pipeline:
 1. 🔍 **Analyze** — Scans source code, maps GUI actions to APIs
@@ -332,7 +332,7 @@ Configure Goose to use a CLI provider such as Claude Code, and make sure that CL
 Once Goose is configured, start a session and use the same CLI-Anything commands described above for Claude Code, for example:
 
 ```bash
-/cli-anything:cli-anything ./gimp
+/cli-anything ./gimp
 /cli-anything:refine ./gimp "batch processing and filters"
 ```
 
@@ -355,7 +355,7 @@ This registers the cli-anything plugin in `~/.qoder.json`. Start a new Qodercli 
 **Step 2: Use CLI-Anything from Qodercli**
 
 ```bash
-/cli-anything:cli-anything ./gimp
+/cli-anything ./gimp
 /cli-anything:refine ./gimp "batch processing and filters"
 /cli-anything:validate ./gimp
 ```
@@ -445,7 +445,7 @@ This installs the CLI-Anything plugin to GitHub Copilot CLI. The plugin should n
 **Step 2: Use CLI-Anything from GitHub Copilot CLI**
 
 ```bash
-/cli-anything:cli-anything ./gimp
+/cli-anything ./gimp
 /cli-anything:refine ./gimp "batch processing and filters"
 /cli-anything:validate ./gimp
 ```


### PR DESCRIPTION
## Summary
- fix the main build command examples in `README.md` to use `/cli-anything` instead of `/cli-anything:cli-anything`
- add a short clarification that only auxiliary commands use the `:subcommand` form
- update the same examples in the Goose, Qodercli, and GitHub Copilot CLI sections for consistency

## Why
The plugin defines the primary command as `/cli-anything`, but the README still showed `/cli-anything:cli-anything` in several places. This causes first-run confusion and matches the problem reported in issue #19.

## Validation
- ran `git diff --check`
- verified there are no remaining `/cli-anything:cli-anything` examples in `README.md`