### PR TITLE
docs: add unknown-skill troubleshooting for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,20 @@ That's it. The plugin is now available in your Claude Code session.
 /cli-anything ./gimp
 ```
 
-Older Claude Code 2.x releases also accepted `/cli-anything:cli-anything`; auxiliary commands still use the `:subcommand` form (e.g. `/cli-anything:refine`).
+Command compatibility across Claude Code versions:
+- Use `/cli-anything` as the primary entrypoint.
+- If your build reports `Unknown skill: cli-anything`, retry with `/cli-anything:cli-anything`.
+- Auxiliary commands keep the `:subcommand` form (e.g. `/cli-anything:refine`).
+
+If you still see `Unknown skill: cli-anything`:
+1. Reload plugin commands: `/reload-plugins`
+2. Verify install state: `/plugin list` (confirm `cli-anything` is present)
+3. Reinstall from marketplace:
+   - `/plugin marketplace add HKUDS/CLI-Anything`
+   - `/plugin install cli-anything`
+4. Retry both entry forms:
+   - `/cli-anything ./gimp`
+   - `/cli-anything:cli-anything ./gimp`
 
 This runs the full pipeline:
 1. 🔍 **Analyze** — Scans source code, maps GUI actions to APIs

--- a/README.md
+++ b/README.md
@@ -190,18 +190,18 @@ That's it. The plugin is now available in your Claude Code session.
 
 Command compatibility across Claude Code versions:
 - Use `/cli-anything` as the primary entrypoint.
-- If your build reports `Unknown skill: cli-anything`, retry with `/cli-anything:cli-anything`.
+- On older builds where `/cli-anything` isn't recognized **after confirming the plugin is installed and loaded**, try the legacy entry form `/cli-anything:cli-anything`.
 - Auxiliary commands keep the `:subcommand` form (e.g. `/cli-anything:refine`).
 
-If you still see `Unknown skill: cli-anything`:
+If you see `Unknown skill: cli-anything`, focus on plugin install/load first (both entry forms reference the same skill, so swapping forms won't help):
 1. Reload plugin commands: `/reload-plugins`
-2. Verify install state: `/plugin list` (confirm `cli-anything` is present)
-3. Reinstall from marketplace:
+2. Verify the plugin is loaded: `/help cli-anything` (CLI-Anything help/commands should appear)
+3. Reinstall from marketplace if needed:
    - `/plugin marketplace add HKUDS/CLI-Anything`
    - `/plugin install cli-anything`
-4. Retry both entry forms:
-   - `/cli-anything ./gimp`
-   - `/cli-anything:cli-anything ./gimp`
+4. After confirming the plugin is available, retry the entry command:
+   - Preferred: `/cli-anything ./gimp`
+   - Older builds only: `/cli-anything:cli-anything ./gimp`
 
 This runs the full pipeline:
 1. 🔍 **Analyze** — Scans source code, maps GUI actions to APIs

--- a/README_CN.md
+++ b/README_CN.md
@@ -93,8 +93,23 @@ CLI-Anything 以 Claude Code 插件市场的形式托管在 GitHub 上。
 # 为 GIMP 生成完整的 CLI（7 个阶段全自动）
 /cli-anything:cli-anything ./gimp
 
-# 注意：如果你的 Claude Code 版本低于 2.x，请使用 "/cli-anything"。
+# 兼容写法：也可以使用 /cli-anything ./gimp
 ```
+
+Claude Code 不同版本的命令兼容说明：
+- 优先使用 `/cli-anything` 作为主入口。
+- 如果报错 `Unknown skill: cli-anything`，请改用 `/cli-anything:cli-anything` 重试。
+- 其他辅助命令保持 `:子命令` 形式（例如 `/cli-anything:refine`）。
+
+如果仍然出现 `Unknown skill: cli-anything`：
+1. 重新加载插件命令：`/reload-plugins`
+2. 检查安装状态：`/plugin list`（确认存在 `cli-anything`）
+3. 重新安装市场插件：
+   - `/plugin marketplace add HKUDS/CLI-Anything`
+   - `/plugin install cli-anything`
+4. 依次重试两种入口：
+   - `/cli-anything ./gimp`
+   - `/cli-anything:cli-anything ./gimp`
 
 完整流水线自动执行：
 1. 🔍 **分析** — 扫描源码，将 GUI 操作映射到 API

--- a/README_CN.md
+++ b/README_CN.md
@@ -89,11 +89,12 @@ CLI-Anything 以 Claude Code 插件市场的形式托管在 GitHub 上。
 **第三步：一行命令生成 CLI**
 
 ```bash
-# /cli-anything:cli-anything <软件路径或仓库地址>
+# /cli-anything <软件路径或仓库地址>
 # 为 GIMP 生成完整的 CLI（7 个阶段全自动）
-/cli-anything:cli-anything ./gimp
+/cli-anything ./gimp
 
-# 兼容写法：也可以使用 /cli-anything ./gimp
+# 兼容写法（旧版本 Claude Code 可重试）
+# /cli-anything:cli-anything ./gimp
 ```
 
 Claude Code 不同版本的命令兼容说明：

--- a/README_CN.md
+++ b/README_CN.md
@@ -99,18 +99,18 @@ CLI-Anything 以 Claude Code 插件市场的形式托管在 GitHub 上。
 
 Claude Code 不同版本的命令兼容说明：
 - 优先使用 `/cli-anything` 作为主入口。
-- 如果报错 `Unknown skill: cli-anything`，请改用 `/cli-anything:cli-anything` 重试。
+- 在已**确认插件已安装并加载**的情况下，若旧版本的 Claude Code 不识别 `/cli-anything`，可尝试兼容写法 `/cli-anything:cli-anything`。
 - 其他辅助命令保持 `:子命令` 形式（例如 `/cli-anything:refine`）。
 
-如果仍然出现 `Unknown skill: cli-anything`：
+如果出现 `Unknown skill: cli-anything`，两种写法都引用同一个 skill 名称，切换写法无法解决，请优先排查插件是否已安装/加载：
 1. 重新加载插件命令：`/reload-plugins`
-2. 检查安装状态：`/plugin list`（确认存在 `cli-anything`）
-3. 重新安装市场插件：
+2. 验证插件是否已加载：`/help cli-anything`（能看到 CLI-Anything 帮助即表示已加载）
+3. 如仍未识别，重新从市场安装：
    - `/plugin marketplace add HKUDS/CLI-Anything`
    - `/plugin install cli-anything`
-4. 依次重试两种入口：
-   - `/cli-anything ./gimp`
-   - `/cli-anything:cli-anything ./gimp`
+4. 确认插件可用后，再重试入口命令：
+   - 推荐：`/cli-anything ./gimp`
+   - 仅旧版本：`/cli-anything:cli-anything ./gimp`
 
 完整流水线自动执行：
 1. 🔍 **分析** — 扫描源码，将 GUI 操作映射到 API


### PR DESCRIPTION
## Description

Document command compatibility and troubleshooting for `Unknown skill: cli-anything` when using Claude Code, including reload/reinstall verification flow in both EN and CN READMEs.

Fixes #19

## Type of Change

- [ ] **New Software CLI (in-repo)** — adds a CLI harness inside this monorepo
- [ ] **New Software CLI (standalone repo)** — registry-only PR pointing to an external repo
- [ ] **New Feature** — adds new functionality to an existing harness or the plugin
- [ ] **Bug Fix** — fixes incorrect behavior
- [x] **Documentation** — updates docs only
- [ ] **Other** — please describe:

---

### For New Software CLIs (in-repo)

- [ ] `<SOFTWARE>.md` SOP document exists at `<software>/agent-harness/<SOFTWARE>.md`
- [ ] Canonical `SKILL.md` exists at `skills/cli-anything-<software>/SKILL.md`
- [ ] Packaged compatibility `SKILL.md` exists at `cli_anything/<software>/skills/SKILL.md`
- [ ] Unit tests at `cli_anything/<software>/tests/test_core.py` are present and pass without backend
- [ ] E2E tests at `cli_anything/<software>/tests/test_full_e2e.py` are present
- [ ] `README.md` includes the new software (with link to harness directory)
- [ ] `registry.json` includes an entry with `source_url: null` (see [Contributing guide](CONTRIBUTING.md#registry-fields))
- [ ] `repl_skin.py` in `utils/` is an unmodified copy from the plugin

### For New Software CLIs (standalone repo)

- [ ] CLI is installable via `pip install <package-name>` or a `pip install git+https://...` URL
- [ ] `SKILL.md` exists in the external repo
- [ ] External repo has its own test suite
- [ ] `registry.json` entry includes `source_url` pointing to the external repo
- [ ] `registry.json` entry includes `skill_md` with full URL to the external SKILL.md
- [ ] `install_cmd` in `registry.json` works (tested locally)

### For Existing CLI Modifications

- [ ] All unit tests pass: `python3 -m pytest cli_anything/<software>/tests/test_core.py -v`
- [ ] All E2E tests pass: `python3 -m pytest cli_anything/<software>/tests/test_full_e2e.py -v`
- [ ] No test regressions — no previously passing tests were removed or weakened
- [ ] `registry.json` entry is updated if version, description, or requirements changed

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands
- [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
- [x] I have tested my changes locally

## Test Results

```bash
N/A (docs-only change)
```