### PR TITLE
feat: add Ink/Stitch CLI harness (standalone)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1033,7 +1033,7 @@
     {
       "name": "inkstitch",
       "display_name": "Ink/Stitch",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "Machine-embroidery digitization — set stitch params, validate, preview, and export to DST/PES/JEF/VP3 via Ink/Stitch",
       "requires": "Ink/Stitch extension installed (https://inkstitch.org/docs/install/)",
       "homepage": "https://inkstitch.org",

--- a/registry.json
+++ b/registry.json
@@ -1029,6 +1029,25 @@
           "url": "https://github.com/LI-Meng420"
         }
       ]
+    },
+    {
+      "name": "inkstitch",
+      "display_name": "Ink/Stitch",
+      "version": "0.1.0",
+      "description": "Machine-embroidery digitization — set stitch params, validate, preview, and export to DST/PES/JEF/VP3 via Ink/Stitch",
+      "requires": "Ink/Stitch extension installed (https://inkstitch.org/docs/install/)",
+      "homepage": "https://inkstitch.org",
+      "source_url": "https://github.com/bobbymarko/cli-anything-inkstitch",
+      "install_cmd": "pip install cli-anything-inkstitch",
+      "entry_point": "cli-anything-inkstitch",
+      "skill_md": "https://github.com/bobbymarko/cli-anything-inkstitch/blob/main/skills/cli-anything-inkstitch/SKILL.md",
+      "category": "design",
+      "contributors": [
+        {
+          "name": "bobbymarko",
+          "url": "https://github.com/bobbymarko"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds registry entry for `cli-anything-inkstitch`, a standalone stateful CLI harness for machine-embroidery digitization with Ink/Stitch
- Package is published on PyPI: `pip install cli-anything-inkstitch`
- Source repo: https://github.com/bobbymarko/cli-anything-inkstitch

## Checklist

- [x] Standalone repo with published PyPI package
- [x] `SKILL.md` present at the linked URL
- [x] Test suite present in the source repo
- [x] `registry.json` entry added (registry-only PR, no monorepo code)

## Test plan

- [ ] Confirm `pip install cli-anything-inkstitch` installs cleanly
- [ ] Confirm `skill_md` URL resolves to a valid SKILL.md
- [ ] Confirm hub entry renders correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)