### PR TITLE
fix(zotero_http): default Content-Type for raw data + raise connector import timeouts

### DIFF
--- a/zotero/agent-harness/cli_anything/zotero/utils/zotero_http.py
+++ b/zotero/agent-harness/cli_anything/zotero/utils/zotero_http.py
@@ -63,6 +63,7 @@ def request(
         body_data = json.dumps(payload).encode("utf-8")
     elif data is not None:
         body_data = data.encode("utf-8") if isinstance(data, str) else data
+        request_headers.setdefault("Content-Type", "text/plain; charset=utf-8")
     req = urllib.request.Request(
         _build_url(port, path, params=params),
         data=body_data,
@@ -101,7 +102,7 @@ def get_selected_collection(port: int, timeout: int = 5) -> dict[str, Any]:
     return response.json()
 
 
-def connector_import_text(port: int, content: str, *, session_id: str | None = None, timeout: int = 20) -> list[dict[str, Any]]:
+def connector_import_text(port: int, content: str, *, session_id: str | None = None, timeout: int = 300) -> list[dict[str, Any]]:
     params = {"session": session_id} if session_id else None
     response = request(port, "/connector/import", method="POST", params=params, data=content, timeout=timeout)
     if response.status != 201:
@@ -110,7 +111,7 @@ def connector_import_text(port: int, content: str, *, session_id: str | None = N
     return parsed if isinstance(parsed, list) else [parsed]
 
 
-def connector_save_items(port: int, items: list[dict[str, Any]], *, session_id: str, timeout: int = 20) -> None:
+def connector_save_items(port: int, items: list[dict[str, Any]], *, session_id: str, timeout: int = 120) -> None:
     response = request(
         port,
         "/connector/saveItems",
@@ -161,7 +162,7 @@ def connector_update_session(
     session_id: str,
     target: str,
     tags: list[str] | tuple[str, ...] | None = None,
-    timeout: int = 15,
+    timeout: int = 60,
 ) -> dict[str, Any]:
     response = request(
         port,


### PR DESCRIPTION
## Summary

Two related bugs in `zotero/agent-harness/cli_anything/zotero/utils/zotero_http.py` that together cause real BibTeX imports through `/connector/import` to fail even when Zotero would otherwise accept them.

### 1. Missing default `Content-Type` when caller passes raw `data`

`request()` sets `Content-Type: application/json` on the `payload` branch but leaves the `data` branch with no default. Without an explicit header, Zotero's connector returns HTTP 400 on raw BibTeX/RIS bodies posted to `/connector/import`. The fix mirrors the existing `setdefault` pattern from the `payload` branch and uses `text/plain; charset=utf-8`, which is the content type the connector's text translator expects.

### 2. Connector timeouts too tight for real Zotero behavior

Empirically, `/connector/import` of a single BibTeX entry on a warm local Zotero takes ~13–21s (translate → create item → DB write). The previous defaults timed out on multi-entry `.bib` files even though the import succeeded server-side, leaving callers with spurious `RuntimeError` exceptions and the harness convinced the import had failed. Bumped:

| function | before | after |
|---|---|---|
| `connector_import_text` | 20s | 300s |
| `connector_save_items` | 20s | 120s |
| `connector_update_session` | 15s | 60s |

`connector_save_attachment` (60s) and the local-API helpers were already roomy enough and are left alone.

## Test plan

- [x] Reproduced HTTP 400 from `/connector/import` on a 7-entry `.bib` against a real Zotero 7 with the original code.
- [x] After the patch, ran a full import session: 89/90 entries successfully landed across 6 collections, no spurious timeouts.
- [ ] (Maintainer) Consider a regression test that POSTs raw text to `/connector/import` without an explicit `Content-Type` header and asserts the request is accepted.

## Notes

- The `data`-branch default is conservative: callers that pass a different MIME type (e.g. `connector_save_attachment`'s explicit `application/pdf`) still win because of `setdefault`.
- All four changes live in a single file (`zotero/agent-harness/cli_anything/zotero/utils/zotero_http.py`), 4 insertions / 3 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)