### PR TITLE
feat: add hacker-feeds-cli to registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1080,12 +1080,8 @@
       "entry_point": "cli-anything-hacker-feeds-cli",
       "skill_md": "https://github.com/collectivewinca/hacker-feeds-cli/blob/main/cli_anything/hacker_feeds_cli/skills/SKILL.md",
       "category": "search",
-      "contributors": [
-        {
-          "name": "collectivewinca",
-          "url": "https://github.com/collectivewinca"
-        }
-      ]
+      "contributor": "collectivewinca",
+      "contributor_url": "https://github.com/collectivewinca"
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -1067,6 +1067,25 @@
           "url": "https://github.com/bobbymarko"
         }
       ]
+    },
+    {
+      "name": "hacker-feeds-cli",
+      "display_name": "Hacker Feeds CLI",
+      "version": "1.0.0",
+      "description": "CLI for GitHub Trending, Hacker News, Reddit, Product Hunt, DEV.to, Lobsters, EchoJS, and V2EX feeds",
+      "requires": "Python 3.10+, Node.js (hf CLI)",
+      "homepage": "https://github.com/collectivewinca/hacker-feeds-cli",
+      "source_url": "https://github.com/collectivewinca/hacker-feeds-cli",
+      "install_cmd": "pip install git+https://github.com/collectivewinca/hacker-feeds-cli.git",
+      "entry_point": "cli-anything-hacker-feeds-cli",
+      "skill_md": "https://github.com/collectivewinca/hacker-feeds-cli/blob/main/cli_anything/hacker_feeds_cli/skills/SKILL.md",
+      "category": "search",
+      "contributors": [
+        {
+          "name": "collectivewinca",
+          "url": "https://github.com/collectivewinca"
+        }
+      ]
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -1080,8 +1080,12 @@
       "entry_point": "cli-anything-hacker-feeds-cli",
       "skill_md": "https://github.com/collectivewinca/hacker-feeds-cli/blob/main/cli_anything/hacker_feeds_cli/skills/SKILL.md",
       "category": "search",
-      "contributor": "collectivewinca",
-      "contributor_url": "https://github.com/collectivewinca"
+      "contributors": [
+        {
+          "name": "collectivewinca",
+          "url": "https://github.com/collectivewinca"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add hacker-feeds-cli (tech news feeds) to CLI-Hub registry.