### PR TITLE
feat: add DeployHQ CLI (dhq) to CLI-Hub registry

### DIFF
--- a/public_registry.json
+++ b/public_registry.json
@@ -339,6 +339,29 @@
           "url": "https://github.com/yanmingyu92"
         }
       ]
+    },
+    {
+      "name": "deployhq",
+      "display_name": "DeployHQ CLI",
+      "version": "0.16.3",
+      "description": "Deploy code, manage projects/servers, run and monitor deployments via the DeployHQ platform — for humans and AI agents",
+      "category": "devops",
+      "requires": "DeployHQ account (free tier available); Homebrew for the default install path",
+      "homepage": "https://www.deployhq.com",
+      "source_url": "https://github.com/deployhq/deployhq-cli",
+      "package_manager": "brew",
+      "install_strategy": "command",
+      "install_cmd": "brew install deployhq/tap/dhq",
+      "uninstall_cmd": "brew uninstall dhq",
+      "update_cmd": "brew upgrade dhq",
+      "skill_md": "https://github.com/deployhq/deployhq-cli/blob/main/skills/deployhq/SKILL.md",
+      "entry_point": "dhq",
+      "contributors": [
+        {
+          "name": "MartaKar",
+          "url": "https://github.com/MartaKar"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a CLI-Hub registry entry for `dhq`, the DeployHQ CLI — deploy code, manage projects/servers, and monitor deployments from the terminal
- Standalone repo: https://github.com/deployhq/deployhq-cli
- SKILL.md: https://github.com/deployhq/deployhq-cli/blob/main/skills/deployhq/SKILL.md
- Built for both humans and AI agents: `--json` on every command, auto non-interactive mode when piped or under an agent, structured errors instead of prompts

## Checklist

- [x] Standalone repo, registry-only PR (no monorepo code)
- [x] CLI installable via `brew install deployhq/tap/dhq` (also `go install` and binary releases — non-pip precedent: `clibrowser` cargo, `sketch` npm)
- [x] `SKILL.md` present at the linked URL with reference docs for each command group
- [x] Test suite present in the source repo (Go unit tests + eval suite under `skill-evals/`)

## Validation

- `python3 -m json.tool registry.json` — registry parses cleanly
- `brew install deployhq/tap/dhq && dhq --version` → `dhq version v0.16.3`
- SKILL.md URL resolves (HTTP 200)