### PR TITLE
fix(obsidian): use vendor Content-Type for /search/ (DQL + JsonLogic)

### DIFF
--- a/obsidian/agent-harness/OBSIDIAN.md
+++ b/obsidian/agent-harness/OBSIDIAN.md
@@ -45,7 +45,7 @@ Our CLI wraps the Obsidian Local REST API plugin with:
 | `/vault/{path}` | PUT | Create/update note |
 | `/vault/{path}` | DELETE | Delete note |
 | `/vault/{path}` | PATCH | Append/prepend to note |
-| `/search/` | POST | Search with Obsidian syntax |
+| `/search/` | POST | Structured search — Dataview DQL (`application/vnd.olrapi.dataview.dql+txt`) or JsonLogic (`application/vnd.olrapi.jsonlogic+json`) |
 | `/search/simple/` | POST | Plain text search |
 | `/active/` | GET | Get active note |
 | `/active/` | PUT | Open a note |
@@ -68,7 +68,7 @@ All requests use HTTPS with a self-signed certificate (`verify=False`).
 | `vault update <path>` | `PUT /vault/{path}` |
 | `vault delete <path>` | `DELETE /vault/{path}` |
 | `vault append <path>` | `PATCH /vault/{path}` |
-| `search query <q>` | `POST /search/` |
+| `search query <q> [--type dql\|jsonlogic]` | `POST /search/` (raw body, vendor Content-Type) |
 | `search simple <q>` | `POST /search/simple/` |
 | `note active` | `GET /active/` |
 | `note open <path>` | `PUT /active/` |

--- a/obsidian/agent-harness/cli_anything/obsidian/README.md
+++ b/obsidian/agent-harness/cli_anything/obsidian/README.md
@@ -67,8 +67,15 @@ vault append <path> --content "..."        # Append content to a note
 ### Search
 
 ```bash
-search query <query>                        # Search using Obsidian query syntax
-search simple <query>                       # Plain text search across the vault
+# Dataview DQL (default) — body is sent verbatim with
+# Content-Type: application/vnd.olrapi.dataview.dql+txt
+search query 'TABLE file.link FROM "Projects"'
+
+# JsonLogic — Content-Type: application/vnd.olrapi.jsonlogic+json
+search query --type jsonlogic '{"==":[{"var":"frontmatter.status"},"active"]}'
+
+# Plain text search across the vault (GET /search/simple/)
+search simple <query>
 ```
 
 ### Note

--- a/obsidian/agent-harness/cli_anything/obsidian/core/search.py
+++ b/obsidian/agent-harness/cli_anything/obsidian/core/search.py
@@ -1,20 +1,45 @@
 """Obsidian search operations — query and simple text search."""
 
-from cli_anything.obsidian.utils.obsidian_backend import api_post
+from cli_anything.obsidian.utils.obsidian_backend import api_post, api_post_raw
+
+# Content types accepted by Obsidian Local REST API on POST /search/.
+# See https://coddingtonbear.github.io/obsidian-local-rest-api/#/Search
+SEARCH_CONTENT_TYPES = {
+    "dql": "application/vnd.olrapi.dataview.dql+txt",
+    "jsonlogic": "application/vnd.olrapi.jsonlogic+json",
+}
 
 
-def search_query(base_url: str, api_key: str, query: str) -> dict:
-    """Search vault using Obsidian's search engine.
+def search_query(base_url: str, api_key: str, query: str,
+                 query_type: str = "dql") -> dict:
+    """Search vault using Obsidian's structured search engine.
+
+    Obsidian's ``/search/`` endpoint expects a vendor-specific Content-Type and
+    a raw body (not a JSON-wrapped ``{"query": ...}`` payload). Sending
+    ``application/json`` results in ``40012 Unknown or invalid Content-Type``.
 
     Args:
         base_url: API base URL.
         api_key: Bearer token.
-        query: Search query string (Obsidian search syntax).
+        query: Search query body. For ``dql``, raw Dataview DQL text. For
+            ``jsonlogic``, a JsonLogic expression as a JSON string.
+        query_type: ``"dql"`` (default) or ``"jsonlogic"``.
 
     Returns:
         Search results from Obsidian.
+
+    Raises:
+        ValueError: If ``query_type`` is not a supported value.
     """
-    return api_post(base_url, "/search/", api_key, data={"query": query})
+    try:
+        content_type = SEARCH_CONTENT_TYPES[query_type]
+    except KeyError as e:
+        valid = ", ".join(sorted(SEARCH_CONTENT_TYPES))
+        raise ValueError(
+            f"Unsupported search query_type {query_type!r}. Valid: {valid}."
+        ) from e
+    return api_post_raw(base_url, "/search/", api_key,
+                        body=query, content_type=content_type)
 
 
 def search_simple(base_url: str, api_key: str, query: str,

--- a/obsidian/agent-harness/cli_anything/obsidian/obsidian_cli.py
+++ b/obsidian/agent-harness/cli_anything/obsidian/obsidian_cli.py
@@ -236,11 +236,19 @@ def search():
 
 @search.command("query")
 @click.argument("query")
+@click.option("--type", "query_type",
+              type=click.Choice(["dql", "jsonlogic"]), default="dql",
+              help="Query language: dql (Dataview, default) or jsonlogic.")
 @handle_error
-def search_query(query):
-    """Search vault using Obsidian's search engine."""
+def search_query(query, query_type):
+    """Search vault using Obsidian's structured search engine.
+
+    The query body is sent verbatim with the matching vendor Content-Type:
+    Dataview DQL as application/vnd.olrapi.dataview.dql+txt, JsonLogic as
+    application/vnd.olrapi.jsonlogic+json.
+    """
     _require_api_key()
-    result = search_mod.search_query(_host, _api_key, query)
+    result = search_mod.search_query(_host, _api_key, query, query_type=query_type)
     if _json_output:
         output(result)
     else:

--- a/obsidian/agent-harness/cli_anything/obsidian/obsidian_cli.py
+++ b/obsidian/agent-harness/cli_anything/obsidian/obsidian_cli.py
@@ -408,7 +408,7 @@ def repl():
     global _repl_mode
     _repl_mode = True
 
-    skin = ReplSkin("obsidian", version="1.0.0")
+    skin = ReplSkin("obsidian", version="1.1.0")
     skin.print_banner()
 
     pt_session = skin.create_prompt_session()

--- a/obsidian/agent-harness/cli_anything/obsidian/skills/SKILL.md
+++ b/obsidian/agent-harness/cli_anything/obsidian/skills/SKILL.md
@@ -150,11 +150,16 @@ cli-anything-obsidian vault append "Projects/new-project.md" --content "\n## New
 ### Search
 
 ```bash
-# Plain text search
+# Plain text search (GET /search/simple/)
 cli-anything-obsidian search simple "meeting notes"
 
-# Obsidian query syntax search (tags, links, etc.)
-cli-anything-obsidian search query "tag:#project"
+# Dataview DQL query — default --type dql, sent as
+# application/vnd.olrapi.dataview.dql+txt
+cli-anything-obsidian search query 'TABLE file.link FROM "Projects"'
+
+# JsonLogic query — application/vnd.olrapi.jsonlogic+json
+cli-anything-obsidian search query --type jsonlogic \
+  '{"==":[{"var":"frontmatter.status"},"active"]}'
 ```
 
 

--- a/obsidian/agent-harness/cli_anything/obsidian/skills/SKILL.md
+++ b/obsidian/agent-harness/cli_anything/obsidian/skills/SKILL.md
@@ -237,4 +237,4 @@ When using this CLI programmatically:
 
 ## Version
 
-1.0.0
+1.1.0

--- a/obsidian/agent-harness/cli_anything/obsidian/tests/test_core.py
+++ b/obsidian/agent-harness/cli_anything/obsidian/tests/test_core.py
@@ -50,6 +50,44 @@ class TestBackend:
         with pytest.raises(RuntimeError, match="Cannot connect to Obsidian"):
             api_post("https://localhost:27124", "/search/", "test-key", data={"query": "test"})
 
+    @patch("cli_anything.obsidian.utils.obsidian_backend.requests.post")
+    def test_api_post_raw_sends_body_and_content_type(self, mock_post):
+        from cli_anything.obsidian.utils.obsidian_backend import api_post_raw
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b'[]'
+        mock_resp.headers = {"content-type": "application/json"}
+        mock_resp.json.return_value = []
+        mock_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_resp
+
+        api_post_raw(
+            "https://localhost:27124", "/search/", "test-key",
+            body='TABLE file.link FROM "x"',
+            content_type="application/vnd.olrapi.dataview.dql+txt",
+        )
+        mock_post.assert_called_once_with(
+            "https://localhost:27124/search/",
+            headers={
+                "Authorization": "Bearer test-key",
+                "Accept": "application/json",
+                "Content-Type": "application/vnd.olrapi.dataview.dql+txt",
+            },
+            data=b'TABLE file.link FROM "x"',
+            params=None,
+            timeout=30,
+            verify=False,
+        )
+
+    @patch("cli_anything.obsidian.utils.obsidian_backend.requests.post")
+    def test_api_post_raw_connection_error(self, mock_post):
+        from cli_anything.obsidian.utils.obsidian_backend import api_post_raw
+        import requests
+        mock_post.side_effect = requests.exceptions.ConnectionError()
+        with pytest.raises(RuntimeError, match="Cannot connect to Obsidian"):
+            api_post_raw("https://localhost:27124", "/search/", "test-key",
+                         body="x", content_type="text/plain")
+
     @patch("cli_anything.obsidian.utils.obsidian_backend.requests.delete")
     def test_api_delete_connection_error(self, mock_delete):
         from cli_anything.obsidian.utils.obsidian_backend import api_delete
@@ -199,15 +237,36 @@ class TestVaultModule:
 
 
 class TestSearchModule:
-    @patch("cli_anything.obsidian.core.search.api_post")
-    def test_search_query(self, mock_api):
+    @patch("cli_anything.obsidian.core.search.api_post_raw")
+    def test_search_query_default_dql(self, mock_api):
         from cli_anything.obsidian.core.search import search_query
         mock_api.return_value = [{"filename": "note.md", "score": 0.9}]
-        result = search_query("https://localhost:27124", "test-key", "test query")
+        search_query("https://localhost:27124", "test-key",
+                     'TABLE file.link FROM "90-System"')
         mock_api.assert_called_once_with(
             "https://localhost:27124", "/search/", "test-key",
-            data={"query": "test query"}
+            body='TABLE file.link FROM "90-System"',
+            content_type="application/vnd.olrapi.dataview.dql+txt",
         )
+
+    @patch("cli_anything.obsidian.core.search.api_post_raw")
+    def test_search_query_jsonlogic(self, mock_api):
+        from cli_anything.obsidian.core.search import search_query
+        mock_api.return_value = [{"filename": "note.md"}]
+        body = '{"==":[{"var":"frontmatter.status"},"active"]}'
+        search_query("https://localhost:27124", "test-key", body,
+                     query_type="jsonlogic")
+        mock_api.assert_called_once_with(
+            "https://localhost:27124", "/search/", "test-key",
+            body=body,
+            content_type="application/vnd.olrapi.jsonlogic+json",
+        )
+
+    def test_search_query_invalid_type_raises(self):
+        from cli_anything.obsidian.core.search import search_query
+        with pytest.raises(ValueError, match="Unsupported search query_type"):
+            search_query("https://localhost:27124", "test-key", "x",
+                         query_type="grep")
 
     @patch("cli_anything.obsidian.core.search.api_post")
     def test_search_simple(self, mock_api):
@@ -380,11 +439,27 @@ class TestVaultCommands:
 
 
 class TestSearchCommands:
-    @patch("cli_anything.obsidian.core.search.api_post")
+    @patch("cli_anything.obsidian.core.search.api_post_raw")
     def test_search_query_json(self, mock_api, runner):
         mock_api.return_value = [{"filename": "note.md", "score": 0.9}]
         result = runner.invoke(cli, ["--json", "--api-key", "k", "search", "query", "test"])
         assert result.exit_code == 0
+        # Default --type is dql; body should be sent verbatim
+        args, kwargs = mock_api.call_args
+        assert kwargs["body"] == "test"
+        assert kwargs["content_type"] == "application/vnd.olrapi.dataview.dql+txt"
+
+    @patch("cli_anything.obsidian.core.search.api_post_raw")
+    def test_search_query_jsonlogic_flag(self, mock_api, runner):
+        mock_api.return_value = [{"filename": "note.md"}]
+        body = '{"==":[{"var":"frontmatter.status"},"active"]}'
+        result = runner.invoke(cli, ["--json", "--api-key", "k",
+                                     "search", "query", body,
+                                     "--type", "jsonlogic"])
+        assert result.exit_code == 0
+        _, kwargs = mock_api.call_args
+        assert kwargs["content_type"] == "application/vnd.olrapi.jsonlogic+json"
+        assert kwargs["body"] == body
 
     @patch("cli_anything.obsidian.core.search.api_post")
     def test_search_simple_json(self, mock_api, runner):

--- a/obsidian/agent-harness/cli_anything/obsidian/utils/obsidian_backend.py
+++ b/obsidian/agent-harness/cli_anything/obsidian/utils/obsidian_backend.py
@@ -85,6 +85,44 @@ def api_post(base_url: str, endpoint: str, api_key: str,
         ) from e
 
 
+def api_post_raw(base_url: str, endpoint: str, api_key: str,
+                 body: str, content_type: str,
+                 params: dict | None = None, timeout: int = 30) -> Any:
+    """POST a raw body with a caller-provided Content-Type.
+
+    Used for Obsidian endpoints that require vendor-specific media types
+    (e.g. ``application/vnd.olrapi.dataview.dql+txt`` for the search endpoint),
+    where the standard ``api_post`` JSON path would be rejected with
+    ``40012 Unknown or invalid Content-Type``.
+    """
+    url = f"{base_url.rstrip('/')}{endpoint}"
+    try:
+        headers = _headers(api_key, content_type=content_type)
+        resp = requests.post(url, headers=headers,
+                             data=body.encode("utf-8"), params=params,
+                             timeout=timeout, verify=False)
+        resp.raise_for_status()
+        if resp.status_code == 204 or not resp.content:
+            return {"status": "ok"}
+        resp_ct = resp.headers.get("content-type", "")
+        if "application/json" in resp_ct:
+            return resp.json()
+        return {"content": resp.text}
+    except requests.exceptions.ConnectionError as e:
+        raise RuntimeError(
+            f"Cannot connect to Obsidian REST API at {base_url}. "
+            "Is Obsidian running with the Local REST API plugin enabled?"
+        ) from e
+    except requests.exceptions.HTTPError as e:
+        raise RuntimeError(
+            f"Obsidian API error {resp.status_code} on POST {endpoint}: {resp.text}"
+        ) from e
+    except requests.exceptions.Timeout as e:
+        raise RuntimeError(
+            f"Request to Obsidian timed out: POST {endpoint}"
+        ) from e
+
+
 def api_put(base_url: str, endpoint: str, api_key: str,
             content: str = "", content_type: str = "text/markdown",
             timeout: int = 30) -> Any:

--- a/obsidian/agent-harness/setup.py
+++ b/obsidian/agent-harness/setup.py
@@ -12,7 +12,7 @@ with open("cli_anything/obsidian/README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="cli-anything-obsidian",
-    version="1.0.0",
+    version="1.1.0",
     author="Doruk Ozgen",
     author_email="",
     description="CLI harness for Obsidian — Knowledge management and note-taking via Obsidian Local REST API. Recommended: Obsidian with Local REST API plugin enabled",

--- a/registry.json
+++ b/registry.json
@@ -957,7 +957,7 @@
     {
       "name": "obsidian",
       "display_name": "Obsidian",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Knowledge management and note-taking — manage notes, search vault, execute commands via Obsidian Local REST API",
       "requires": "Obsidian desktop app with Local REST API plugin enabled",
       "homepage": "https://obsidian.md",
@@ -970,6 +970,10 @@
         {
           "name": "dorukozgen",
           "url": "https://github.com/dorukozgen"
+        },
+        {
+          "name": "Mubashirrrr",
+          "url": "https://github.com/Mubashirrrr"
         }
       ]
     },

--- a/skills/cli-anything-obsidian/SKILL.md
+++ b/skills/cli-anything-obsidian/SKILL.md
@@ -149,11 +149,16 @@ cli-anything-obsidian vault append "Projects/new-project.md" --content "\n## New
 ### Search
 
 ```bash
-# Plain text search
+# Plain text search (GET /search/simple/)
 cli-anything-obsidian search simple "meeting notes"
 
-# Obsidian query syntax search (tags, links, etc.)
-cli-anything-obsidian search query "tag:#project"
+# Dataview DQL query — default --type dql, sent as
+# application/vnd.olrapi.dataview.dql+txt
+cli-anything-obsidian search query 'TABLE file.link FROM "Projects"'
+
+# JsonLogic query — application/vnd.olrapi.jsonlogic+json
+cli-anything-obsidian search query --type jsonlogic \
+  '{"==":[{"var":"frontmatter.status"},"active"]}'
 ```
 
 

--- a/skills/cli-anything-obsidian/SKILL.md
+++ b/skills/cli-anything-obsidian/SKILL.md
@@ -236,4 +236,4 @@ When using this CLI programmatically:
 
 ## Version
 
-1.0.0
+1.1.0


### PR DESCRIPTION
## Summary

Fixes #271 — `cli-anything-obsidian search query` currently fails with
`40012 Unknown or invalid Content-Type` because the harness posts a
JSON-wrapped body (`Content-Type: application/json`) to Obsidian
Local REST API's `/search/` endpoint.

That endpoint expects raw bodies with vendor media types:

| Query language | Content-Type |
|---|---|
| Dataview DQL  | `application/vnd.olrapi.dataview.dql+txt` |
| JsonLogic     | `application/vnd.olrapi.jsonlogic+json`   |

## Approach

- Add `api_post_raw(base_url, endpoint, api_key, body, content_type, …)` to
  `utils/obsidian_backend.py`, mirroring the existing `api_put` raw-text
  pattern. Keeps the simple JSON-body `api_post` untouched.
- `core/search.py::search_query` takes a `query_type` arg (default `"dql"`),
  maps it to the right vendor Content-Type, and routes through `api_post_raw`
  with the query as the raw body.
- `search query` CLI command gains `--type [dql|jsonlogic]` (default `dql`).
- Refresh unit + CLI tests; add backend tests for `api_post_raw`.
- Update SKILL.md (canonical at `skills/cli-anything-obsidian/SKILL.md`
  and packaged copy), `README.md`, `OBSIDIAN.md` SOP doc.
- Bump package + registry version `1.0.0` → `1.1.0`.

## Examples

```bash
# Dataview DQL (default)
cli-anything-obsidian search query 'TABLE file.link FROM "90-System"'

# JsonLogic
cli-anything-obsidian search query --type jsonlogic \
  '{"==":[{"var":"frontmatter.status"},"active"]}'
```

## Tests

```
python3 -m pytest cli_anything/obsidian/tests/
================ 52 passed, 7 skipped in 0.12s ================
```

The 7 skipped are pre-existing E2E tests that need a live Obsidian
instance — unchanged here.

## Credit

The root cause and fix design were laid out in detail by @Edo78 on the
issue thread (#271), including the working content types and a TDD
patch description. This PR is an implementation of that approach with
matching tests + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)