### PR TITLE
fix(n8n): drop bogus arg from print_banner call to unbreak REPL

### DIFF
--- a/n8n/agent-harness/cli_anything/n8n/n8n_cli.py
+++ b/n8n/agent-harness/cli_anything/n8n/n8n_cli.py
@@ -127,8 +127,7 @@ def repl(ctx: click.Context) -> None:
         click.echo("prompt-toolkit is required for REPL mode. Install: pip install prompt-toolkit")
         sys.exit(1)
 
-    base_url = ctx.obj["base_url"]
-    print_banner(base_url or "(not configured)")
+    print_banner()
 
     # Build completer from all CLI commands
     words = ["help", "exit", "quit", "status"]

--- a/n8n/agent-harness/cli_anything/n8n/tests/test_repl_invocation.py
+++ b/n8n/agent-harness/cli_anything/n8n/tests/test_repl_invocation.py
@@ -1,0 +1,34 @@
+"""Regression test for issue #278: cli-anything-n8n REPL must not TypeError on print_banner.
+
+The bug: n8n_cli.py called print_banner(base_url or "(not configured)") but
+print_banner takes no arguments, so invoking `cli-anything-n8n` with no
+subcommand raised TypeError before the REPL prompt was ever reached.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+from cli_anything.n8n import n8n_cli
+from cli_anything.n8n.utils import repl_skin
+
+
+def test_print_banner_takes_no_args():
+    """The wrapper at repl_skin.print_banner accepts no positional args; callers
+    must not pass any."""
+    sig = inspect.signature(repl_skin.print_banner)
+    assert len(sig.parameters) == 0, (
+        f"repl_skin.print_banner() takes no positional args; callers must call "
+        f"it with no arguments. Got params: {list(sig.parameters)}"
+    )
+
+
+def test_n8n_cli_repl_does_not_pass_args_to_print_banner():
+    """The REPL invocation site in n8n_cli.py must call print_banner() with no
+    arguments. Reading the source guards against the call signature drifting
+    out of sync with the function definition again."""
+    src = Path(n8n_cli.__file__).read_text()
+    assert "print_banner(base_url" not in src, (
+        "n8n_cli.py is passing base_url to print_banner(); the function takes "
+        "no arguments. See issue #278."
+    )


### PR DESCRIPTION
`n8n/agent-harness/cli_anything/n8n/n8n_cli.py:131` calls `print_banner(base_url or "(not configured)")` but the function at `cli_anything/n8n/utils/repl_skin.py:592` takes no arguments. Running `cli-anything-n8n` with no subcommand triggers `ctx.invoke(repl)` at line 113, which hits the broken call before the REPL prompt is reached.

```
$ cli-anything-n8n
TypeError: print_banner() takes 0 positional arguments but 1 was given
```

The `base_url` local at line 130 is only used by this broken call and is otherwise dead in the `repl()` function, so the minimal fix is to drop both lines and call `print_banner()` directly.

If the original intent was to surface the configured URL in the banner, that is a separate enhancement: the function would need to accept and render a URL, and the banner template would need updating. Out of scope here; this PR just restores the REPL to a working state.

Added `cli_anything/n8n/tests/test_repl_invocation.py` with two cases:

1. `test_print_banner_takes_no_args` asserts `repl_skin.print_banner`'s signature has zero parameters. Catches a future regression where someone adds a parameter back to the function without updating callers.
2. `test_n8n_cli_repl_does_not_pass_args_to_print_banner` reads the source of `n8n_cli.py` and asserts the call site doesn't pass `base_url`. Catches a future regression on the call site itself.

On main the second test fails (`'print_banner(base_url' is contained here: ...`); with the fix both pass:

```
$ python -m pytest cli_anything/n8n/tests/test_repl_invocation.py -v
2 passed in 0.12s
```

Closes #278
