### PR TITLE
fix(zoom): download recordings from direct URL

### DIFF
--- a/zoom/agent-harness/cli_anything/zoom/core/recordings.py
+++ b/zoom/agent-harness/cli_anything/zoom/core/recordings.py
@@ -10,7 +10,7 @@ Handles:
 import os
 from pathlib import Path
 
-from cli_anything.zoom.utils.zoom_backend import api_get, api_delete, api_request
+from cli_anything.zoom.utils.zoom_backend import api_get, api_delete
 
 
 def list_recordings(
@@ -130,9 +130,7 @@ def download_recording(
 
     out.parent.mkdir(parents=True, exist_ok=True)
 
-    # Download with streaming
-    resp = api_request("GET", "", stream=True)
-    # For recording downloads, we need to use the direct URL with token
+    # For recording downloads, we need to use the direct URL with token.
     import requests
     from cli_anything.zoom.utils.zoom_backend import _get_valid_token
 

--- a/zoom/agent-harness/cli_anything/zoom/tests/test_core.py
+++ b/zoom/agent-harness/cli_anything/zoom/tests/test_core.py
@@ -374,6 +374,42 @@ class TestRecordingCommands:
         assert result.exit_code == 0
         assert "MP4" in result.output
 
+    def test_download_recording_uses_direct_url(self, tmp_path):
+        """recording download should request the provided download URL."""
+        from cli_anything.zoom.core.recordings import download_recording
+
+        mock_response = MagicMock()
+        mock_response.headers = {"content-length": "10"}
+        mock_response.iter_content.return_value = [b"hello", b"world"]
+        mock_response.raise_for_status = MagicMock()
+
+        output_path = tmp_path / "recording.mp4"
+        download_url = "https://zoom.us/rec/download/abc"
+
+        with patch(
+            "cli_anything.zoom.core.recordings.api_request",
+            side_effect=AssertionError("api_request should not be used"),
+            create=True,
+        ) as mock_api_request, \
+             patch(
+                 "cli_anything.zoom.utils.zoom_backend._get_valid_token",
+                 return_value="access-token",
+             ), \
+             patch("requests.get", return_value=mock_response) as mock_get:
+            result = download_recording(download_url, str(output_path))
+
+        mock_api_request.assert_not_called()
+        mock_get.assert_called_once_with(
+            download_url,
+            headers={"Authorization": "Bearer access-token"},
+            stream=True,
+            timeout=300,
+        )
+        assert output_path.read_bytes() == b"helloworld"
+        assert result["status"] == "downloaded"
+        assert result["path"] == str(output_path.resolve())
+        assert result["size_bytes"] == 10
+
 
 # ── JSON Output Tests ───────────────────────────────────────────
 


### PR DESCRIPTION
## Description

Fixes #292.

`download_recording()` was calling `api_request("GET", "", stream=True)` before using the recording file's direct `download_url`. That empty endpoint resolves to the Zoom API base URL and can raise a 404 before the real download request runs.

This removes the stray API request and adds a regression test that verifies recording downloads use the provided direct URL with the bearer token.

## Type of Change

- [ ] **New Software CLI (in-repo)** — adds a CLI harness inside this monorepo
- [ ] **New Software CLI (standalone repo)** — registry-only PR pointing to an external repo
- [ ] **New Feature** — adds new functionality to an existing harness or the plugin
- [x] **Bug Fix** — fixes incorrect behavior
- [ ] **Documentation** — updates docs only
- [ ] **Other** — please describe:

---

### For Existing CLI Modifications

- [x] All unit tests pass: `python3 -m pytest cli_anything/zoom/tests/test_core.py -v`
- [ ] All E2E tests pass: not run against real Zoom OAuth credentials; default E2E tests were collected and skipped without `CLI_ANYTHING_ZOOM_E2E=1`
- [x] No test regressions — no previously passing tests were removed or weakened
- [x] `registry.json` entry unchanged because version, description, and requirements did not change

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands
- [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
- [x] I have tested my changes locally

## Test Results

```text
PYTHONPATH=. uv run --with pytest --with click --with requests --with prompt-toolkit python -m pytest cli_anything/zoom/tests/test_core.py::TestRecordingCommands::test_download_recording_uses_direct_url -v
# 1 passed in 0.09s

PYTHONPATH=. uv run --with pytest --with click --with requests --with prompt-toolkit python -m pytest cli_anything/zoom/tests/test_core.py -v
# 28 passed in 0.11s

PYTHONPATH=. uv run --with pytest --with click --with requests --with prompt-toolkit python -m pytest cli_anything/zoom/tests/ -v
# 28 passed, 4 skipped in 0.16s

git diff --check
# passed
```