### PR TITLE
test(zoom): add credential permission regression tests

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -430,7 +430,7 @@
     {
       "name": "zoom",
       "display_name": "Zoom",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Meeting management via Zoom REST API (OAuth2)",
       "requires": "Zoom account + OAuth app credentials",
       "homepage": "https://zoom.us",

--- a/zoom/agent-harness/cli_anything/zoom/tests/test_core.py
+++ b/zoom/agent-harness/cli_anything/zoom/tests/test_core.py
@@ -11,9 +11,9 @@ Tests cover:
 
 import json
 import os
-import tempfile
+import stat
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, call, patch
 from click.testing import CliRunner
 
 from cli_anything.zoom.zoom_cli import cli
@@ -439,6 +439,67 @@ class TestBackend:
         loaded = load_tokens()
         assert loaded["access_token"] == "at_test"
         assert "saved_at" in loaded
+
+    def test_save_config_restricts_directory_and_file(self, mock_config):
+        """save_config should enforce 700 on dir and 600 on config file."""
+        from cli_anything.zoom.utils.zoom_backend import save_config
+
+        with patch("cli_anything.zoom.utils.zoom_backend._restrict_path") as mock_restrict:
+            save_config({"client_id": "abc", "client_secret": "xyz"})
+
+        assert (mock_config / "config.json").exists()
+        assert mock_restrict.call_args_list == [
+            call(mock_config, 0o700),
+            call(mock_config / "config.json", 0o600),
+        ]
+
+    def test_save_tokens_restricts_directory_and_file(self, mock_config):
+        """save_tokens should enforce 700 on dir and 600 on token file."""
+        from cli_anything.zoom.utils.zoom_backend import save_tokens
+
+        with patch("cli_anything.zoom.utils.zoom_backend._restrict_path") as mock_restrict:
+            save_tokens({"access_token": "at_test", "refresh_token": "rt_test"})
+
+        assert (mock_config / "tokens.json").exists()
+        assert mock_restrict.call_args_list == [
+            call(mock_config, 0o700),
+            call(mock_config / "tokens.json", 0o600),
+        ]
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="POSIX permission bits are not supported on Windows",
+    )
+    def test_get_config_dir_sets_posix_700_permissions(self, mock_config):
+        """get_config_dir should force 700 permissions on POSIX."""
+        from cli_anything.zoom.utils.zoom_backend import get_config_dir
+
+        mock_config.chmod(0o755)
+        config_dir = get_config_dir()
+        assert config_dir == mock_config
+        assert stat.S_IMODE(config_dir.stat().st_mode) == 0o700
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="POSIX permission bits are not supported on Windows",
+    )
+    def test_save_config_sets_posix_600_permissions(self, mock_config):
+        """save_config should force 600 on config.json on POSIX."""
+        from cli_anything.zoom.utils.zoom_backend import save_config
+
+        save_config({"client_id": "abc", "client_secret": "xyz"})
+        assert stat.S_IMODE((mock_config / "config.json").stat().st_mode) == 0o600
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="POSIX permission bits are not supported on Windows",
+    )
+    def test_save_tokens_sets_posix_600_permissions(self, mock_config):
+        """save_tokens should force 600 on tokens.json on POSIX."""
+        from cli_anything.zoom.utils.zoom_backend import save_tokens
+
+        save_tokens({"access_token": "at_test", "refresh_token": "rt_test"})
+        assert stat.S_IMODE((mock_config / "tokens.json").stat().st_mode) == 0o600
 
     def test_authorize_url(self):
         """get_authorize_url should build valid URL."""

--- a/zoom/agent-harness/cli_anything/zoom/zoom_cli.py
+++ b/zoom/agent-harness/cli_anything/zoom/zoom_cli.py
@@ -442,7 +442,7 @@ def repl():
     global _repl_mode
     _repl_mode = True
 
-    skin = ReplSkin("zoom", version="1.0.0")
+    skin = ReplSkin("zoom", version="1.0.1")
     skin.print_banner()
 
     pt_session = skin.create_prompt_session()

--- a/zoom/agent-harness/setup.py
+++ b/zoom/agent-harness/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name="cli-anything-zoom",
-    version="1.0.0",
+    version="1.0.1",
     author="cli-anything contributors",
     author_email="",
     description="CLI harness for Zoom - Meeting management via Zoom REST API (OAuth2). Requires: Zoom account + OAuth app credentials",


### PR DESCRIPTION
## Description

Add regression coverage for Zoom credential file/directory permissions so the security behavior reported in #144 cannot regress.

Fixes #144

## Type of Change

- [ ] **New Software CLI (in-repo)** — adds a CLI harness inside this monorepo
- [ ] **New Software CLI (standalone repo)** — registry-only PR pointing to an external repo
- [ ] **New Feature** — adds new functionality to an existing harness or the plugin
- [x] **Bug Fix** — fixes incorrect behavior
- [ ] **Documentation** — updates docs only
- [ ] **Other** — please describe:

---

### For Existing CLI Modifications

- [x] All unit tests pass: `python3 -m pytest cli_anything/zoom/tests/test_core.py -v`
- [x] All E2E tests pass: `python3 -m pytest cli_anything/zoom/tests/test_full_e2e.py -v` (suite runs successfully; tests are skipped without external Zoom/OAuth setup)
- [x] No test regressions — no previously passing tests were removed or weakened
- [x] `registry.json` entry is updated if version, description, or requirements changed (`zoom` 1.0.0 → 1.0.1)

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands
- [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
- [x] I have tested my changes locally

## Test Results

```bash
$ /tmp/CLI-Anything/.venv/bin/python -m pytest zoom/agent-harness/cli_anything/zoom/tests/test_core.py -v
27 passed

$ /tmp/CLI-Anything/.venv/bin/python -m pytest zoom/agent-harness/cli_anything/zoom/tests/test_full_e2e.py -v
4 skipped
```
