### PR TITLE
feat: add quietshrink harness — Apple Silicon screen recording compressor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@
 !/unrealinsights/
 !/nsight-graphics/
 !/lldb/
+!/quietshrink/
 
 # Step 5: Inside each software dir, ignore everything (including dotfiles)
 /gimp/*
@@ -170,6 +171,8 @@
 /nsight-graphics/.*
 /lldb/*
 /lldb/.*
+/quietshrink/*
+/quietshrink/.*
 
 # Step 6: ...except agent-harness/
 !/gimp/agent-harness/
@@ -221,6 +224,7 @@
 !/unrealinsights/agent-harness/
 !/nsight-graphics/agent-harness/
 !/lldb/agent-harness/
+!/quietshrink/agent-harness/
 
 # Step 7: Ignore build artifacts within allowed dirs
 **/__pycache__/

--- a/quietshrink/agent-harness/QUIETSHRINK.md
+++ b/quietshrink/agent-harness/QUIETSHRINK.md
@@ -1,0 +1,57 @@
+# quietshrink Agent Harness
+
+Agent-native CLI for [quietshrink](https://github.com/achiya-automation/quietshrink) — compress macOS screen recordings on Apple Silicon with zero CPU stress, achieving 70-90% file size reduction at visually lossless quality.
+
+## What this harness does
+
+Wraps the standalone `quietshrink` bash CLI with a Python (click-based) interface that exposes structured JSON output for AI agents. Agents can:
+
+- **`compress`** a video file with quality presets (tiny / balanced / transparent / pristine)
+- **`probe`** a file before compressing to inspect codec, resolution, duration
+- **`presets`** list available quality profiles with empirical SSIM/size data
+- **`doctor`** verify that ffmpeg, hevc_videotoolbox, and the bash CLI are ready
+
+All commands accept `--json` for machine-readable output and exit with proper error codes.
+
+## Why agents care
+
+Screen recording compression is a frequent agent task: "compress this screencast before sharing", "make this file smaller", "convert recording.mov for email". The agent needs deterministic, predictable behavior:
+
+- Hardware encoding → stays under any budget; computer remains responsive  
+- Smart frame deduplication → exploits the static nature of screen content  
+- Long GOP + adaptive quantization → matches software-encoder size at hardware speed  
+- SSIM-validated quality presets → the agent can pick a preset based on the user's goal (sharing vs archiving)
+
+## Install
+
+```bash
+pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=quietshrink/agent-harness
+```
+
+The harness depends on the bash `quietshrink` CLI being available in `$PATH`. Install it with:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/achiya-automation/quietshrink/main/install.sh | bash
+```
+
+## Usage
+
+```bash
+# Inspect a file
+cli-anything-quietshrink probe recording.mov --json
+
+# Compress (default: transparent quality)
+cli-anything-quietshrink compress recording.mov compressed.mov --json
+
+# List quality presets
+cli-anything-quietshrink presets --json
+
+# Verify environment
+cli-anything-quietshrink doctor --json
+```
+
+## Source
+
+- Main repo: <https://github.com/achiya-automation/quietshrink>
+- Why this approach: <https://github.com/achiya-automation/quietshrink/blob/main/WHY.md>
+- License: MIT

--- a/quietshrink/agent-harness/QUIETSHRINK.md
+++ b/quietshrink/agent-harness/QUIETSHRINK.md
@@ -17,9 +17,9 @@ All commands accept `--json` for machine-readable output and exit with proper er
 
 Screen recording compression is a frequent agent task: "compress this screencast before sharing", "make this file smaller", "convert recording.mov for email". The agent needs deterministic, predictable behavior:
 
-- Hardware encoding → stays under any budget; computer remains responsive  
-- Smart frame deduplication → exploits the static nature of screen content  
-- Long GOP + adaptive quantization → matches software-encoder size at hardware speed  
+- Hardware encoding → stays under any budget; computer remains responsive
+- Smart frame deduplication → exploits the static nature of screen content
+- Long GOP + adaptive quantization → matches software-encoder size at hardware speed
 - SSIM-validated quality presets → the agent can pick a preset based on the user's goal (sharing vs archiving)
 
 ## Install

--- a/quietshrink/agent-harness/TEST.md
+++ b/quietshrink/agent-harness/TEST.md
@@ -1,0 +1,53 @@
+# quietshrink Agent Harness — Tests
+
+This is a thin wrapper around the standalone `quietshrink` bash CLI. The bash CLI itself has its own smoke test suite at <https://github.com/achiya-automation/quietshrink/blob/main/tests/test_cli.sh> with 6 passing tests verified in CI on macos-latest.
+
+## Smoke tests covered by upstream
+
+```
+test: --help
+  ✓ help shows USAGE section
+  ✓ help mentions tiny preset
+  ✓ help mentions transparent preset
+test: --version
+  ✓ version output mentions quietshrink
+test: missing input file
+  ✓ correctly errors on missing file
+test: invalid quality preset
+  ✓ correctly errors on invalid preset
+
+Results: 6 passed, 0 failed
+```
+
+CI: <https://github.com/achiya-automation/quietshrink/actions>
+
+## Harness-level integration
+
+The Python harness shells out to the bash CLI and re-emits its JSON output. Tests are intentionally minimal because:
+
+1. The encoding logic lives in the bash CLI, validated upstream.
+2. The harness's job is JSON conformance + agent ergonomics.
+3. End-to-end behavior is verified by running `cli-anything-quietshrink doctor --json` post-install.
+
+## Manual verification
+
+```bash
+# After install:
+cli-anything-quietshrink doctor --json
+# Expected: { "checks": [...], "ready": true }
+
+# Probe a real video:
+cli-anything-quietshrink probe ~/Desktop/some-recording.mov --json
+# Expected: codec, dimensions, duration, size
+
+# Compress:
+cli-anything-quietshrink compress input.mov output.mov --json
+# Expected: input_size, output_size, saved_percent, encoding_speed
+```
+
+## Hardware requirements
+
+- macOS Apple Silicon (M1/M2/M3/M4) — for hardware HEVC encoder
+- ffmpeg 6+ with `hevc_videotoolbox` enabled (`brew install ffmpeg`)
+
+Intel Macs and Linux work without hardware acceleration; the underlying ffmpeg falls back to `libx265` (software), which defeats the "quiet computer" promise but still produces correct output.

--- a/quietshrink/agent-harness/TEST.md
+++ b/quietshrink/agent-harness/TEST.md
@@ -1,8 +1,28 @@
 # quietshrink Agent Harness — Tests
 
-This is a thin wrapper around the standalone `quietshrink` bash CLI. The bash CLI itself has its own smoke test suite at <https://github.com/achiya-automation/quietshrink/blob/main/tests/test_cli.sh> with 6 passing tests verified in CI on macos-latest.
+## Harness unit tests (this repo)
 
-## Smoke tests covered by upstream
+The harness ships with 15 unit/smoke tests under `cli_anything/quietshrink/tests/test_cli.py`. They exercise the harness layer (command wiring, JSON output schema, error paths, subprocess interface) without invoking ffmpeg or the bash CLI.
+
+```bash
+pip install -e '.[dev]'
+pytest cli_anything/quietshrink/tests/ -v
+```
+
+Test groups:
+
+- `TestVersionAndHelp` — `--version`, `--help`, no-args behavior
+- `TestPresets` — text + JSON output, schema, all 4 presets present
+- `TestFindBashCli` — `$PATH` resolution, error when missing
+- `TestDoctor` — environment checks (ffmpeg, hevc_videotoolbox, bash CLI)
+- `TestProbe` — ffprobe wiring, missing file, metadata extraction
+- `TestCompress` — quality flag passthrough, JSON output, bash failure handling
+
+All 15 tests pass on Python 3.10+ with no external dependencies (bash CLI and ffmpeg are mocked).
+
+## Bash CLI tests (upstream)
+
+The encoding logic itself lives in the standalone quietshrink bash CLI, which has 6 smoke tests passing on macos-latest CI:
 
 ```
 test: --help
@@ -20,34 +40,29 @@ Results: 6 passed, 0 failed
 ```
 
 CI: <https://github.com/achiya-automation/quietshrink/actions>
+Test source: <https://github.com/achiya-automation/quietshrink/blob/main/tests/test_cli.sh>
 
-## Harness-level integration
+## Manual end-to-end verification
 
-The Python harness shells out to the bash CLI and re-emits its JSON output. Tests are intentionally minimal because:
-
-1. The encoding logic lives in the bash CLI, validated upstream.
-2. The harness's job is JSON conformance + agent ergonomics.
-3. End-to-end behavior is verified by running `cli-anything-quietshrink doctor --json` post-install.
-
-## Manual verification
+After installing both the harness (`pip install …`) and the bash CLI (`install.sh`):
 
 ```bash
-# After install:
+# Verify environment
 cli-anything-quietshrink doctor --json
 # Expected: { "checks": [...], "ready": true }
 
-# Probe a real video:
-cli-anything-quietshrink probe ~/Desktop/some-recording.mov --json
+# Probe a real video
+cli-anything-quietshrink probe ~/Desktop/recording.mov --json
 # Expected: codec, dimensions, duration, size
 
-# Compress:
+# Compress
 cli-anything-quietshrink compress input.mov output.mov --json
 # Expected: input_size, output_size, saved_percent, encoding_speed
 ```
 
-## Hardware requirements
+## Hardware requirements (compress only)
 
-- macOS Apple Silicon (M1/M2/M3/M4) — for hardware HEVC encoder
+- macOS Apple Silicon (M1/M2/M3/M4) — for the hardware HEVC encoder
 - ffmpeg 6+ with `hevc_videotoolbox` enabled (`brew install ffmpeg`)
 
-Intel Macs and Linux work without hardware acceleration; the underlying ffmpeg falls back to `libx265` (software), which defeats the "quiet computer" promise but still produces correct output.
+Intel Macs and Linux work without hardware acceleration; ffmpeg falls back to `libx265` (software), which defeats the "quiet computer" promise but still produces correct output.

--- a/quietshrink/agent-harness/cli_anything/quietshrink/README.md
+++ b/quietshrink/agent-harness/cli_anything/quietshrink/README.md
@@ -1,0 +1,30 @@
+# cli-anything-quietshrink
+
+Agent-native CLI harness for [quietshrink](https://github.com/achiya-automation/quietshrink).
+
+See [QUIETSHRINK.md](../../QUIETSHRINK.md) at the harness root for full documentation.
+
+## Quick reference
+
+```bash
+cli-anything-quietshrink compress <input> [output]   # Compress a video
+cli-anything-quietshrink probe <input>               # Inspect a file
+cli-anything-quietshrink presets                     # List quality presets
+cli-anything-quietshrink doctor                      # Verify environment
+```
+
+All commands accept `--json` for structured output.
+
+## Quality presets
+
+| Preset | q | Reduction | SSIM | Use case |
+|--------|---|-----------|------|----------|
+| tiny | 50 | ~90% | ~0.95 | chat / email |
+| balanced | 55 | ~88% | ~0.99 | docs / sharing |
+| transparent (default) | 60 | ~87% | ~0.99+ | visually lossless |
+| pristine | 70 | ~84% | ~0.997 | archival |
+
+## See also
+
+- Skill file for agents: [skills/SKILL.md](skills/SKILL.md)
+- Standalone CLI: <https://github.com/achiya-automation/quietshrink>

--- a/quietshrink/agent-harness/cli_anything/quietshrink/__init__.py
+++ b/quietshrink/agent-harness/cli_anything/quietshrink/__init__.py
@@ -1,0 +1,3 @@
+"""quietshrink — compress screen recordings on Apple Silicon."""
+
+__version__ = "1.0.0"

--- a/quietshrink/agent-harness/cli_anything/quietshrink/quietshrink_cli.py
+++ b/quietshrink/agent-harness/cli_anything/quietshrink/quietshrink_cli.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""quietshrink agent-native CLI — wraps the bash CLI with structured output."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from . import __version__
+
+# Find the bash CLI: prefer $PATH (installed), fall back to bundled (dev mode)
+PACKAGE_DIR = Path(__file__).parent
+# Walk up to project root (cli_anything/quietshrink → cli_anything → agent-harness → project_root)
+BUNDLED_BIN = PACKAGE_DIR.parent.parent.parent / "bin" / "quietshrink"
+
+
+def find_bash_cli() -> Path:
+    """Locate the quietshrink bash binary."""
+    in_path = shutil.which("quietshrink")
+    if in_path:
+        return Path(in_path)
+    if BUNDLED_BIN.exists():
+        return BUNDLED_BIN
+    raise click.ClickException(
+        "quietshrink bash CLI not found. Install via:\n"
+        "  curl -fsSL https://raw.githubusercontent.com/achiya-automation/quietshrink/main/install.sh | bash"
+    )
+
+
+def emit(data: dict, json_mode: bool) -> None:
+    """Emit data as JSON or pretty-printed."""
+    if json_mode:
+        click.echo(json.dumps(data, indent=2))
+    else:
+        for k, v in data.items():
+            click.echo(f"{k}: {v}")
+
+
+@click.group(invoke_without_command=True)
+@click.version_option(version=__version__, prog_name="cli-anything-quietshrink")
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """Agent-native CLI for quietshrink — Apple Silicon screen recording compressor.
+
+    Designed for AI agents (Claude Code, OpenClaw, Cursor) — every command supports
+    --json for machine-readable output and exits with proper error codes.
+    """
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@cli.command()
+@click.argument("input_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("output_path", type=click.Path(dir_okay=False, path_type=Path), required=False)
+@click.option(
+    "--quality", "-q",
+    type=click.Choice(["tiny", "balanced", "transparent", "pristine"]),
+    default="transparent",
+    help="Quality preset",
+)
+@click.option("--gop", "-g", type=int, default=600, help="GOP size")
+@click.option("--audio", "-a", default="96k", help="Audio bitrate")
+@click.option("--replace", is_flag=True, help="Replace input file with compressed version")
+@click.option("--json", "json_mode", is_flag=True, help="JSON output")
+def compress(
+    input_path: Path,
+    output_path: Optional[Path],
+    quality: str,
+    gop: int,
+    audio: str,
+    replace: bool,
+    json_mode: bool,
+) -> None:
+    """Compress a video file. Returns size statistics."""
+    bash_cli = find_bash_cli()
+    args = [
+        str(bash_cli),
+        "--quality", quality,
+        "--gop", str(gop),
+        "--audio", audio,
+        "--json",
+    ]
+    if replace:
+        args.append("--replace")
+    args.append(str(input_path))
+    if output_path:
+        args.append(str(output_path))
+
+    try:
+        result = subprocess.run(args, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        emit({"error": "compression_failed", "stderr": e.stderr.strip()}, json_mode)
+        sys.exit(1)
+
+    try:
+        data = json.loads(result.stdout)
+        emit(data, json_mode)
+    except json.JSONDecodeError as e:
+        emit({"error": "invalid_output", "raw": result.stdout, "detail": str(e)}, json_mode)
+        sys.exit(1)
+
+
+@cli.command()
+@click.argument("input_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--json", "json_mode", is_flag=True, help="JSON output")
+def probe(input_path: Path, json_mode: bool) -> None:
+    """Inspect a video file before compression. Returns codec, resolution, duration, size."""
+    if not shutil.which("ffprobe"):
+        emit({"error": "ffprobe not found", "hint": "brew install ffmpeg"}, json_mode)
+        sys.exit(2)
+
+    cmd = [
+        "ffprobe", "-v", "error",
+        "-show_entries", "stream=codec_name,width,height,r_frame_rate",
+        "-show_entries", "format=duration,bit_rate,size",
+        "-of", "json",
+        str(input_path),
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        probe_data = json.loads(result.stdout)
+        size = input_path.stat().st_size
+        video_stream = next((s for s in probe_data.get("streams", []) if s.get("codec_name") not in ("aac", "mp3")), {})
+        duration = float(probe_data.get("format", {}).get("duration", 0))
+
+        info = {
+            "path": str(input_path),
+            "size_bytes": size,
+            "size_mb": round(size / 1024 / 1024, 2),
+            "codec": video_stream.get("codec_name"),
+            "width": video_stream.get("width"),
+            "height": video_stream.get("height"),
+            "framerate": video_stream.get("r_frame_rate"),
+            "duration_seconds": round(duration, 2),
+        }
+        emit(info, json_mode)
+    except subprocess.CalledProcessError as e:
+        emit({"error": "probe_failed", "stderr": e.stderr.strip()}, json_mode)
+        sys.exit(1)
+
+
+@cli.command()
+@click.option("--json", "json_mode", is_flag=True, help="JSON output")
+def presets(json_mode: bool) -> None:
+    """List available quality presets with their characteristics."""
+    presets_data = [
+        {"name": "tiny",        "q_value": 50, "typical_reduction": "~90%", "ssim": "~0.95",  "use_case": "chat / email"},
+        {"name": "balanced",    "q_value": 55, "typical_reduction": "~88%", "ssim": "~0.99",  "use_case": "docs / sharing"},
+        {"name": "transparent", "q_value": 60, "typical_reduction": "~87%", "ssim": "~0.99+", "use_case": "default — visually lossless"},
+        {"name": "pristine",    "q_value": 70, "typical_reduction": "~84%", "ssim": "~0.997", "use_case": "archival / editing"},
+    ]
+    if json_mode:
+        click.echo(json.dumps({"presets": presets_data}, indent=2))
+    else:
+        for p in presets_data:
+            click.echo(f"  {p['name']:<13} q={p['q_value']:<3} {p['typical_reduction']:<6} ssim={p['ssim']:<8} — {p['use_case']}")
+
+
+@cli.command()
+@click.option("--json", "json_mode", is_flag=True, help="JSON output")
+def doctor(json_mode: bool) -> None:
+    """Verify environment is set up correctly."""
+    checks = []
+
+    # Check ffmpeg
+    ffmpeg = shutil.which("ffmpeg")
+    checks.append({"check": "ffmpeg installed", "ok": bool(ffmpeg), "path": ffmpeg or "not found"})
+
+    # Check hevc_videotoolbox
+    if ffmpeg:
+        try:
+            result = subprocess.run(
+                [ffmpeg, "-hide_banner", "-encoders"],
+                capture_output=True, text=True, check=True,
+            )
+            has_vt = "hevc_videotoolbox" in result.stdout
+            checks.append({"check": "hevc_videotoolbox available", "ok": has_vt})
+        except subprocess.CalledProcessError:
+            checks.append({"check": "hevc_videotoolbox available", "ok": False})
+
+    # Check bash CLI
+    try:
+        find_bash_cli()
+        checks.append({"check": "quietshrink bash CLI", "ok": True})
+    except click.ClickException:
+        checks.append({"check": "quietshrink bash CLI", "ok": False})
+
+    # Platform check
+    import platform
+    is_arm_mac = platform.system() == "Darwin" and platform.machine() == "arm64"
+    checks.append({"check": "Apple Silicon Mac", "ok": is_arm_mac})
+
+    all_ok = all(c["ok"] for c in checks)
+
+    if json_mode:
+        click.echo(json.dumps({"checks": checks, "ready": all_ok}, indent=2))
+    else:
+        for c in checks:
+            mark = "✓" if c["ok"] else "✗"
+            click.echo(f"  {mark} {c['check']}")
+        click.echo()
+        click.echo("Ready" if all_ok else "Setup incomplete")
+    sys.exit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/quietshrink/agent-harness/cli_anything/quietshrink/quietshrink_cli.py
+++ b/quietshrink/agent-harness/cli_anything/quietshrink/quietshrink_cli.py
@@ -14,22 +14,20 @@ import click
 
 from . import __version__
 
-# Find the bash CLI: prefer $PATH (installed), fall back to bundled (dev mode)
-PACKAGE_DIR = Path(__file__).parent
-# Walk up to project root (cli_anything/quietshrink → cli_anything → agent-harness → project_root)
-BUNDLED_BIN = PACKAGE_DIR.parent.parent.parent / "bin" / "quietshrink"
-
 
 def find_bash_cli() -> Path:
-    """Locate the quietshrink bash binary."""
+    """Locate the quietshrink bash binary on $PATH.
+
+    The harness is a thin Python wrapper around the standalone quietshrink bash
+    CLI, which must be installed separately. See QUIETSHRINK.md for install.
+    """
     in_path = shutil.which("quietshrink")
     if in_path:
         return Path(in_path)
-    if BUNDLED_BIN.exists():
-        return BUNDLED_BIN
     raise click.ClickException(
-        "quietshrink bash CLI not found. Install via:\n"
-        "  curl -fsSL https://raw.githubusercontent.com/achiya-automation/quietshrink/main/install.sh | bash"
+        "quietshrink bash CLI not found on $PATH. Install it with:\n"
+        "  curl -fsSL https://raw.githubusercontent.com/achiya-automation/quietshrink/main/install.sh | bash\n"
+        "Or download a release from https://github.com/achiya-automation/quietshrink/releases"
     )
 
 

--- a/quietshrink/agent-harness/cli_anything/quietshrink/skills/SKILL.md
+++ b/quietshrink/agent-harness/cli_anything/quietshrink/skills/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: quietshrink
+description: Compress macOS screen recordings with zero CPU stress using Apple Silicon's hardware HEVC encoder. Typically reduces file size 70-90% while staying visually lossless. Computer stays silent during encoding.
+---
+
+# quietshrink — Agent Skill
+
+You have access to `cli-anything-quietshrink`, a CLI for compressing video files on macOS Apple Silicon. It uses the Media Engine (hardware HEVC encoder), not the CPU, so encoding is fast and silent.
+
+## When to use it
+
+- User wants to compress a screen recording, screencast, or any .mov/.mp4 file
+- File is too large to share (chat, email, GitHub)
+- Need smaller files but cannot tolerate visible quality loss
+- Apple Silicon Mac (M1/M2/M3/M4) — best results
+
+**Don't** use this on non-screen content (camera footage, vlogs) — savings will be much smaller because there are no duplicate frames to drop.
+
+## Commands
+
+```bash
+# Compress with default transparent quality
+cli-anything-quietshrink compress <input> [output]
+
+# Compress with specific preset
+cli-anything-quietshrink compress -q tiny <input>     # smallest
+cli-anything-quietshrink compress -q transparent <input>  # default, visually lossless
+cli-anything-quietshrink compress -q pristine <input>     # near-source quality
+
+# Inspect a file before compressing
+cli-anything-quietshrink probe <input>
+
+# List quality presets
+cli-anything-quietshrink presets
+
+# Verify environment
+cli-anything-quietshrink doctor
+```
+
+All commands accept `--json` for machine-readable output.
+
+## Quality presets
+
+| Preset | q | Typical reduction | SSIM | Use case |
+|--------|---|-------------------|------|----------|
+| `tiny` | 50 | ~90% | ~0.95 | Chat/email — small artifacts OK |
+| `balanced` | 55 | ~88% | ~0.99 | Docs/sharing — high quality |
+| `transparent` (default) | 60 | ~87% | ~0.99+ | **Anything important** — visually lossless |
+| `pristine` | 70 | ~84% | ~0.997 | Archival — near-source |
+
+## JSON output schema
+
+`compress` returns:
+```json
+{
+  "input": "/path/to/input.mov",
+  "output": "/path/to/output.mov",
+  "input_size": 105952129,
+  "output_size": 12345678,
+  "saved_bytes": 93606451,
+  "saved_percent": 88.3,
+  "duration_seconds": 193.3,
+  "elapsed_seconds": 87,
+  "encoding_speed": "2.2x",
+  "quality_preset": "transparent",
+  "q_value": 60,
+  "gop": 600
+}
+```
+
+`probe` returns:
+```json
+{
+  "path": "...",
+  "size_bytes": 105952129,
+  "size_mb": 101.04,
+  "codec": "h264",
+  "width": 3024,
+  "height": 1964,
+  "framerate": "120/1",
+  "duration_seconds": 193.31
+}
+```
+
+## Decision flow for agents
+
+```
+User wants to share a recording
+  ├─ Is it on Apple Silicon Mac? → use quietshrink
+  │  ├─ For chat/email/quick share → -q tiny
+  │  ├─ For docs/important sharing → -q transparent (default)
+  │  └─ For archival/editing → -q pristine
+  └─ Not on Mac? → falls back to software, less efficient
+```
+
+Before processing, run `doctor` to verify environment.
+For unfamiliar files, run `probe` to understand resolution/codec/duration.
+
+## Errors and recovery
+
+- `ffmpeg not found` → `brew install ffmpeg`
+- `hevc_videotoolbox not available` → `brew reinstall ffmpeg`
+- `compression_failed` → check input file isn't corrupted; try `--verbose` mode to see ffmpeg errors
+
+## Source
+
+- Main repo: https://github.com/achiya-automation/quietshrink
+- Bash CLI: `quietshrink` command (via the install script)
+- Why this approach works: see [WHY.md](https://github.com/achiya-automation/quietshrink/blob/main/WHY.md)

--- a/quietshrink/agent-harness/cli_anything/quietshrink/tests/test_cli.py
+++ b/quietshrink/agent-harness/cli_anything/quietshrink/tests/test_cli.py
@@ -1,0 +1,212 @@
+"""Smoke tests for the cli-anything-quietshrink harness.
+
+The harness is a thin Python wrapper around the standalone quietshrink bash
+CLI. The bash CLI itself is tested upstream
+(https://github.com/achiya-automation/quietshrink/blob/main/tests/test_cli.sh).
+
+These tests exercise the harness layer: command wiring, JSON output schema,
+error paths, and the subprocess interface — all without invoking ffmpeg.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from cli_anything.quietshrink import __version__
+from cli_anything.quietshrink.quietshrink_cli import cli, find_bash_cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestVersionAndHelp:
+    def test_version_flag(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert __version__ in result.output
+
+    def test_help_lists_all_subcommands(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        for subcommand in ("compress", "probe", "presets", "doctor"):
+            assert subcommand in result.output
+
+    def test_no_args_shows_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, [])
+        assert result.exit_code == 0
+        assert "Usage" in result.output or "usage" in result.output
+
+
+class TestPresets:
+    def test_presets_text_output(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["presets"])
+        assert result.exit_code == 0
+        for name in ("tiny", "balanced", "transparent", "pristine"):
+            assert name in result.output
+
+    def test_presets_json_schema(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["presets", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "presets" in data
+        assert len(data["presets"]) == 4
+
+        names = {p["name"] for p in data["presets"]}
+        assert names == {"tiny", "balanced", "transparent", "pristine"}
+
+        for preset in data["presets"]:
+            assert {"name", "q_value", "typical_reduction", "ssim", "use_case"} <= preset.keys()
+            assert isinstance(preset["q_value"], int)
+
+
+class TestFindBashCli:
+    def test_uses_path_when_available(self, tmp_path: Path) -> None:
+        fake_bin = tmp_path / "quietshrink"
+        fake_bin.write_text("#!/bin/bash\necho fake")
+        fake_bin.chmod(0o755)
+
+        with patch("shutil.which", return_value=str(fake_bin)):
+            assert find_bash_cli() == fake_bin
+
+    def test_raises_when_missing(self) -> None:
+        from click import ClickException
+
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(ClickException) as exc_info:
+                find_bash_cli()
+            assert "not found" in str(exc_info.value.message).lower()
+            assert "install" in str(exc_info.value.message).lower()
+
+
+class TestDoctor:
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_doctor_all_ok_json(self, mock_run: MagicMock, mock_which: MagicMock, runner: CliRunner) -> None:
+        mock_which.side_effect = lambda name: f"/usr/local/bin/{name}"
+        mock_run.return_value = MagicMock(returncode=0, stdout="hevc_videotoolbox", stderr="")
+
+        result = runner.invoke(cli, ["doctor", "--json"])
+        data = json.loads(result.output)
+        assert "checks" in data
+        assert "ready" in data
+        assert isinstance(data["ready"], bool)
+
+    @patch("shutil.which", return_value=None)
+    def test_doctor_no_ffmpeg_json(self, _mock_which: MagicMock, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["doctor", "--json"])
+        data = json.loads(result.output)
+        assert data["ready"] is False
+        ffmpeg_check = next(c for c in data["checks"] if c["check"] == "ffmpeg installed")
+        assert ffmpeg_check["ok"] is False
+
+
+class TestProbe:
+    @patch("shutil.which", return_value=None)
+    def test_probe_no_ffprobe(self, _mock_which: MagicMock, runner: CliRunner, tmp_path: Path) -> None:
+        sample = tmp_path / "sample.mov"
+        sample.write_bytes(b"fake-mov-data")
+
+        result = runner.invoke(cli, ["probe", str(sample), "--json"])
+        assert result.exit_code == 2
+        data = json.loads(result.output)
+        assert "error" in data
+        assert "ffprobe" in data["error"]
+
+    @patch("shutil.which", return_value="/usr/local/bin/ffprobe")
+    @patch("subprocess.run")
+    def test_probe_returns_metadata(
+        self, mock_run: MagicMock, _mock_which: MagicMock, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        sample = tmp_path / "rec.mov"
+        sample.write_bytes(b"x" * 1024)
+
+        ffprobe_output = {
+            "streams": [{"codec_name": "h264", "width": 1920, "height": 1080, "r_frame_rate": "60/1"}],
+            "format": {"duration": "12.5", "bit_rate": "5000000", "size": "1024"},
+        }
+        mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(ffprobe_output), stderr="")
+
+        result = runner.invoke(cli, ["probe", str(sample), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["codec"] == "h264"
+        assert data["width"] == 1920
+        assert data["height"] == 1080
+        assert data["duration_seconds"] == 12.5
+        assert data["size_bytes"] == 1024
+
+    def test_probe_missing_file_errors(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["probe", "/does/not/exist.mov"])
+        assert result.exit_code != 0
+
+
+class TestCompress:
+    @patch("cli_anything.quietshrink.quietshrink_cli.find_bash_cli")
+    @patch("subprocess.run")
+    def test_compress_emits_bash_json(
+        self, mock_run: MagicMock, mock_find: MagicMock, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        mock_find.return_value = Path("/fake/quietshrink")
+        sample = tmp_path / "rec.mov"
+        sample.write_bytes(b"x" * 1024)
+
+        bash_response = {
+            "input": str(sample),
+            "output": str(tmp_path / "out.mov"),
+            "input_size": 1024,
+            "output_size": 256,
+            "saved_percent": 75.0,
+            "quality_preset": "transparent",
+            "q_value": 60,
+        }
+        mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(bash_response), stderr="")
+
+        result = runner.invoke(cli, ["compress", str(sample), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["quality_preset"] == "transparent"
+        assert data["saved_percent"] == 75.0
+
+    @patch("cli_anything.quietshrink.quietshrink_cli.find_bash_cli")
+    @patch("subprocess.run")
+    def test_compress_passes_quality_flag(
+        self, mock_run: MagicMock, mock_find: MagicMock, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        mock_find.return_value = Path("/fake/quietshrink")
+        sample = tmp_path / "rec.mov"
+        sample.write_bytes(b"x")
+
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"saved_percent": 90}', stderr="")
+
+        result = runner.invoke(cli, ["compress", str(sample), "-q", "tiny", "--json"])
+        assert result.exit_code == 0
+        invoked_args = mock_run.call_args[0][0]
+        assert "--quality" in invoked_args
+        assert "tiny" in invoked_args
+
+    @patch("cli_anything.quietshrink.quietshrink_cli.find_bash_cli")
+    @patch("subprocess.run")
+    def test_compress_handles_bash_failure(
+        self, mock_run: MagicMock, mock_find: MagicMock, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        mock_find.return_value = Path("/fake/quietshrink")
+        sample = tmp_path / "rec.mov"
+        sample.write_bytes(b"x")
+
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, ["quietshrink"], stderr="ffmpeg crashed",
+        )
+
+        result = runner.invoke(cli, ["compress", str(sample), "--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["error"] == "compression_failed"
+        assert "ffmpeg crashed" in data["stderr"]

--- a/quietshrink/agent-harness/setup.py
+++ b/quietshrink/agent-harness/setup.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Setup for cli-anything-quietshrink agent harness."""
+
+from setuptools import setup, find_namespace_packages
+from pathlib import Path
+
+readme = Path(__file__).parent / "README.md"
+long_description = readme.read_text(encoding="utf-8") if readme.exists() else ""
+
+setup(
+    name="cli-anything-quietshrink",
+    version="1.0.0",
+    author="quietshrink contributors",
+    description=(
+        "Agent-native CLI harness for quietshrink — compress screen recordings "
+        "with zero CPU stress on Apple Silicon. JSON output, structured probes, "
+        "skill-aware help."
+    ),
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/achiya-automation/quietshrink",
+    packages=find_namespace_packages(include=["cli_anything.*"]),
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Topic :: Multimedia :: Video",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Operating System :: MacOS :: MacOS X",
+    ],
+    python_requires=">=3.10",
+    install_requires=[
+        "click>=8.0.0",
+    ],
+    extras_require={
+        "dev": ["pytest>=7.0.0"],
+    },
+    entry_points={
+        "console_scripts": [
+            "cli-anything-quietshrink=cli_anything.quietshrink.quietshrink_cli:cli",
+        ],
+    },
+    package_data={
+        "cli_anything.quietshrink": ["skills/*.md"],
+    },
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/quietshrink/agent-harness/setup.py
+++ b/quietshrink/agent-harness/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_namespace_packages
 from pathlib import Path
 
-readme = Path(__file__).parent / "README.md"
+readme = Path(__file__).parent / "QUIETSHRINK.md"
 long_description = readme.read_text(encoding="utf-8") if readme.exists() else ""
 
 setup(
@@ -45,6 +45,9 @@ setup(
     },
     package_data={
         "cli_anything.quietshrink": ["skills/*.md"],
+    },
+    exclude_package_data={
+        "cli_anything.quietshrink": ["tests/*"],
     },
     include_package_data=True,
     zip_safe=False,

--- a/registry.json
+++ b/registry.json
@@ -2,25 +2,25 @@
   "meta": {
     "repo": "https://github.com/HKUDS/CLI-Anything",
     "description": "CLI-Hub — Agent-native stateful CLI interfaces for softwares, codebases, and Web Services",
-    "updated": "2026-04-16"
+    "updated": "2026-04-26"
   },
   "clis": [
     {
-      "name": "wiremock",
-      "display_name": "WireMock",
-      "version": "0.1.0",
-      "description": "HTTP mock server management — create stubs, inspect requests, record traffic, and manage scenarios via WireMock REST API",
-      "requires": "WireMock server running (java -jar wiremock-standalone.jar)",
-      "homepage": "https://wiremock.org",
+      "name": "adguardhome",
+      "display_name": "AdGuardHome",
+      "version": "1.0.0",
+      "description": "DNS ad-blocking and network infrastructure management via AdGuardHome REST API",
+      "requires": "AdGuardHome instance running",
+      "homepage": "https://adguard.com/adguard-home/overview.html",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=wiremock/agent-harness",
-      "entry_point": "cli-anything-wiremock",
-      "skill_md": "skills/cli-anything-wiremock/SKILL.md",
-      "category": "testing",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=adguardhome/agent-harness",
+      "entry_point": "cli-anything-adguardhome",
+      "skill_md": null,
+      "category": "network",
       "contributors": [
         {
-          "name": "fabiomantel",
-          "url": "https://github.com/fabiomantel"
+          "name": "pyxl-dev",
+          "url": "https://github.com/pyxl-dev"
         }
       ]
     },
@@ -40,25 +40,6 @@
         {
           "name": "koltyu-anygen",
           "url": "https://github.com/koltyu-anygen"
-        }
-      ]
-    },
-    {
-      "name": "adguardhome",
-      "display_name": "AdGuardHome",
-      "version": "1.0.0",
-      "description": "DNS ad-blocking and network infrastructure management via AdGuardHome REST API",
-      "requires": "AdGuardHome instance running",
-      "homepage": "https://adguard.com/adguard-home/overview.html",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=adguardhome/agent-harness",
-      "entry_point": "cli-anything-adguardhome",
-      "skill_md": null,
-      "category": "network",
-      "contributors": [
-        {
-          "name": "pyxl-dev",
-          "url": "https://github.com/pyxl-dev"
         }
       ]
     },
@@ -120,6 +101,82 @@
       ]
     },
     {
+      "name": "chromadb",
+      "display_name": "ChromaDB",
+      "version": "1.0.0",
+      "description": "Vector database operations — collections, documents, semantic search via ChromaDB HTTP API",
+      "requires": "ChromaDB server running at localhost:8000",
+      "homepage": "https://www.trychroma.com",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=chromadb/agent-harness",
+      "entry_point": "cli-anything-chromadb",
+      "skill_md": "skills/cli-anything-chromadb/SKILL.md",
+      "category": "database",
+      "contributors": [
+        {
+          "name": "t4tarzan",
+          "url": "https://github.com/t4tarzan"
+        }
+      ]
+    },
+    {
+      "name": "clibrowser",
+      "display_name": "clibrowser",
+      "version": "0.1.0",
+      "description": "Zero-dependency CLI browser for AI agents with search, extraction, forms, RSS, crawling, auth, and WebMCP support",
+      "requires": "Rust toolchain (cargo) for source install, or manual binary download from GitHub Releases",
+      "homepage": "https://github.com/allthingssecurity/clibrowser",
+      "source_url": null,
+      "install_cmd": "cargo install --git https://github.com/allthingssecurity/clibrowser.git --tag v0.1.0 --locked",
+      "entry_point": "clibrowser",
+      "skill_md": null,
+      "category": "web",
+      "contributors": [
+        {
+          "name": "allthingssecurity",
+          "url": "https://github.com/allthingssecurity"
+        }
+      ]
+    },
+    {
+      "name": "cloudanalyzer",
+      "display_name": "CloudAnalyzer",
+      "version": "1.0.0",
+      "description": "Point cloud and trajectory QA: Chamfer/AUC/F1, ATE/RPE/drift, ground segmentation metrics, config-driven quality gates, baseline evolution — harness wraps the CloudAnalyzer Python API",
+      "requires": "Python 3.10+; cloudanalyzer (`pip install cloudanalyzer`), Open3D for full IO/viewer paths",
+      "homepage": "https://github.com/rsasaki0109/CloudAnalyzer",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=cloudanalyzer/agent-harness",
+      "entry_point": "cli-anything-cloudanalyzer",
+      "skill_md": "skills/cli-anything-cloudanalyzer/SKILL.md",
+      "category": "graphics",
+      "contributors": [
+        {
+          "name": "rsasaki0109",
+          "url": "https://github.com/rsasaki0109"
+        }
+      ]
+    },
+    {
+      "name": "cloudcompare",
+      "display_name": "CloudCompare",
+      "version": "1.0.0",
+      "description": "3D point cloud and mesh processing: load/save, color ops, normal estimation, Delaunay meshing, noise filtering, ICP registration, connected component segmentation",
+      "requires": "cloudcompare (CloudCompare application installed, e.g. via Flatpak or package manager)",
+      "homepage": "https://cloudcompare.org",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=cloudcompare/agent-harness",
+      "entry_point": "cli-anything-cloudcompare",
+      "skill_md": "skills/cli-anything-cloudcompare/SKILL.md",
+      "category": "graphics",
+      "contributors": [
+        {
+          "name": "Taeyoung96",
+          "url": "https://github.com/Taeyoung96"
+        }
+      ]
+    },
+    {
       "name": "comfyui",
       "display_name": "ComfyUI",
       "version": "1.0.0",
@@ -135,6 +192,25 @@
         {
           "name": "Bortlesboat",
           "url": "https://github.com/Bortlesboat"
+        }
+      ]
+    },
+    {
+      "name": "dify-workflow",
+      "display_name": "Dify Workflow",
+      "version": "0.1.0",
+      "description": "CLI-Anything wrapper for the Dify workflow DSL editor covering create, inspect, validate, edit, export, and layout operations",
+      "requires": "Upstream dify-workflow CLI installed from https://github.com/Akabane71/dify-workflow-cli",
+      "homepage": "https://github.com/Akabane71/dify-workflow-cli",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=dify-workflow/agent-harness",
+      "entry_point": "cli-anything-dify-workflow",
+      "skill_md": "skills/cli-anything-dify-workflow/SKILL.md",
+      "category": "ai",
+      "contributors": [
+        {
+          "name": "Akabane71",
+          "url": "https://github.com/Akabane71"
         }
       ]
     },
@@ -177,6 +253,44 @@
       ]
     },
     {
+      "name": "exa",
+      "display_name": "Exa",
+      "version": "1.0.0",
+      "description": "AI-powered web search and content extraction via the Exa API",
+      "requires": "EXA_API_KEY (free tier at exa.ai)",
+      "homepage": "https://exa.ai",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=exa/agent-harness",
+      "entry_point": "cli-anything-exa",
+      "skill_md": "skills/cli-anything-exa/SKILL.md",
+      "category": "search",
+      "contributors": [
+        {
+          "name": "tgonzalezc5",
+          "url": "https://github.com/tgonzalezc5"
+        }
+      ]
+    },
+    {
+      "name": "freecad",
+      "display_name": "FreeCAD",
+      "version": "1.1.0",
+      "description": "Parametric 3D CAD modeling via FreeCAD CLI (258 commands: Part, Sketcher, PartDesign, Assembly, Mesh, TechDraw, Draft, FEM, CAM, and more)",
+      "requires": "FreeCAD >= 1.1 (freecad.org)",
+      "homepage": "https://www.freecad.org",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=freecad/agent-harness",
+      "entry_point": "cli-anything-freecad",
+      "skill_md": "skills/cli-anything-freecad/SKILL.md",
+      "category": "3d",
+      "contributors": [
+        {
+          "name": "AlexGabbia",
+          "url": "https://github.com/AlexGabbia"
+        }
+      ]
+    },
+    {
       "name": "gimp",
       "display_name": "GIMP",
       "version": "1.0.0",
@@ -196,6 +310,25 @@
       ]
     },
     {
+      "name": "godot",
+      "display_name": "Godot Engine",
+      "version": "1.0.0",
+      "description": "Game engine project management, scene editing, export and GDScript execution via Godot 4 headless mode",
+      "requires": "Godot 4.x (godotengine.org)",
+      "homepage": "https://godotengine.org",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=godot/agent-harness",
+      "entry_point": "cli-anything-godot",
+      "skill_md": "skills/cli-anything-godot/SKILL.md",
+      "category": "gamedev",
+      "contributors": [
+        {
+          "name": "omerarslan0",
+          "url": "https://github.com/omerarslan0"
+        }
+      ]
+    },
+    {
       "name": "inkscape",
       "display_name": "Inkscape",
       "version": "1.0.0",
@@ -211,6 +344,44 @@
         {
           "name": "CLI-Anything-Team",
           "url": "https://github.com/HKUDS/CLI-Anything"
+        }
+      ]
+    },
+    {
+      "name": "intelwatch",
+      "display_name": "Intelwatch",
+      "version": "1.0.0",
+      "description": "Competitive intelligence, M&A due diligence, and OSINT directly from your terminal.",
+      "requires": "Node.js >=18",
+      "homepage": "https://github.com/ashroth/intelwatch",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=intelwatch/agent-harness",
+      "entry_point": "cli-anything-intelwatch",
+      "skill_md": "skills/cli-anything-intelwatch/SKILL.md",
+      "category": "osint",
+      "contributors": [
+        {
+          "name": "ashroth",
+          "url": "https://github.com/ashroth"
+        }
+      ]
+    },
+    {
+      "name": "iterm2",
+      "display_name": "iTerm2",
+      "version": "1.0.0",
+      "description": "Control a running iTerm2 instance — manage windows, tabs, split panes, send text, read output, run tmux -CC, broadcast keystrokes, and configure preferences.",
+      "requires": "iTerm2.app (macOS only)",
+      "homepage": "https://iterm2.com",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=iterm2/agent-harness",
+      "entry_point": "cli-anything-iterm2",
+      "skill_md": "skills/cli-anything-iterm2/SKILL.md",
+      "category": "devops",
+      "contributors": [
+        {
+          "name": "voidfreud",
+          "url": "https://github.com/voidfreud"
         }
       ]
     },
@@ -291,25 +462,21 @@
       ]
     },
     {
-      "name": "zotero",
-      "display_name": "Zotero",
-      "version": "0.4.1",
-      "description": "CLI & MCP server for Zotero 7/8 — 52 MCP tools + 70+ CLI commands for search, import, PDF, BibTeX, notes, and more",
-      "requires": "Zotero 7/8 desktop app (running), Python 3.10+",
-      "homepage": "https://www.zotero.org",
-      "source_url": "https://github.com/PiaoyangGuohai1/cli-anything-zotero",
-      "install_cmd": "pip install cli-anything-zotero",
-      "entry_point": "cli-anything-zotero",
-      "skill_md": "https://github.com/PiaoyangGuohai1/cli-anything-zotero/blob/main/cli_anything/zotero/skills/SKILL.md",
-      "category": "office",
+      "name": "mermaid",
+      "display_name": "Mermaid",
+      "version": "1.0.0",
+      "description": "Mermaid Live Editor state files and renderer URLs",
+      "requires": null,
+      "homepage": "https://mermaid.js.org",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=mermaid/agent-harness",
+      "entry_point": "cli-anything-mermaid",
+      "skill_md": null,
+      "category": "diagrams",
       "contributors": [
         {
-          "name": "zhiwuyazhe_fjr",
-          "url": "https://github.com/zhiwuyazhe-fjr"
-        },
-        {
-          "name": "PiaoyangGuohai1",
-          "url": "https://github.com/PiaoyangGuohai1"
+          "name": "getmored-create",
+          "url": "https://github.com/getmored-create"
         }
       ]
     },
@@ -333,21 +500,40 @@
       ]
     },
     {
-      "name": "mermaid",
-      "display_name": "Mermaid",
+      "name": "musescore",
+      "display_name": "MuseScore",
       "version": "1.0.0",
-      "description": "Mermaid Live Editor state files and renderer URLs",
-      "requires": null,
-      "homepage": "https://mermaid.js.org",
+      "description": "CLI for music notation — transpose, export PDF/audio/MIDI, extract parts, manage instruments",
+      "requires": "MuseScore 4 (musescore.org)",
+      "homepage": "https://musescore.org",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=mermaid/agent-harness",
-      "entry_point": "cli-anything-mermaid",
-      "skill_md": null,
-      "category": "diagrams",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=musescore/agent-harness",
+      "entry_point": "cli-anything-musescore",
+      "skill_md": "skills/cli-anything-musescore/SKILL.md",
+      "category": "music",
       "contributors": [
         {
-          "name": "getmored-create",
-          "url": "https://github.com/getmored-create"
+          "name": "tamvicky",
+          "url": "https://github.com/tamvicky"
+        }
+      ]
+    },
+    {
+      "name": "n8n",
+      "display_name": "n8n",
+      "version": "2.4.7",
+      "description": "Workflow automation via n8n REST API — 55+ commands",
+      "requires": "n8n >= 1.0.0",
+      "homepage": "https://n8n.io",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=n8n/agent-harness",
+      "entry_point": "cli-anything-n8n",
+      "skill_md": "skills/cli-anything-n8n/SKILL.md",
+      "category": "automation",
+      "contributors": [
+        {
+          "name": "webcomunicasolutions",
+          "url": "https://github.com/webcomunicasolutions"
         }
       ]
     },
@@ -371,21 +557,40 @@
       ]
     },
     {
-      "name": "ollama",
-      "display_name": "Ollama",
-      "version": "1.0.1",
-      "description": "Local LLM inference and model management via Ollama REST API",
-      "requires": "Ollama running at http://localhost:11434",
-      "homepage": "https://ollama.com",
+      "name": "novita",
+      "display_name": "Novita",
+      "version": "1.0.0",
+      "description": "Access AI models via Novita's OpenAI-compatible API (DeepSeek, GLM, MiniMax)",
+      "requires": "NOVITA_API_KEY",
+      "homepage": "https://novita.ai",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=ollama/agent-harness",
-      "entry_point": "cli-anything-ollama",
-      "skill_md": "skills/cli-anything-ollama/SKILL.md",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=novita/agent-harness",
+      "entry_point": "cli-anything-novita",
+      "skill_md": "skills/cli-anything-novita/SKILL.md",
       "category": "ai",
       "contributors": [
         {
-          "name": "CLI-Anything-Team",
-          "url": "https://github.com/HKUDS/CLI-Anything"
+          "name": "Alex-wuhu",
+          "url": "https://github.com/Alex-wuhu"
+        }
+      ]
+    },
+    {
+      "name": "nsight-graphics",
+      "display_name": "Nsight Graphics CLI",
+      "version": "0.1.0",
+      "description": "Windows-first Nsight Graphics CLI for Graphics/Frame capture, GPU Trace, Generate C++ Capture, and one-step GPU Trace summary",
+      "requires": "NVIDIA Nsight Graphics installation with ngfx.exe or newer split capture/replay tools",
+      "homepage": "https://developer.nvidia.com/nsight-graphics",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=nsight-graphics/agent-harness",
+      "entry_point": "cli-anything-nsight-graphics",
+      "skill_md": "nsight-graphics/agent-harness/cli_anything/nsight_graphics/skills/SKILL.md",
+      "category": "graphics",
+      "contributors": [
+        {
+          "name": "AiMiDi",
+          "url": "https://github.com/AiMiDi"
         }
       ]
     },
@@ -409,21 +614,59 @@
       ]
     },
     {
-      "name": "shotcut",
-      "display_name": "Shotcut",
+      "name": "obsidian",
+      "display_name": "Obsidian",
       "version": "1.0.0",
-      "description": "Video editing and rendering via melt/ffmpeg",
-      "requires": "melt (apt install melt), ffmpeg (apt install ffmpeg)",
-      "homepage": "https://shotcut.org",
+      "description": "Knowledge management and note-taking — manage notes, search vault, execute commands via Obsidian Local REST API",
+      "requires": "Obsidian desktop app with Local REST API plugin enabled",
+      "homepage": "https://obsidian.md",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=shotcut/agent-harness",
-      "entry_point": "cli-anything-shotcut",
-      "skill_md": "skills/cli-anything-shotcut/SKILL.md",
-      "category": "video",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=obsidian/agent-harness",
+      "entry_point": "cli-anything-obsidian",
+      "skill_md": "skills/cli-anything-obsidian/SKILL.md",
+      "category": "knowledge",
+      "contributors": [
+        {
+          "name": "dorukozgen",
+          "url": "https://github.com/dorukozgen"
+        }
+      ]
+    },
+    {
+      "name": "ollama",
+      "display_name": "Ollama",
+      "version": "1.0.1",
+      "description": "Local LLM inference and model management via Ollama REST API",
+      "requires": "Ollama running at http://localhost:11434",
+      "homepage": "https://ollama.com",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=ollama/agent-harness",
+      "entry_point": "cli-anything-ollama",
+      "skill_md": "skills/cli-anything-ollama/SKILL.md",
+      "category": "ai",
       "contributors": [
         {
           "name": "CLI-Anything-Team",
           "url": "https://github.com/HKUDS/CLI-Anything"
+        }
+      ]
+    },
+    {
+      "name": "openclaw-macro",
+      "display_name": "OpenClaw Macro System",
+      "version": "1.0.0",
+      "description": "Layered CLI that converts GUI workflows into parameterized, agent-callable macros — with backend routing across native APIs, file transforms, accessibility controls, and compiled GUI replay",
+      "requires": null,
+      "homepage": "https://github.com/HKUDS/CLI-Anything",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=openclaw-skill/agent-harness",
+      "entry_point": "cli-anything-openclaw",
+      "skill_md": "openclaw-skill/agent-harness/cli_anything/openclaw/skills/SKILL.md",
+      "category": "automation",
+      "contributors": [
+        {
+          "name": "haorui-harry",
+          "url": "https://github.com/haorui-harry"
         }
       ]
     },
@@ -443,63 +686,6 @@
         {
           "name": "ndpvt-web",
           "url": "https://github.com/ndpvt-web"
-        }
-      ]
-    },
-    {
-      "name": "zoom",
-      "display_name": "Zoom",
-      "version": "1.0.0",
-      "description": "Meeting management via Zoom REST API (OAuth2)",
-      "requires": "Zoom account + OAuth app credentials",
-      "homepage": "https://zoom.us",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=zoom/agent-harness",
-      "entry_point": "cli-anything-zoom",
-      "skill_md": "skills/cli-anything-zoom/SKILL.md",
-      "category": "communication",
-      "contributors": [
-        {
-          "name": "zhangxilong-43",
-          "url": "https://github.com/zhangxilong-43"
-        }
-      ]
-    },
-    {
-      "name": "novita",
-      "display_name": "Novita",
-      "version": "1.0.0",
-      "description": "Access AI models via Novita's OpenAI-compatible API (DeepSeek, GLM, MiniMax)",
-      "requires": "NOVITA_API_KEY",
-      "homepage": "https://novita.ai",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=novita/agent-harness",
-      "entry_point": "cli-anything-novita",
-      "skill_md": "skills/cli-anything-novita/SKILL.md",
-      "category": "ai",
-      "contributors": [
-        {
-          "name": "Alex-wuhu",
-          "url": "https://github.com/Alex-wuhu"
-        }
-      ]
-    },
-    {
-      "name": "seaclip",
-      "display_name": "SeaClip",
-      "version": "1.0.0",
-      "description": "Kanban board, 6-agent AI pipeline, and issue management via SeaClip-Lite FastAPI + SQLite",
-      "requires": "SeaClip-Lite running at localhost:5200",
-      "homepage": "https://github.com/t4tarzan/cli-anything-seaclip",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=seaclip/agent-harness",
-      "entry_point": "cli-anything-seaclip",
-      "skill_md": "skills/cli-anything-seaclip/SKILL.md",
-      "category": "project-management",
-      "contributors": [
-        {
-          "name": "t4tarzan",
-          "url": "https://github.com/t4tarzan"
         }
       ]
     },
@@ -537,135 +723,21 @@
       "contributor_url": "https://github.com/scially"
     },
     {
-      "name": "chromadb",
-      "display_name": "ChromaDB",
+      "name": "quietshrink",
+      "display_name": "QuietShrink",
       "version": "1.0.0",
-      "description": "Vector database operations — collections, documents, semantic search via ChromaDB HTTP API",
-      "requires": "ChromaDB server running at localhost:8000",
-      "homepage": "https://www.trychroma.com",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=chromadb/agent-harness",
-      "entry_point": "cli-anything-chromadb",
-      "skill_md": "skills/cli-anything-chromadb/SKILL.md",
-      "category": "database",
+      "description": "Compress macOS screen recordings on Apple Silicon — 70-90% smaller files at visually lossless quality, hardware-encoded, computer stays silent",
+      "requires": "ffmpeg with hevc_videotoolbox + the quietshrink bash CLI (curl -fsSL https://raw.githubusercontent.com/achiya-automation/quietshrink/main/install.sh | bash)",
+      "homepage": "https://github.com/achiya-automation/quietshrink",
+      "source_url": "https://github.com/achiya-automation/quietshrink",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=quietshrink/agent-harness",
+      "entry_point": "cli-anything-quietshrink",
+      "skill_md": "quietshrink/agent-harness/cli_anything/quietshrink/skills/SKILL.md",
+      "category": "video",
       "contributors": [
         {
-          "name": "t4tarzan",
-          "url": "https://github.com/t4tarzan"
-        }
-      ]
-    },
-    {
-      "name": "musescore",
-      "display_name": "MuseScore",
-      "version": "1.0.0",
-      "description": "CLI for music notation — transpose, export PDF/audio/MIDI, extract parts, manage instruments",
-      "requires": "MuseScore 4 (musescore.org)",
-      "homepage": "https://musescore.org",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=musescore/agent-harness",
-      "entry_point": "cli-anything-musescore",
-      "skill_md": "skills/cli-anything-musescore/SKILL.md",
-      "category": "music",
-      "contributors": [
-        {
-          "name": "tamvicky",
-          "url": "https://github.com/tamvicky"
-        }
-      ]
-    },
-    {
-      "name": "sketch",
-      "display_name": "Sketch",
-      "version": "1.0.0",
-      "description": "Generate Sketch design files (.sketch) from JSON design specifications via sketch-constructor",
-      "requires": "Node.js >= 16.0.0",
-      "homepage": "https://www.sketch.com",
-      "source_url": null,
-      "install_cmd": "cd sketch/agent-harness && npm install && npm link",
-      "entry_point": "sketch-cli",
-      "skill_md": null,
-      "category": "design",
-      "contributors": [
-        {
-          "name": "zhangxilong-43",
-          "url": "https://github.com/zhangxilong-43"
-        }
-      ]
-    },
-    {
-      "name": "freecad",
-      "display_name": "FreeCAD",
-      "version": "1.1.0",
-      "description": "Parametric 3D CAD modeling via FreeCAD CLI (258 commands: Part, Sketcher, PartDesign, Assembly, Mesh, TechDraw, Draft, FEM, CAM, and more)",
-      "requires": "FreeCAD >= 1.1 (freecad.org)",
-      "homepage": "https://www.freecad.org",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=freecad/agent-harness",
-      "entry_point": "cli-anything-freecad",
-      "skill_md": "skills/cli-anything-freecad/SKILL.md",
-      "category": "3d",
-      "contributors": [
-        {
-          "name": "AlexGabbia",
-          "url": "https://github.com/AlexGabbia"
-        }
-      ]
-    },
-    {
-      "name": "iterm2",
-      "display_name": "iTerm2",
-      "version": "1.0.0",
-      "description": "Control a running iTerm2 instance — manage windows, tabs, split panes, send text, read output, run tmux -CC, broadcast keystrokes, and configure preferences.",
-      "requires": "iTerm2.app (macOS only)",
-      "homepage": "https://iterm2.com",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=iterm2/agent-harness",
-      "entry_point": "cli-anything-iterm2",
-      "skill_md": "skills/cli-anything-iterm2/SKILL.md",
-      "category": "devops",
-      "contributors": [
-        {
-          "name": "voidfreud",
-          "url": "https://github.com/voidfreud"
-        }
-      ]
-    },
-    {
-      "name": "slay_the_spire_ii",
-      "display_name": "Slay the Spire 2",
-      "version": "1.0.0",
-      "description": "Control the real Slay the Spire 2 game via local STS2_Bridge HTTP API",
-      "requires": "Slay the Spire 2 (Steam) with STS2_Bridge mod enabled",
-      "homepage": "https://github.com/HKUDS/CLI-Anything/tree/main/slay_the_spire_ii",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=slay_the_spire_ii/agent-harness",
-      "entry_point": "cli-anything-sts2",
-      "skill_md": "skills/cli-anything-slay-the-spire-ii/SKILL.md",
-      "category": "game",
-      "contributors": [
-        {
-          "name": "TianyuFan0504",
-          "url": "https://github.com/TianyuFan0504"
-        }
-      ]
-    },
-    {
-      "name": "rms",
-      "display_name": "Teltonika RMS",
-      "version": "1.0.0",
-      "description": "Device management and monitoring via Teltonika RMS REST API",
-      "requires": "RMS_API_TOKEN",
-      "homepage": "https://rms.teltonika-networks.com",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=rms/agent-harness",
-      "entry_point": "cli-anything-rms",
-      "skill_md": "skills/cli-anything-rms/SKILL.md",
-      "category": "network",
-      "contributors": [
-        {
-          "name": "galke",
-          "url": "https://github.com/galke7"
+          "name": "achiya-automation",
+          "url": "https://github.com/achiya-automation"
         }
       ]
     },
@@ -689,6 +761,139 @@
       ]
     },
     {
+      "name": "rms",
+      "display_name": "Teltonika RMS",
+      "version": "1.0.0",
+      "description": "Device management and monitoring via Teltonika RMS REST API",
+      "requires": "RMS_API_TOKEN",
+      "homepage": "https://rms.teltonika-networks.com",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=rms/agent-harness",
+      "entry_point": "cli-anything-rms",
+      "skill_md": "skills/cli-anything-rms/SKILL.md",
+      "category": "network",
+      "contributors": [
+        {
+          "name": "galke",
+          "url": "https://github.com/galke7"
+        }
+      ]
+    },
+    {
+      "name": "safari",
+      "display_name": "Safari",
+      "version": "1.0.0",
+      "description": "Native macOS Safari browser automation via safari-mcp — 84 tools for navigation, DOM, forms, network capture, and screenshots",
+      "requires": "macOS, Safari, safari-mcp (npm install -g safari-mcp)",
+      "homepage": "https://github.com/achiya-automation/safari-mcp",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=safari/agent-harness",
+      "entry_point": "cli-anything-safari",
+      "skill_md": "skills/cli-anything-safari/SKILL.md",
+      "category": "web",
+      "contributors": [
+        {
+          "name": "achiya-automation",
+          "url": "https://github.com/achiya-automation"
+        }
+      ]
+    },
+    {
+      "name": "seaclip",
+      "display_name": "SeaClip",
+      "version": "1.0.0",
+      "description": "Kanban board, 6-agent AI pipeline, and issue management via SeaClip-Lite FastAPI + SQLite",
+      "requires": "SeaClip-Lite running at localhost:5200",
+      "homepage": "https://github.com/t4tarzan/cli-anything-seaclip",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=seaclip/agent-harness",
+      "entry_point": "cli-anything-seaclip",
+      "skill_md": "skills/cli-anything-seaclip/SKILL.md",
+      "category": "project-management",
+      "contributors": [
+        {
+          "name": "t4tarzan",
+          "url": "https://github.com/t4tarzan"
+        }
+      ]
+    },
+    {
+      "name": "shotcut",
+      "display_name": "Shotcut",
+      "version": "1.0.0",
+      "description": "Video editing and rendering via melt/ffmpeg",
+      "requires": "melt (apt install melt), ffmpeg (apt install ffmpeg)",
+      "homepage": "https://shotcut.org",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=shotcut/agent-harness",
+      "entry_point": "cli-anything-shotcut",
+      "skill_md": "skills/cli-anything-shotcut/SKILL.md",
+      "category": "video",
+      "contributors": [
+        {
+          "name": "CLI-Anything-Team",
+          "url": "https://github.com/HKUDS/CLI-Anything"
+        }
+      ]
+    },
+    {
+      "name": "sketch",
+      "display_name": "Sketch",
+      "version": "1.0.0",
+      "description": "Generate Sketch design files (.sketch) from JSON design specifications via sketch-constructor",
+      "requires": "Node.js >= 16.0.0",
+      "homepage": "https://www.sketch.com",
+      "source_url": null,
+      "install_cmd": "cd sketch/agent-harness && npm install && npm link",
+      "entry_point": "sketch-cli",
+      "skill_md": null,
+      "category": "design",
+      "contributors": [
+        {
+          "name": "zhangxilong-43",
+          "url": "https://github.com/zhangxilong-43"
+        }
+      ]
+    },
+    {
+      "name": "slay_the_spire_ii",
+      "display_name": "Slay the Spire 2",
+      "version": "1.0.0",
+      "description": "Control the real Slay the Spire 2 game via local STS2_Bridge HTTP API",
+      "requires": "Slay the Spire 2 (Steam) with STS2_Bridge mod enabled",
+      "homepage": "https://github.com/HKUDS/CLI-Anything/tree/main/slay_the_spire_ii",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=slay_the_spire_ii/agent-harness",
+      "entry_point": "cli-anything-sts2",
+      "skill_md": "skills/cli-anything-slay-the-spire-ii/SKILL.md",
+      "category": "game",
+      "contributors": [
+        {
+          "name": "TianyuFan0504",
+          "url": "https://github.com/TianyuFan0504"
+        }
+      ]
+    },
+    {
+      "name": "unimol_tools",
+      "display_name": "Uni-Mol Tools",
+      "version": "1.0.0",
+      "description": "Molecular property prediction — train and predict with 5 task types (classification, regression, multiclass, multilabel) for drug discovery",
+      "requires": "PyTorch 1.12+, Uni-Mol Tools backend",
+      "homepage": "https://github.com/dptech-corp/Uni-Mol/tree/main/unimol_tools",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=unimol_tools/agent-harness",
+      "entry_point": "cli-anything-unimol-tools",
+      "skill_md": "skills/cli-anything-unimol-tools/SKILL.md",
+      "category": "science",
+      "contributors": [
+        {
+          "name": "545487677",
+          "url": "https://github.com/545487677"
+        }
+      ]
+    },
+    {
       "name": "unrealinsights",
       "display_name": "Unreal Insights",
       "version": "0.1.0",
@@ -700,25 +905,6 @@
       "entry_point": "cli-anything-unrealinsights",
       "skill_md": "unrealinsights/agent-harness/cli_anything/unrealinsights/skills/SKILL.md",
       "category": "debugging",
-      "contributors": [
-        {
-          "name": "AiMiDi",
-          "url": "https://github.com/AiMiDi"
-        }
-      ]
-    },
-    {
-      "name": "nsight-graphics",
-      "display_name": "Nsight Graphics CLI",
-      "version": "0.1.0",
-      "description": "Windows-first Nsight Graphics CLI for Graphics/Frame capture, GPU Trace, Generate C++ Capture, and one-step GPU Trace summary",
-      "requires": "NVIDIA Nsight Graphics installation with ngfx.exe or newer split capture/replay tools",
-      "homepage": "https://developer.nvidia.com/nsight-graphics",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=nsight-graphics/agent-harness",
-      "entry_point": "cli-anything-nsight-graphics",
-      "skill_md": "nsight-graphics/agent-harness/cli_anything/nsight_graphics/skills/SKILL.md",
-      "category": "graphics",
       "contributors": [
         {
           "name": "AiMiDi",
@@ -746,230 +932,63 @@
       ]
     },
     {
-      "name": "intelwatch",
-      "display_name": "Intelwatch",
-      "version": "1.0.0",
-      "description": "Competitive intelligence, M&A due diligence, and OSINT directly from your terminal.",
-      "requires": "Node.js >=18",
-      "homepage": "https://github.com/ashroth/intelwatch",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=intelwatch/agent-harness",
-      "entry_point": "cli-anything-intelwatch",
-      "skill_md": "skills/cli-anything-intelwatch/SKILL.md",
-      "category": "osint",
-      "contributors": [
-        {
-          "name": "ashroth",
-          "url": "https://github.com/ashroth"
-        }
-      ]
-    },
-    {
-      "name": "clibrowser",
-      "display_name": "clibrowser",
+      "name": "wiremock",
+      "display_name": "WireMock",
       "version": "0.1.0",
-      "description": "Zero-dependency CLI browser for AI agents with search, extraction, forms, RSS, crawling, auth, and WebMCP support",
-      "requires": "Rust toolchain (cargo) for source install, or manual binary download from GitHub Releases",
-      "homepage": "https://github.com/allthingssecurity/clibrowser",
+      "description": "HTTP mock server management — create stubs, inspect requests, record traffic, and manage scenarios via WireMock REST API",
+      "requires": "WireMock server running (java -jar wiremock-standalone.jar)",
+      "homepage": "https://wiremock.org",
       "source_url": null,
-      "install_cmd": "cargo install --git https://github.com/allthingssecurity/clibrowser.git --tag v0.1.0 --locked",
-      "entry_point": "clibrowser",
-      "skill_md": null,
-      "category": "web",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=wiremock/agent-harness",
+      "entry_point": "cli-anything-wiremock",
+      "skill_md": "skills/cli-anything-wiremock/SKILL.md",
+      "category": "testing",
       "contributors": [
         {
-          "name": "allthingssecurity",
-          "url": "https://github.com/allthingssecurity"
+          "name": "fabiomantel",
+          "url": "https://github.com/fabiomantel"
         }
       ]
     },
     {
-      "name": "cloudcompare",
-      "display_name": "CloudCompare",
+      "name": "zoom",
+      "display_name": "Zoom",
       "version": "1.0.0",
-      "description": "3D point cloud and mesh processing: load/save, color ops, normal estimation, Delaunay meshing, noise filtering, ICP registration, connected component segmentation",
-      "requires": "cloudcompare (CloudCompare application installed, e.g. via Flatpak or package manager)",
-      "homepage": "https://cloudcompare.org",
+      "description": "Meeting management via Zoom REST API (OAuth2)",
+      "requires": "Zoom account + OAuth app credentials",
+      "homepage": "https://zoom.us",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=cloudcompare/agent-harness",
-      "entry_point": "cli-anything-cloudcompare",
-      "skill_md": "skills/cli-anything-cloudcompare/SKILL.md",
-      "category": "graphics",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=zoom/agent-harness",
+      "entry_point": "cli-anything-zoom",
+      "skill_md": "skills/cli-anything-zoom/SKILL.md",
+      "category": "communication",
       "contributors": [
         {
-          "name": "Taeyoung96",
-          "url": "https://github.com/Taeyoung96"
+          "name": "zhangxilong-43",
+          "url": "https://github.com/zhangxilong-43"
         }
       ]
     },
     {
-      "name": "exa",
-      "display_name": "Exa",
-      "version": "1.0.0",
-      "description": "AI-powered web search and content extraction via the Exa API",
-      "requires": "EXA_API_KEY (free tier at exa.ai)",
-      "homepage": "https://exa.ai",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=exa/agent-harness",
-      "entry_point": "cli-anything-exa",
-      "skill_md": "skills/cli-anything-exa/SKILL.md",
-      "category": "search",
+      "name": "zotero",
+      "display_name": "Zotero",
+      "version": "0.4.1",
+      "description": "CLI & MCP server for Zotero 7/8 — 52 MCP tools + 70+ CLI commands for search, import, PDF, BibTeX, notes, and more",
+      "requires": "Zotero 7/8 desktop app (running), Python 3.10+",
+      "homepage": "https://www.zotero.org",
+      "source_url": "https://github.com/PiaoyangGuohai1/cli-anything-zotero",
+      "install_cmd": "pip install cli-anything-zotero",
+      "entry_point": "cli-anything-zotero",
+      "skill_md": "https://github.com/PiaoyangGuohai1/cli-anything-zotero/blob/main/cli_anything/zotero/skills/SKILL.md",
+      "category": "office",
       "contributors": [
         {
-          "name": "tgonzalezc5",
-          "url": "https://github.com/tgonzalezc5"
-        }
-      ]
-    },
-    {
-      "name": "godot",
-      "display_name": "Godot Engine",
-      "version": "1.0.0",
-      "description": "Game engine project management, scene editing, export and GDScript execution via Godot 4 headless mode",
-      "requires": "Godot 4.x (godotengine.org)",
-      "homepage": "https://godotengine.org",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=godot/agent-harness",
-      "entry_point": "cli-anything-godot",
-      "skill_md": "skills/cli-anything-godot/SKILL.md",
-      "category": "gamedev",
-      "contributors": [
+          "name": "zhiwuyazhe_fjr",
+          "url": "https://github.com/zhiwuyazhe-fjr"
+        },
         {
-          "name": "omerarslan0",
-          "url": "https://github.com/omerarslan0"
-        }
-      ]
-    },
-    {
-      "name": "dify-workflow",
-      "display_name": "Dify Workflow",
-      "version": "0.1.0",
-      "description": "CLI-Anything wrapper for the Dify workflow DSL editor covering create, inspect, validate, edit, export, and layout operations",
-      "requires": "Upstream dify-workflow CLI installed from https://github.com/Akabane71/dify-workflow-cli",
-      "homepage": "https://github.com/Akabane71/dify-workflow-cli",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=dify-workflow/agent-harness",
-      "entry_point": "cli-anything-dify-workflow",
-      "skill_md": "skills/cli-anything-dify-workflow/SKILL.md",
-      "category": "ai",
-      "contributors": [
-        {
-          "name": "Akabane71",
-          "url": "https://github.com/Akabane71"
-        }
-      ]
-    },
-    {
-      "name": "n8n",
-      "display_name": "n8n",
-      "version": "2.4.7",
-      "description": "Workflow automation via n8n REST API — 55+ commands",
-      "requires": "n8n >= 1.0.0",
-      "homepage": "https://n8n.io",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=n8n/agent-harness",
-      "entry_point": "cli-anything-n8n",
-      "skill_md": "skills/cli-anything-n8n/SKILL.md",
-      "category": "automation",
-      "contributors": [
-        {
-          "name": "webcomunicasolutions",
-          "url": "https://github.com/webcomunicasolutions"
-        }
-      ]
-    },
-    {
-      "name": "cloudanalyzer",
-      "display_name": "CloudAnalyzer",
-      "version": "1.0.0",
-      "description": "Point cloud and trajectory QA: Chamfer/AUC/F1, ATE/RPE/drift, ground segmentation metrics, config-driven quality gates, baseline evolution — harness wraps the CloudAnalyzer Python API",
-      "requires": "Python 3.10+; cloudanalyzer (`pip install cloudanalyzer`), Open3D for full IO/viewer paths",
-      "homepage": "https://github.com/rsasaki0109/CloudAnalyzer",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=cloudanalyzer/agent-harness",
-      "entry_point": "cli-anything-cloudanalyzer",
-      "skill_md": "skills/cli-anything-cloudanalyzer/SKILL.md",
-      "category": "graphics",
-      "contributors": [
-        {
-          "name": "rsasaki0109",
-          "url": "https://github.com/rsasaki0109"
-        }
-      ]
-    },
-    {
-      "name": "obsidian",
-      "display_name": "Obsidian",
-      "version": "1.0.0",
-      "description": "Knowledge management and note-taking — manage notes, search vault, execute commands via Obsidian Local REST API",
-      "requires": "Obsidian desktop app with Local REST API plugin enabled",
-      "homepage": "https://obsidian.md",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=obsidian/agent-harness",
-      "entry_point": "cli-anything-obsidian",
-      "skill_md": "skills/cli-anything-obsidian/SKILL.md",
-      "category": "knowledge",
-      "contributors": [
-        {
-          "name": "dorukozgen",
-          "url": "https://github.com/dorukozgen"
-        }
-      ]
-    },
-    {
-      "name": "unimol_tools",
-      "display_name": "Uni-Mol Tools",
-      "version": "1.0.0",
-      "description": "Molecular property prediction — train and predict with 5 task types (classification, regression, multiclass, multilabel) for drug discovery",
-      "requires": "PyTorch 1.12+, Uni-Mol Tools backend",
-      "homepage": "https://github.com/dptech-corp/Uni-Mol/tree/main/unimol_tools",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=unimol_tools/agent-harness",
-      "entry_point": "cli-anything-unimol-tools",
-      "skill_md": "skills/cli-anything-unimol-tools/SKILL.md",
-      "category": "science",
-      "contributors": [
-        {
-          "name": "545487677",
-          "url": "https://github.com/545487677"
-        }
-      ]
-    },
-    {
-      "name": "safari",
-      "display_name": "Safari",
-      "version": "1.0.0",
-      "description": "Native macOS Safari browser automation via safari-mcp — 84 tools for navigation, DOM, forms, network capture, and screenshots",
-      "requires": "macOS, Safari, safari-mcp (npm install -g safari-mcp)",
-      "homepage": "https://github.com/achiya-automation/safari-mcp",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=safari/agent-harness",
-      "entry_point": "cli-anything-safari",
-      "skill_md": "skills/cli-anything-safari/SKILL.md",
-      "category": "web",
-      "contributors": [
-        {
-          "name": "achiya-automation",
-          "url": "https://github.com/achiya-automation"
-        }
-      ]
-    },
-    {
-      "name": "openclaw-macro",
-      "display_name": "OpenClaw Macro System",
-      "version": "1.0.0",
-      "description": "Layered CLI that converts GUI workflows into parameterized, agent-callable macros — with backend routing across native APIs, file transforms, accessibility controls, and compiled GUI replay",
-      "requires": null,
-      "homepage": "https://github.com/HKUDS/CLI-Anything",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=openclaw-skill/agent-harness",
-      "entry_point": "cli-anything-openclaw",
-      "skill_md": "openclaw-skill/agent-harness/cli_anything/openclaw/skills/SKILL.md",
-      "category": "automation",
-      "contributors": [
-        {
-          "name": "haorui-harry",
-          "url": "https://github.com/haorui-harry"
+          "name": "PiaoyangGuohai1",
+          "url": "https://github.com/PiaoyangGuohai1"
         }
       ]
     }

--- a/registry.json
+++ b/registry.json
@@ -980,10 +980,10 @@
       "description": "Compress macOS screen recordings on Apple Silicon — 70-90% smaller files at visually lossless quality, hardware-encoded, computer stays silent",
       "requires": "ffmpeg with hevc_videotoolbox + the quietshrink bash CLI (curl -fsSL https://raw.githubusercontent.com/achiya-automation/quietshrink/main/install.sh | bash)",
       "homepage": "https://github.com/achiya-automation/quietshrink",
-      "source_url": "https://github.com/achiya-automation/quietshrink",
+      "source_url": null,
       "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=quietshrink/agent-harness",
       "entry_point": "cli-anything-quietshrink",
-      "skill_md": "quietshrink/agent-harness/cli_anything/quietshrink/skills/SKILL.md",
+      "skill_md": "skills/cli-anything-quietshrink/SKILL.md",
       "category": "video",
       "contributors": [
         {

--- a/registry.json
+++ b/registry.json
@@ -2,25 +2,25 @@
   "meta": {
     "repo": "https://github.com/HKUDS/CLI-Anything",
     "description": "CLI-Hub — Agent-native stateful CLI interfaces for softwares, codebases, and Web Services",
-    "updated": "2026-04-26"
+    "updated": "2026-04-16"
   },
   "clis": [
     {
-      "name": "adguardhome",
-      "display_name": "AdGuardHome",
-      "version": "1.0.0",
-      "description": "DNS ad-blocking and network infrastructure management via AdGuardHome REST API",
-      "requires": "AdGuardHome instance running",
-      "homepage": "https://adguard.com/adguard-home/overview.html",
+      "name": "wiremock",
+      "display_name": "WireMock",
+      "version": "0.1.0",
+      "description": "HTTP mock server management — create stubs, inspect requests, record traffic, and manage scenarios via WireMock REST API",
+      "requires": "WireMock server running (java -jar wiremock-standalone.jar)",
+      "homepage": "https://wiremock.org",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=adguardhome/agent-harness",
-      "entry_point": "cli-anything-adguardhome",
-      "skill_md": null,
-      "category": "network",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=wiremock/agent-harness",
+      "entry_point": "cli-anything-wiremock",
+      "skill_md": "skills/cli-anything-wiremock/SKILL.md",
+      "category": "testing",
       "contributors": [
         {
-          "name": "pyxl-dev",
-          "url": "https://github.com/pyxl-dev"
+          "name": "fabiomantel",
+          "url": "https://github.com/fabiomantel"
         }
       ]
     },
@@ -40,6 +40,25 @@
         {
           "name": "koltyu-anygen",
           "url": "https://github.com/koltyu-anygen"
+        }
+      ]
+    },
+    {
+      "name": "adguardhome",
+      "display_name": "AdGuardHome",
+      "version": "1.0.0",
+      "description": "DNS ad-blocking and network infrastructure management via AdGuardHome REST API",
+      "requires": "AdGuardHome instance running",
+      "homepage": "https://adguard.com/adguard-home/overview.html",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=adguardhome/agent-harness",
+      "entry_point": "cli-anything-adguardhome",
+      "skill_md": null,
+      "category": "network",
+      "contributors": [
+        {
+          "name": "pyxl-dev",
+          "url": "https://github.com/pyxl-dev"
         }
       ]
     },
@@ -101,82 +120,6 @@
       ]
     },
     {
-      "name": "chromadb",
-      "display_name": "ChromaDB",
-      "version": "1.0.0",
-      "description": "Vector database operations — collections, documents, semantic search via ChromaDB HTTP API",
-      "requires": "ChromaDB server running at localhost:8000",
-      "homepage": "https://www.trychroma.com",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=chromadb/agent-harness",
-      "entry_point": "cli-anything-chromadb",
-      "skill_md": "skills/cli-anything-chromadb/SKILL.md",
-      "category": "database",
-      "contributors": [
-        {
-          "name": "t4tarzan",
-          "url": "https://github.com/t4tarzan"
-        }
-      ]
-    },
-    {
-      "name": "clibrowser",
-      "display_name": "clibrowser",
-      "version": "0.1.0",
-      "description": "Zero-dependency CLI browser for AI agents with search, extraction, forms, RSS, crawling, auth, and WebMCP support",
-      "requires": "Rust toolchain (cargo) for source install, or manual binary download from GitHub Releases",
-      "homepage": "https://github.com/allthingssecurity/clibrowser",
-      "source_url": null,
-      "install_cmd": "cargo install --git https://github.com/allthingssecurity/clibrowser.git --tag v0.1.0 --locked",
-      "entry_point": "clibrowser",
-      "skill_md": null,
-      "category": "web",
-      "contributors": [
-        {
-          "name": "allthingssecurity",
-          "url": "https://github.com/allthingssecurity"
-        }
-      ]
-    },
-    {
-      "name": "cloudanalyzer",
-      "display_name": "CloudAnalyzer",
-      "version": "1.0.0",
-      "description": "Point cloud and trajectory QA: Chamfer/AUC/F1, ATE/RPE/drift, ground segmentation metrics, config-driven quality gates, baseline evolution — harness wraps the CloudAnalyzer Python API",
-      "requires": "Python 3.10+; cloudanalyzer (`pip install cloudanalyzer`), Open3D for full IO/viewer paths",
-      "homepage": "https://github.com/rsasaki0109/CloudAnalyzer",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=cloudanalyzer/agent-harness",
-      "entry_point": "cli-anything-cloudanalyzer",
-      "skill_md": "skills/cli-anything-cloudanalyzer/SKILL.md",
-      "category": "graphics",
-      "contributors": [
-        {
-          "name": "rsasaki0109",
-          "url": "https://github.com/rsasaki0109"
-        }
-      ]
-    },
-    {
-      "name": "cloudcompare",
-      "display_name": "CloudCompare",
-      "version": "1.0.0",
-      "description": "3D point cloud and mesh processing: load/save, color ops, normal estimation, Delaunay meshing, noise filtering, ICP registration, connected component segmentation",
-      "requires": "cloudcompare (CloudCompare application installed, e.g. via Flatpak or package manager)",
-      "homepage": "https://cloudcompare.org",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=cloudcompare/agent-harness",
-      "entry_point": "cli-anything-cloudcompare",
-      "skill_md": "skills/cli-anything-cloudcompare/SKILL.md",
-      "category": "graphics",
-      "contributors": [
-        {
-          "name": "Taeyoung96",
-          "url": "https://github.com/Taeyoung96"
-        }
-      ]
-    },
-    {
       "name": "comfyui",
       "display_name": "ComfyUI",
       "version": "1.0.0",
@@ -192,25 +135,6 @@
         {
           "name": "Bortlesboat",
           "url": "https://github.com/Bortlesboat"
-        }
-      ]
-    },
-    {
-      "name": "dify-workflow",
-      "display_name": "Dify Workflow",
-      "version": "0.1.0",
-      "description": "CLI-Anything wrapper for the Dify workflow DSL editor covering create, inspect, validate, edit, export, and layout operations",
-      "requires": "Upstream dify-workflow CLI installed from https://github.com/Akabane71/dify-workflow-cli",
-      "homepage": "https://github.com/Akabane71/dify-workflow-cli",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=dify-workflow/agent-harness",
-      "entry_point": "cli-anything-dify-workflow",
-      "skill_md": "skills/cli-anything-dify-workflow/SKILL.md",
-      "category": "ai",
-      "contributors": [
-        {
-          "name": "Akabane71",
-          "url": "https://github.com/Akabane71"
         }
       ]
     },
@@ -253,44 +177,6 @@
       ]
     },
     {
-      "name": "exa",
-      "display_name": "Exa",
-      "version": "1.0.0",
-      "description": "AI-powered web search and content extraction via the Exa API",
-      "requires": "EXA_API_KEY (free tier at exa.ai)",
-      "homepage": "https://exa.ai",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=exa/agent-harness",
-      "entry_point": "cli-anything-exa",
-      "skill_md": "skills/cli-anything-exa/SKILL.md",
-      "category": "search",
-      "contributors": [
-        {
-          "name": "tgonzalezc5",
-          "url": "https://github.com/tgonzalezc5"
-        }
-      ]
-    },
-    {
-      "name": "freecad",
-      "display_name": "FreeCAD",
-      "version": "1.1.0",
-      "description": "Parametric 3D CAD modeling via FreeCAD CLI (258 commands: Part, Sketcher, PartDesign, Assembly, Mesh, TechDraw, Draft, FEM, CAM, and more)",
-      "requires": "FreeCAD >= 1.1 (freecad.org)",
-      "homepage": "https://www.freecad.org",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=freecad/agent-harness",
-      "entry_point": "cli-anything-freecad",
-      "skill_md": "skills/cli-anything-freecad/SKILL.md",
-      "category": "3d",
-      "contributors": [
-        {
-          "name": "AlexGabbia",
-          "url": "https://github.com/AlexGabbia"
-        }
-      ]
-    },
-    {
       "name": "gimp",
       "display_name": "GIMP",
       "version": "1.0.0",
@@ -310,25 +196,6 @@
       ]
     },
     {
-      "name": "godot",
-      "display_name": "Godot Engine",
-      "version": "1.0.0",
-      "description": "Game engine project management, scene editing, export and GDScript execution via Godot 4 headless mode",
-      "requires": "Godot 4.x (godotengine.org)",
-      "homepage": "https://godotengine.org",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=godot/agent-harness",
-      "entry_point": "cli-anything-godot",
-      "skill_md": "skills/cli-anything-godot/SKILL.md",
-      "category": "gamedev",
-      "contributors": [
-        {
-          "name": "omerarslan0",
-          "url": "https://github.com/omerarslan0"
-        }
-      ]
-    },
-    {
       "name": "inkscape",
       "display_name": "Inkscape",
       "version": "1.0.0",
@@ -344,44 +211,6 @@
         {
           "name": "CLI-Anything-Team",
           "url": "https://github.com/HKUDS/CLI-Anything"
-        }
-      ]
-    },
-    {
-      "name": "intelwatch",
-      "display_name": "Intelwatch",
-      "version": "1.0.0",
-      "description": "Competitive intelligence, M&A due diligence, and OSINT directly from your terminal.",
-      "requires": "Node.js >=18",
-      "homepage": "https://github.com/ashroth/intelwatch",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=intelwatch/agent-harness",
-      "entry_point": "cli-anything-intelwatch",
-      "skill_md": "skills/cli-anything-intelwatch/SKILL.md",
-      "category": "osint",
-      "contributors": [
-        {
-          "name": "ashroth",
-          "url": "https://github.com/ashroth"
-        }
-      ]
-    },
-    {
-      "name": "iterm2",
-      "display_name": "iTerm2",
-      "version": "1.0.0",
-      "description": "Control a running iTerm2 instance — manage windows, tabs, split panes, send text, read output, run tmux -CC, broadcast keystrokes, and configure preferences.",
-      "requires": "iTerm2.app (macOS only)",
-      "homepage": "https://iterm2.com",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=iterm2/agent-harness",
-      "entry_point": "cli-anything-iterm2",
-      "skill_md": "skills/cli-anything-iterm2/SKILL.md",
-      "category": "devops",
-      "contributors": [
-        {
-          "name": "voidfreud",
-          "url": "https://github.com/voidfreud"
         }
       ]
     },
@@ -462,21 +291,25 @@
       ]
     },
     {
-      "name": "mermaid",
-      "display_name": "Mermaid",
-      "version": "1.0.0",
-      "description": "Mermaid Live Editor state files and renderer URLs",
-      "requires": null,
-      "homepage": "https://mermaid.js.org",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=mermaid/agent-harness",
-      "entry_point": "cli-anything-mermaid",
-      "skill_md": null,
-      "category": "diagrams",
+      "name": "zotero",
+      "display_name": "Zotero",
+      "version": "0.4.1",
+      "description": "CLI & MCP server for Zotero 7/8 — 52 MCP tools + 70+ CLI commands for search, import, PDF, BibTeX, notes, and more",
+      "requires": "Zotero 7/8 desktop app (running), Python 3.10+",
+      "homepage": "https://www.zotero.org",
+      "source_url": "https://github.com/PiaoyangGuohai1/cli-anything-zotero",
+      "install_cmd": "pip install cli-anything-zotero",
+      "entry_point": "cli-anything-zotero",
+      "skill_md": "https://github.com/PiaoyangGuohai1/cli-anything-zotero/blob/main/cli_anything/zotero/skills/SKILL.md",
+      "category": "office",
       "contributors": [
         {
-          "name": "getmored-create",
-          "url": "https://github.com/getmored-create"
+          "name": "zhiwuyazhe_fjr",
+          "url": "https://github.com/zhiwuyazhe-fjr"
+        },
+        {
+          "name": "PiaoyangGuohai1",
+          "url": "https://github.com/PiaoyangGuohai1"
         }
       ]
     },
@@ -500,40 +333,21 @@
       ]
     },
     {
-      "name": "musescore",
-      "display_name": "MuseScore",
+      "name": "mermaid",
+      "display_name": "Mermaid",
       "version": "1.0.0",
-      "description": "CLI for music notation — transpose, export PDF/audio/MIDI, extract parts, manage instruments",
-      "requires": "MuseScore 4 (musescore.org)",
-      "homepage": "https://musescore.org",
+      "description": "Mermaid Live Editor state files and renderer URLs",
+      "requires": null,
+      "homepage": "https://mermaid.js.org",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=musescore/agent-harness",
-      "entry_point": "cli-anything-musescore",
-      "skill_md": "skills/cli-anything-musescore/SKILL.md",
-      "category": "music",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=mermaid/agent-harness",
+      "entry_point": "cli-anything-mermaid",
+      "skill_md": null,
+      "category": "diagrams",
       "contributors": [
         {
-          "name": "tamvicky",
-          "url": "https://github.com/tamvicky"
-        }
-      ]
-    },
-    {
-      "name": "n8n",
-      "display_name": "n8n",
-      "version": "2.4.7",
-      "description": "Workflow automation via n8n REST API — 55+ commands",
-      "requires": "n8n >= 1.0.0",
-      "homepage": "https://n8n.io",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=n8n/agent-harness",
-      "entry_point": "cli-anything-n8n",
-      "skill_md": "skills/cli-anything-n8n/SKILL.md",
-      "category": "automation",
-      "contributors": [
-        {
-          "name": "webcomunicasolutions",
-          "url": "https://github.com/webcomunicasolutions"
+          "name": "getmored-create",
+          "url": "https://github.com/getmored-create"
         }
       ]
     },
@@ -557,40 +371,21 @@
       ]
     },
     {
-      "name": "novita",
-      "display_name": "Novita",
-      "version": "1.0.0",
-      "description": "Access AI models via Novita's OpenAI-compatible API (DeepSeek, GLM, MiniMax)",
-      "requires": "NOVITA_API_KEY",
-      "homepage": "https://novita.ai",
+      "name": "ollama",
+      "display_name": "Ollama",
+      "version": "1.0.1",
+      "description": "Local LLM inference and model management via Ollama REST API",
+      "requires": "Ollama running at http://localhost:11434",
+      "homepage": "https://ollama.com",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=novita/agent-harness",
-      "entry_point": "cli-anything-novita",
-      "skill_md": "skills/cli-anything-novita/SKILL.md",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=ollama/agent-harness",
+      "entry_point": "cli-anything-ollama",
+      "skill_md": "skills/cli-anything-ollama/SKILL.md",
       "category": "ai",
       "contributors": [
         {
-          "name": "Alex-wuhu",
-          "url": "https://github.com/Alex-wuhu"
-        }
-      ]
-    },
-    {
-      "name": "nsight-graphics",
-      "display_name": "Nsight Graphics CLI",
-      "version": "0.1.0",
-      "description": "Windows-first Nsight Graphics CLI for Graphics/Frame capture, GPU Trace, Generate C++ Capture, and one-step GPU Trace summary",
-      "requires": "NVIDIA Nsight Graphics installation with ngfx.exe or newer split capture/replay tools",
-      "homepage": "https://developer.nvidia.com/nsight-graphics",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=nsight-graphics/agent-harness",
-      "entry_point": "cli-anything-nsight-graphics",
-      "skill_md": "nsight-graphics/agent-harness/cli_anything/nsight_graphics/skills/SKILL.md",
-      "category": "graphics",
-      "contributors": [
-        {
-          "name": "AiMiDi",
-          "url": "https://github.com/AiMiDi"
+          "name": "CLI-Anything-Team",
+          "url": "https://github.com/HKUDS/CLI-Anything"
         }
       ]
     },
@@ -614,59 +409,21 @@
       ]
     },
     {
-      "name": "obsidian",
-      "display_name": "Obsidian",
+      "name": "shotcut",
+      "display_name": "Shotcut",
       "version": "1.0.0",
-      "description": "Knowledge management and note-taking — manage notes, search vault, execute commands via Obsidian Local REST API",
-      "requires": "Obsidian desktop app with Local REST API plugin enabled",
-      "homepage": "https://obsidian.md",
+      "description": "Video editing and rendering via melt/ffmpeg",
+      "requires": "melt (apt install melt), ffmpeg (apt install ffmpeg)",
+      "homepage": "https://shotcut.org",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=obsidian/agent-harness",
-      "entry_point": "cli-anything-obsidian",
-      "skill_md": "skills/cli-anything-obsidian/SKILL.md",
-      "category": "knowledge",
-      "contributors": [
-        {
-          "name": "dorukozgen",
-          "url": "https://github.com/dorukozgen"
-        }
-      ]
-    },
-    {
-      "name": "ollama",
-      "display_name": "Ollama",
-      "version": "1.0.1",
-      "description": "Local LLM inference and model management via Ollama REST API",
-      "requires": "Ollama running at http://localhost:11434",
-      "homepage": "https://ollama.com",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=ollama/agent-harness",
-      "entry_point": "cli-anything-ollama",
-      "skill_md": "skills/cli-anything-ollama/SKILL.md",
-      "category": "ai",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=shotcut/agent-harness",
+      "entry_point": "cli-anything-shotcut",
+      "skill_md": "skills/cli-anything-shotcut/SKILL.md",
+      "category": "video",
       "contributors": [
         {
           "name": "CLI-Anything-Team",
           "url": "https://github.com/HKUDS/CLI-Anything"
-        }
-      ]
-    },
-    {
-      "name": "openclaw-macro",
-      "display_name": "OpenClaw Macro System",
-      "version": "1.0.0",
-      "description": "Layered CLI that converts GUI workflows into parameterized, agent-callable macros — with backend routing across native APIs, file transforms, accessibility controls, and compiled GUI replay",
-      "requires": null,
-      "homepage": "https://github.com/HKUDS/CLI-Anything",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=openclaw-skill/agent-harness",
-      "entry_point": "cli-anything-openclaw",
-      "skill_md": "openclaw-skill/agent-harness/cli_anything/openclaw/skills/SKILL.md",
-      "category": "automation",
-      "contributors": [
-        {
-          "name": "haorui-harry",
-          "url": "https://github.com/haorui-harry"
         }
       ]
     },
@@ -686,6 +443,63 @@
         {
           "name": "ndpvt-web",
           "url": "https://github.com/ndpvt-web"
+        }
+      ]
+    },
+    {
+      "name": "zoom",
+      "display_name": "Zoom",
+      "version": "1.0.1",
+      "description": "Meeting management via Zoom REST API (OAuth2)",
+      "requires": "Zoom account + OAuth app credentials",
+      "homepage": "https://zoom.us",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=zoom/agent-harness",
+      "entry_point": "cli-anything-zoom",
+      "skill_md": "skills/cli-anything-zoom/SKILL.md",
+      "category": "communication",
+      "contributors": [
+        {
+          "name": "zhangxilong-43",
+          "url": "https://github.com/zhangxilong-43"
+        }
+      ]
+    },
+    {
+      "name": "novita",
+      "display_name": "Novita",
+      "version": "1.0.0",
+      "description": "Access AI models via Novita's OpenAI-compatible API (DeepSeek, GLM, MiniMax)",
+      "requires": "NOVITA_API_KEY",
+      "homepage": "https://novita.ai",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=novita/agent-harness",
+      "entry_point": "cli-anything-novita",
+      "skill_md": "skills/cli-anything-novita/SKILL.md",
+      "category": "ai",
+      "contributors": [
+        {
+          "name": "Alex-wuhu",
+          "url": "https://github.com/Alex-wuhu"
+        }
+      ]
+    },
+    {
+      "name": "seaclip",
+      "display_name": "SeaClip",
+      "version": "1.0.0",
+      "description": "Kanban board, 6-agent AI pipeline, and issue management via SeaClip-Lite FastAPI + SQLite",
+      "requires": "SeaClip-Lite running at localhost:5200",
+      "homepage": "https://github.com/t4tarzan/cli-anything-seaclip",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=seaclip/agent-harness",
+      "entry_point": "cli-anything-seaclip",
+      "skill_md": "skills/cli-anything-seaclip/SKILL.md",
+      "category": "project-management",
+      "contributors": [
+        {
+          "name": "t4tarzan",
+          "url": "https://github.com/t4tarzan"
         }
       ]
     },
@@ -723,93 +537,17 @@
       "contributor_url": "https://github.com/scially"
     },
     {
-      "name": "quietshrink",
-      "display_name": "QuietShrink",
+      "name": "chromadb",
+      "display_name": "ChromaDB",
       "version": "1.0.0",
-      "description": "Compress macOS screen recordings on Apple Silicon — 70-90% smaller files at visually lossless quality, hardware-encoded, computer stays silent",
-      "requires": "ffmpeg with hevc_videotoolbox + the quietshrink bash CLI (curl -fsSL https://raw.githubusercontent.com/achiya-automation/quietshrink/main/install.sh | bash)",
-      "homepage": "https://github.com/achiya-automation/quietshrink",
-      "source_url": "https://github.com/achiya-automation/quietshrink",
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=quietshrink/agent-harness",
-      "entry_point": "cli-anything-quietshrink",
-      "skill_md": "quietshrink/agent-harness/cli_anything/quietshrink/skills/SKILL.md",
-      "category": "video",
-      "contributors": [
-        {
-          "name": "achiya-automation",
-          "url": "https://github.com/achiya-automation"
-        }
-      ]
-    },
-    {
-      "name": "renderdoc",
-      "display_name": "RenderDoc",
-      "version": "0.1.0",
-      "description": "GPU frame capture analysis: pipeline state, shader export, texture inspection, draw call browsing",
-      "requires": "renderdoc (Python bindings from RenderDoc installation)",
-      "homepage": "https://renderdoc.org",
+      "description": "Vector database operations — collections, documents, semantic search via ChromaDB HTTP API",
+      "requires": "ChromaDB server running at localhost:8000",
+      "homepage": "https://www.trychroma.com",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=renderdoc/agent-harness",
-      "entry_point": "cli-anything-renderdoc",
-      "skill_md": "skills/cli-anything-renderdoc/SKILL.md",
-      "category": "graphics",
-      "contributors": [
-        {
-          "name": "levishilf",
-          "url": "https://github.com/levishilf"
-        }
-      ]
-    },
-    {
-      "name": "rms",
-      "display_name": "Teltonika RMS",
-      "version": "1.0.0",
-      "description": "Device management and monitoring via Teltonika RMS REST API",
-      "requires": "RMS_API_TOKEN",
-      "homepage": "https://rms.teltonika-networks.com",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=rms/agent-harness",
-      "entry_point": "cli-anything-rms",
-      "skill_md": "skills/cli-anything-rms/SKILL.md",
-      "category": "network",
-      "contributors": [
-        {
-          "name": "galke",
-          "url": "https://github.com/galke7"
-        }
-      ]
-    },
-    {
-      "name": "safari",
-      "display_name": "Safari",
-      "version": "1.0.0",
-      "description": "Native macOS Safari browser automation via safari-mcp — 84 tools for navigation, DOM, forms, network capture, and screenshots",
-      "requires": "macOS, Safari, safari-mcp (npm install -g safari-mcp)",
-      "homepage": "https://github.com/achiya-automation/safari-mcp",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=safari/agent-harness",
-      "entry_point": "cli-anything-safari",
-      "skill_md": "skills/cli-anything-safari/SKILL.md",
-      "category": "web",
-      "contributors": [
-        {
-          "name": "achiya-automation",
-          "url": "https://github.com/achiya-automation"
-        }
-      ]
-    },
-    {
-      "name": "seaclip",
-      "display_name": "SeaClip",
-      "version": "1.0.0",
-      "description": "Kanban board, 6-agent AI pipeline, and issue management via SeaClip-Lite FastAPI + SQLite",
-      "requires": "SeaClip-Lite running at localhost:5200",
-      "homepage": "https://github.com/t4tarzan/cli-anything-seaclip",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=seaclip/agent-harness",
-      "entry_point": "cli-anything-seaclip",
-      "skill_md": "skills/cli-anything-seaclip/SKILL.md",
-      "category": "project-management",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=chromadb/agent-harness",
+      "entry_point": "cli-anything-chromadb",
+      "skill_md": "skills/cli-anything-chromadb/SKILL.md",
+      "category": "database",
       "contributors": [
         {
           "name": "t4tarzan",
@@ -818,21 +556,21 @@
       ]
     },
     {
-      "name": "shotcut",
-      "display_name": "Shotcut",
+      "name": "musescore",
+      "display_name": "MuseScore",
       "version": "1.0.0",
-      "description": "Video editing and rendering via melt/ffmpeg",
-      "requires": "melt (apt install melt), ffmpeg (apt install ffmpeg)",
-      "homepage": "https://shotcut.org",
+      "description": "CLI for music notation — transpose, export PDF/audio/MIDI, extract parts, manage instruments",
+      "requires": "MuseScore 4 (musescore.org)",
+      "homepage": "https://musescore.org",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=shotcut/agent-harness",
-      "entry_point": "cli-anything-shotcut",
-      "skill_md": "skills/cli-anything-shotcut/SKILL.md",
-      "category": "video",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=musescore/agent-harness",
+      "entry_point": "cli-anything-musescore",
+      "skill_md": "skills/cli-anything-musescore/SKILL.md",
+      "category": "music",
       "contributors": [
         {
-          "name": "CLI-Anything-Team",
-          "url": "https://github.com/HKUDS/CLI-Anything"
+          "name": "tamvicky",
+          "url": "https://github.com/tamvicky"
         }
       ]
     },
@@ -856,6 +594,44 @@
       ]
     },
     {
+      "name": "freecad",
+      "display_name": "FreeCAD",
+      "version": "1.1.0",
+      "description": "Parametric 3D CAD modeling via FreeCAD CLI (258 commands: Part, Sketcher, PartDesign, Assembly, Mesh, TechDraw, Draft, FEM, CAM, and more)",
+      "requires": "FreeCAD >= 1.1 (freecad.org)",
+      "homepage": "https://www.freecad.org",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=freecad/agent-harness",
+      "entry_point": "cli-anything-freecad",
+      "skill_md": "skills/cli-anything-freecad/SKILL.md",
+      "category": "3d",
+      "contributors": [
+        {
+          "name": "AlexGabbia",
+          "url": "https://github.com/AlexGabbia"
+        }
+      ]
+    },
+    {
+      "name": "iterm2",
+      "display_name": "iTerm2",
+      "version": "1.0.0",
+      "description": "Control a running iTerm2 instance — manage windows, tabs, split panes, send text, read output, run tmux -CC, broadcast keystrokes, and configure preferences.",
+      "requires": "iTerm2.app (macOS only)",
+      "homepage": "https://iterm2.com",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=iterm2/agent-harness",
+      "entry_point": "cli-anything-iterm2",
+      "skill_md": "skills/cli-anything-iterm2/SKILL.md",
+      "category": "devops",
+      "contributors": [
+        {
+          "name": "voidfreud",
+          "url": "https://github.com/voidfreud"
+        }
+      ]
+    },
+    {
       "name": "slay_the_spire_ii",
       "display_name": "Slay the Spire 2",
       "version": "1.0.0",
@@ -875,21 +651,40 @@
       ]
     },
     {
-      "name": "unimol_tools",
-      "display_name": "Uni-Mol Tools",
+      "name": "rms",
+      "display_name": "Teltonika RMS",
       "version": "1.0.0",
-      "description": "Molecular property prediction — train and predict with 5 task types (classification, regression, multiclass, multilabel) for drug discovery",
-      "requires": "PyTorch 1.12+, Uni-Mol Tools backend",
-      "homepage": "https://github.com/dptech-corp/Uni-Mol/tree/main/unimol_tools",
+      "description": "Device management and monitoring via Teltonika RMS REST API",
+      "requires": "RMS_API_TOKEN",
+      "homepage": "https://rms.teltonika-networks.com",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=unimol_tools/agent-harness",
-      "entry_point": "cli-anything-unimol-tools",
-      "skill_md": "skills/cli-anything-unimol-tools/SKILL.md",
-      "category": "science",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=rms/agent-harness",
+      "entry_point": "cli-anything-rms",
+      "skill_md": "skills/cli-anything-rms/SKILL.md",
+      "category": "network",
       "contributors": [
         {
-          "name": "545487677",
-          "url": "https://github.com/545487677"
+          "name": "galke",
+          "url": "https://github.com/galke7"
+        }
+      ]
+    },
+    {
+      "name": "renderdoc",
+      "display_name": "RenderDoc",
+      "version": "0.1.0",
+      "description": "GPU frame capture analysis: pipeline state, shader export, texture inspection, draw call browsing",
+      "requires": "renderdoc (Python bindings from RenderDoc installation)",
+      "homepage": "https://renderdoc.org",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=renderdoc/agent-harness",
+      "entry_point": "cli-anything-renderdoc",
+      "skill_md": "skills/cli-anything-renderdoc/SKILL.md",
+      "category": "graphics",
+      "contributors": [
+        {
+          "name": "levishilf",
+          "url": "https://github.com/levishilf"
         }
       ]
     },
@@ -905,6 +700,25 @@
       "entry_point": "cli-anything-unrealinsights",
       "skill_md": "unrealinsights/agent-harness/cli_anything/unrealinsights/skills/SKILL.md",
       "category": "debugging",
+      "contributors": [
+        {
+          "name": "AiMiDi",
+          "url": "https://github.com/AiMiDi"
+        }
+      ]
+    },
+    {
+      "name": "nsight-graphics",
+      "display_name": "Nsight Graphics CLI",
+      "version": "0.2.0",
+      "description": "Windows-first Nsight Graphics CLI for Graphics/OpenGL capture, GPU Trace summary, Generate C++ Capture, and ngfx-replay analysis",
+      "requires": "NVIDIA Nsight Graphics installation with ngfx.exe plus optional split capture/replay tools",
+      "homepage": "https://developer.nvidia.com/nsight-graphics",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=nsight-graphics/agent-harness",
+      "entry_point": "cli-anything-nsight-graphics",
+      "skill_md": "skills/cli-anything-nsight-graphics/SKILL.md",
+      "category": "graphics",
       "contributors": [
         {
           "name": "AiMiDi",
@@ -932,63 +746,249 @@
       ]
     },
     {
-      "name": "wiremock",
-      "display_name": "WireMock",
-      "version": "0.1.0",
-      "description": "HTTP mock server management — create stubs, inspect requests, record traffic, and manage scenarios via WireMock REST API",
-      "requires": "WireMock server running (java -jar wiremock-standalone.jar)",
-      "homepage": "https://wiremock.org",
-      "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=wiremock/agent-harness",
-      "entry_point": "cli-anything-wiremock",
-      "skill_md": "skills/cli-anything-wiremock/SKILL.md",
-      "category": "testing",
-      "contributors": [
-        {
-          "name": "fabiomantel",
-          "url": "https://github.com/fabiomantel"
-        }
-      ]
-    },
-    {
-      "name": "zoom",
-      "display_name": "Zoom",
+      "name": "intelwatch",
+      "display_name": "Intelwatch",
       "version": "1.0.0",
-      "description": "Meeting management via Zoom REST API (OAuth2)",
-      "requires": "Zoom account + OAuth app credentials",
-      "homepage": "https://zoom.us",
+      "description": "Competitive intelligence, M&A due diligence, and OSINT directly from your terminal.",
+      "requires": "Node.js >=18",
+      "homepage": "https://github.com/ashroth/intelwatch",
       "source_url": null,
-      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=zoom/agent-harness",
-      "entry_point": "cli-anything-zoom",
-      "skill_md": "skills/cli-anything-zoom/SKILL.md",
-      "category": "communication",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=intelwatch/agent-harness",
+      "entry_point": "cli-anything-intelwatch",
+      "skill_md": "skills/cli-anything-intelwatch/SKILL.md",
+      "category": "osint",
       "contributors": [
         {
-          "name": "zhangxilong-43",
-          "url": "https://github.com/zhangxilong-43"
+          "name": "ashroth",
+          "url": "https://github.com/ashroth"
         }
       ]
     },
     {
-      "name": "zotero",
-      "display_name": "Zotero",
-      "version": "0.4.1",
-      "description": "CLI & MCP server for Zotero 7/8 — 52 MCP tools + 70+ CLI commands for search, import, PDF, BibTeX, notes, and more",
-      "requires": "Zotero 7/8 desktop app (running), Python 3.10+",
-      "homepage": "https://www.zotero.org",
-      "source_url": "https://github.com/PiaoyangGuohai1/cli-anything-zotero",
-      "install_cmd": "pip install cli-anything-zotero",
-      "entry_point": "cli-anything-zotero",
-      "skill_md": "https://github.com/PiaoyangGuohai1/cli-anything-zotero/blob/main/cli_anything/zotero/skills/SKILL.md",
-      "category": "office",
+      "name": "clibrowser",
+      "display_name": "clibrowser",
+      "version": "0.1.0",
+      "description": "Zero-dependency CLI browser for AI agents with search, extraction, forms, RSS, crawling, auth, and WebMCP support",
+      "requires": "Rust toolchain (cargo) for source install, or manual binary download from GitHub Releases",
+      "homepage": "https://github.com/allthingssecurity/clibrowser",
+      "source_url": null,
+      "install_cmd": "cargo install --git https://github.com/allthingssecurity/clibrowser.git --tag v0.1.0 --locked",
+      "entry_point": "clibrowser",
+      "skill_md": null,
+      "category": "web",
       "contributors": [
         {
-          "name": "zhiwuyazhe_fjr",
-          "url": "https://github.com/zhiwuyazhe-fjr"
-        },
+          "name": "allthingssecurity",
+          "url": "https://github.com/allthingssecurity"
+        }
+      ]
+    },
+    {
+      "name": "cloudcompare",
+      "display_name": "CloudCompare",
+      "version": "1.0.0",
+      "description": "3D point cloud and mesh processing: load/save, color ops, normal estimation, Delaunay meshing, noise filtering, ICP registration, connected component segmentation",
+      "requires": "cloudcompare (CloudCompare application installed, e.g. via Flatpak or package manager)",
+      "homepage": "https://cloudcompare.org",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=cloudcompare/agent-harness",
+      "entry_point": "cli-anything-cloudcompare",
+      "skill_md": "skills/cli-anything-cloudcompare/SKILL.md",
+      "category": "graphics",
+      "contributors": [
         {
-          "name": "PiaoyangGuohai1",
-          "url": "https://github.com/PiaoyangGuohai1"
+          "name": "Taeyoung96",
+          "url": "https://github.com/Taeyoung96"
+        }
+      ]
+    },
+    {
+      "name": "exa",
+      "display_name": "Exa",
+      "version": "1.0.0",
+      "description": "AI-powered web search and content extraction via the Exa API",
+      "requires": "EXA_API_KEY (free tier at exa.ai)",
+      "homepage": "https://exa.ai",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=exa/agent-harness",
+      "entry_point": "cli-anything-exa",
+      "skill_md": "skills/cli-anything-exa/SKILL.md",
+      "category": "search",
+      "contributors": [
+        {
+          "name": "tgonzalezc5",
+          "url": "https://github.com/tgonzalezc5"
+        }
+      ]
+    },
+    {
+      "name": "godot",
+      "display_name": "Godot Engine",
+      "version": "1.0.0",
+      "description": "Game engine project management, scene editing, export and GDScript execution via Godot 4 headless mode",
+      "requires": "Godot 4.x (godotengine.org)",
+      "homepage": "https://godotengine.org",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=godot/agent-harness",
+      "entry_point": "cli-anything-godot",
+      "skill_md": "skills/cli-anything-godot/SKILL.md",
+      "category": "gamedev",
+      "contributors": [
+        {
+          "name": "omerarslan0",
+          "url": "https://github.com/omerarslan0"
+        }
+      ]
+    },
+    {
+      "name": "dify-workflow",
+      "display_name": "Dify Workflow",
+      "version": "0.1.0",
+      "description": "CLI-Anything wrapper for the Dify workflow DSL editor covering create, inspect, validate, edit, export, and layout operations",
+      "requires": "Upstream dify-workflow CLI installed from https://github.com/Akabane71/dify-workflow-cli",
+      "homepage": "https://github.com/Akabane71/dify-workflow-cli",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=dify-workflow/agent-harness",
+      "entry_point": "cli-anything-dify-workflow",
+      "skill_md": "skills/cli-anything-dify-workflow/SKILL.md",
+      "category": "ai",
+      "contributors": [
+        {
+          "name": "Akabane71",
+          "url": "https://github.com/Akabane71"
+        }
+      ]
+    },
+    {
+      "name": "n8n",
+      "display_name": "n8n",
+      "version": "2.4.7",
+      "description": "Workflow automation via n8n REST API — 55+ commands",
+      "requires": "n8n >= 1.0.0",
+      "homepage": "https://n8n.io",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=n8n/agent-harness",
+      "entry_point": "cli-anything-n8n",
+      "skill_md": "skills/cli-anything-n8n/SKILL.md",
+      "category": "automation",
+      "contributors": [
+        {
+          "name": "webcomunicasolutions",
+          "url": "https://github.com/webcomunicasolutions"
+        }
+      ]
+    },
+    {
+      "name": "cloudanalyzer",
+      "display_name": "CloudAnalyzer",
+      "version": "1.0.0",
+      "description": "Point cloud and trajectory QA: Chamfer/AUC/F1, ATE/RPE/drift, ground segmentation metrics, config-driven quality gates, baseline evolution — harness wraps the CloudAnalyzer Python API",
+      "requires": "Python 3.10+; cloudanalyzer (`pip install cloudanalyzer`), Open3D for full IO/viewer paths",
+      "homepage": "https://github.com/rsasaki0109/CloudAnalyzer",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=cloudanalyzer/agent-harness",
+      "entry_point": "cli-anything-cloudanalyzer",
+      "skill_md": "skills/cli-anything-cloudanalyzer/SKILL.md",
+      "category": "graphics",
+      "contributors": [
+        {
+          "name": "rsasaki0109",
+          "url": "https://github.com/rsasaki0109"
+        }
+      ]
+    },
+    {
+      "name": "obsidian",
+      "display_name": "Obsidian",
+      "version": "1.0.0",
+      "description": "Knowledge management and note-taking — manage notes, search vault, execute commands via Obsidian Local REST API",
+      "requires": "Obsidian desktop app with Local REST API plugin enabled",
+      "homepage": "https://obsidian.md",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=obsidian/agent-harness",
+      "entry_point": "cli-anything-obsidian",
+      "skill_md": "skills/cli-anything-obsidian/SKILL.md",
+      "category": "knowledge",
+      "contributors": [
+        {
+          "name": "dorukozgen",
+          "url": "https://github.com/dorukozgen"
+        }
+      ]
+    },
+    {
+      "name": "unimol_tools",
+      "display_name": "Uni-Mol Tools",
+      "version": "1.0.0",
+      "description": "Molecular property prediction — train and predict with 5 task types (classification, regression, multiclass, multilabel) for drug discovery",
+      "requires": "PyTorch 1.12+, Uni-Mol Tools backend",
+      "homepage": "https://github.com/dptech-corp/Uni-Mol/tree/main/unimol_tools",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=unimol_tools/agent-harness",
+      "entry_point": "cli-anything-unimol-tools",
+      "skill_md": "skills/cli-anything-unimol-tools/SKILL.md",
+      "category": "science",
+      "contributors": [
+        {
+          "name": "545487677",
+          "url": "https://github.com/545487677"
+        }
+      ]
+    },
+    {
+      "name": "safari",
+      "display_name": "Safari",
+      "version": "1.0.0",
+      "description": "Native macOS Safari browser automation via safari-mcp — 84 tools for navigation, DOM, forms, network capture, and screenshots",
+      "requires": "macOS, Safari, safari-mcp (npm install -g safari-mcp)",
+      "homepage": "https://github.com/achiya-automation/safari-mcp",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=safari/agent-harness",
+      "entry_point": "cli-anything-safari",
+      "skill_md": "skills/cli-anything-safari/SKILL.md",
+      "category": "web",
+      "contributors": [
+        {
+          "name": "achiya-automation",
+          "url": "https://github.com/achiya-automation"
+        }
+      ]
+    },
+    {
+      "name": "openclaw-macro",
+      "display_name": "OpenClaw Macro System",
+      "version": "1.0.0",
+      "description": "Layered CLI that converts GUI workflows into parameterized, agent-callable macros — with backend routing across native APIs, file transforms, accessibility controls, and compiled GUI replay",
+      "requires": null,
+      "homepage": "https://github.com/HKUDS/CLI-Anything",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=openclaw-skill/agent-harness",
+      "entry_point": "cli-anything-openclaw",
+      "skill_md": "openclaw-skill/agent-harness/cli_anything/openclaw/skills/SKILL.md",
+      "category": "automation",
+      "contributors": [
+        {
+          "name": "haorui-harry",
+          "url": "https://github.com/haorui-harry"
+        }
+      ]
+    },
+    {
+      "name": "quietshrink",
+      "display_name": "QuietShrink",
+      "version": "1.0.0",
+      "description": "Compress macOS screen recordings on Apple Silicon — 70-90% smaller files at visually lossless quality, hardware-encoded, computer stays silent",
+      "requires": "ffmpeg with hevc_videotoolbox + the quietshrink bash CLI (curl -fsSL https://raw.githubusercontent.com/achiya-automation/quietshrink/main/install.sh | bash)",
+      "homepage": "https://github.com/achiya-automation/quietshrink",
+      "source_url": "https://github.com/achiya-automation/quietshrink",
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=quietshrink/agent-harness",
+      "entry_point": "cli-anything-quietshrink",
+      "skill_md": "quietshrink/agent-harness/cli_anything/quietshrink/skills/SKILL.md",
+      "category": "video",
+      "contributors": [
+        {
+          "name": "achiya-automation",
+          "url": "https://github.com/achiya-automation"
         }
       ]
     }

--- a/skills/cli-anything-quietshrink/SKILL.md
+++ b/skills/cli-anything-quietshrink/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: "cli-anything-quietshrink"
+description: Compress macOS screen recordings with zero CPU stress using Apple Silicon's hardware HEVC encoder. Typically reduces file size 70-90% while staying visually lossless. Computer stays silent during encoding.
+---
+
+# quietshrink — Agent Skill
+
+You have access to `cli-anything-quietshrink`, a CLI for compressing video files on macOS Apple Silicon. It uses the Media Engine (hardware HEVC encoder), not the CPU, so encoding is fast and silent.
+
+## When to use it
+
+- User wants to compress a screen recording, screencast, or any .mov/.mp4 file
+- File is too large to share (chat, email, GitHub)
+- Need smaller files but cannot tolerate visible quality loss
+- Apple Silicon Mac (M1/M2/M3/M4) — best results
+
+**Don't** use this on non-screen content (camera footage, vlogs) — savings will be much smaller because there are no duplicate frames to drop.
+
+## Commands
+
+```bash
+# Compress with default transparent quality
+cli-anything-quietshrink compress <input> [output]
+
+# Compress with specific preset
+cli-anything-quietshrink compress -q tiny <input>     # smallest
+cli-anything-quietshrink compress -q transparent <input>  # default, visually lossless
+cli-anything-quietshrink compress -q pristine <input>     # near-source quality
+
+# Inspect a file before compressing
+cli-anything-quietshrink probe <input>
+
+# List quality presets
+cli-anything-quietshrink presets
+
+# Verify environment
+cli-anything-quietshrink doctor
+```
+
+All commands accept `--json` for machine-readable output.
+
+## Quality presets
+
+| Preset | q | Typical reduction | SSIM | Use case |
+|--------|---|-------------------|------|----------|
+| `tiny` | 50 | ~90% | ~0.95 | Chat/email — small artifacts OK |
+| `balanced` | 55 | ~88% | ~0.99 | Docs/sharing — high quality |
+| `transparent` (default) | 60 | ~87% | ~0.99+ | **Anything important** — visually lossless |
+| `pristine` | 70 | ~84% | ~0.997 | Archival — near-source |
+
+## JSON output schema
+
+`compress` returns:
+```json
+{
+  "input": "/path/to/input.mov",
+  "output": "/path/to/output.mov",
+  "input_size": 105952129,
+  "output_size": 12345678,
+  "saved_bytes": 93606451,
+  "saved_percent": 88.3,
+  "duration_seconds": 193.3,
+  "elapsed_seconds": 87,
+  "encoding_speed": "2.2x",
+  "quality_preset": "transparent",
+  "q_value": 60,
+  "gop": 600
+}
+```
+
+`probe` returns:
+```json
+{
+  "path": "...",
+  "size_bytes": 105952129,
+  "size_mb": 101.04,
+  "codec": "h264",
+  "width": 3024,
+  "height": 1964,
+  "framerate": "120/1",
+  "duration_seconds": 193.31
+}
+```
+
+## Decision flow for agents
+
+```
+User wants to share a recording
+  ├─ Is it on Apple Silicon Mac? → use quietshrink
+  │  ├─ For chat/email/quick share → -q tiny
+  │  ├─ For docs/important sharing → -q transparent (default)
+  │  └─ For archival/editing → -q pristine
+  └─ Not on Mac? → falls back to software, less efficient
+```
+
+Before processing, run `doctor` to verify environment.
+For unfamiliar files, run `probe` to understand resolution/codec/duration.
+
+## Errors and recovery
+
+- `ffmpeg not found` → `brew install ffmpeg`
+- `hevc_videotoolbox not available` → `brew reinstall ffmpeg`
+- `compression_failed` → check input file isn't corrupted; try `--verbose` mode to see ffmpeg errors
+
+## Source
+
+- Main repo: https://github.com/achiya-automation/quietshrink
+- Bash CLI: `quietshrink` command (via the install script)
+- Why this approach works: see [WHY.md](https://github.com/achiya-automation/quietshrink/blob/main/WHY.md)


### PR DESCRIPTION
## Summary

Adds an agent-native CLI harness for [quietshrink](https://github.com/achiya-automation/quietshrink) — a macOS Apple Silicon tool that compresses screen recordings to **70-90% smaller files at visually lossless quality (SSIM 0.99+)**, while keeping the computer **silent** (it uses Apple's hardware HEVC encoder, not the CPU).

## Why this fills a gap

CLI-Anything has three video harnesses today:

| Harness | What it does |
|---|---|
| `kdenlive` | Video editor |
| `openscreen` | Screen recording editor (zoom, speed ramps, annotations) |
| `videocaptioner` | AI captioning |

**None of them compress.** Users producing screencasts (and the agents helping them) routinely need to shrink files for chat, email, GitHub, etc. quietshrink fills this niche specifically for the Apple Silicon Mac demographic — which is a meaningful slice of CLI-Anything's audience.

## What the harness exposes

```bash
cli-anything-quietshrink compress <input> [output]   # Compress a file
cli-anything-quietshrink probe <input>               # Inspect codec/dims/duration
cli-anything-quietshrink presets                     # List quality profiles
cli-anything-quietshrink doctor                      # Verify ffmpeg + hevc_videotoolbox + bash CLI
```

All commands accept `--json` for machine-readable output. The skill file at `quietshrink/agent-harness/cli_anything/quietshrink/skills/SKILL.md` documents the decision flow for agents.

### Quality presets (SSIM-validated empirically)

| Preset | q | Reduction | SSIM | Use case |
|--------|---|-----------|------|----------|
| `tiny` | 50 | ~90% | ~0.95 | chat / email |
| `balanced` | 55 | ~88% | ~0.99 | docs / sharing |
| `transparent` (default) | 60 | ~87% | ~0.99+ | visually lossless |
| `pristine` | 70 | ~84% | ~0.997 | archival |

## Architecture

The harness is a thin Python wrapper (click + JSON) around the standalone `quietshrink` bash CLI (~200 LOC). The bash CLI is the core: it runs `ffmpeg -c:v hevc_videotoolbox -q:v 60 -vf mpdecimate -g 600 ...` with parameters tuned via empirical SSIM measurement (see [WHY.md](https://github.com/achiya-automation/quietshrink/blob/main/WHY.md) for the engineering decisions).

Why a thin wrapper:
- The encoding logic must stay close to ffmpeg invariants
- Standalone bash CLI is the audience's primary interaction (humans on macOS)
- The Python harness is purely about agent ergonomics (JSON, structured probes, skill file)

## Tests

Tests live with the standalone CLI: 6 smoke tests passing on macOS CI ([action runs](https://github.com/achiya-automation/quietshrink/actions)). The harness itself shells out and re-emits — no separate test logic needed. See [TEST.md](quietshrink/agent-harness/TEST.md).

## Install path

```bash
pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=quietshrink/agent-harness
```

The bash CLI is required separately (one-line install in the harness docs).

## Test plan

- [x] `pip install` succeeds (verified locally)
- [x] `cli-anything-quietshrink doctor --json` reports `ready: true` on Apple Silicon Mac with ffmpeg
- [x] `cli-anything-quietshrink probe` returns correct codec/dims/duration for a real .mov
- [x] `cli-anything-quietshrink compress` actually compresses (~89% reduction observed on a 4 MB sample)
- [x] `cli-anything-quietshrink presets --json` returns 4 presets

🤖 Generated with [Claude Code](https://claude.com/claude-code)