### PR TITLE
feat(registry): add Stata CLI harness (standalone repo)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1010,6 +1010,25 @@
           "url": "https://github.com/achiya-automation"
         }
       ]
+    },
+    {
+      "name": "stata",
+      "display_name": "Stata",
+      "version": "0.1.0",
+      "description": "Run Stata do-files, batch jobs, and reproducible econometric projects from the terminal with JSON output, log parsing, project scaffolding, and security guard",
+      "requires": "Licensed Stata installation (StataMP/SE/BE 15+), Python 3.10+",
+      "homepage": "https://www.stata.com",
+      "source_url": "https://github.com/LI-Meng420/stata-cli",
+      "install_cmd": "pip install git+https://github.com/LI-Meng420/stata-cli.git",
+      "entry_point": "cli-anything-stata",
+      "skill_md": "https://raw.githubusercontent.com/LI-Meng420/stata-cli/main/cli_anything/stata/skills/SKILL.md",
+      "category": "science",
+      "contributors": [
+        {
+          "name": "LI-Meng420",
+          "url": "https://github.com/LI-Meng420"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add registry entry for **cli-anything-stata**, a standalone Stata agent harness
- Hosted at https://github.com/LI-Meng420/stata-cli
- Follows CLI-Anything harness architecture (Option 2: Standalone repository)

## What it does

CLI harness for running real Stata `.do` files from a shell, coding agent, or reproducible analysis pipeline. Features include:

- **do-file execution** with profile, globals, arguments, adopath, and logging
- **Batch execution** via manifests and globs
- **Project scaffolding** with templates for DID, IV, panel, simulation
- **Log parsing** with error/warning/metric extraction
- **Security guard** with command blacklist
- **JSON output** for agent integration
- **Interactive REPL**

## Checklist

- [x] Standalone repo with tests and SKILL.md
- [x] Registry entry with  pointing to repo
- [x]  pointing to raw SKILL.md URL
- [x] Only  modified in this PR (no code in monorepo)
