### PR TITLE
fix(security): route untrusted XML parsing through defusedxml

### DIFF
--- a/drawio/agent-harness/cli_anything/drawio/core/session.py
+++ b/drawio/agent-harness/cli_anything/drawio/core/session.py
@@ -10,6 +10,7 @@ import time
 from pathlib import Path
 from typing import Optional
 from xml.etree import ElementTree as ET
+from defusedxml.ElementTree import fromstring as _defused_fromstring
 
 from ..utils import drawio_xml
 
@@ -93,7 +94,7 @@ class Session:
             return False
         self._redo_stack.append(self._snapshot())
         prev = self._undo_stack.pop()
-        self.root = ET.fromstring(prev)
+        self.root = _defused_fromstring(prev)
         self._modified = bool(self._undo_stack)
         return True
 
@@ -103,7 +104,7 @@ class Session:
             return False
         self._undo_stack.append(self._snapshot())
         nxt = self._redo_stack.pop()
-        self.root = ET.fromstring(nxt)
+        self.root = _defused_fromstring(nxt)
         self._modified = True
         return True
 

--- a/drawio/agent-harness/cli_anything/drawio/utils/drawio_xml.py
+++ b/drawio/agent-harness/cli_anything/drawio/utils/drawio_xml.py
@@ -26,6 +26,7 @@ Structure:
 import os
 import time
 from xml.etree import ElementTree as ET
+from defusedxml.ElementTree import parse as _defused_parse
 from typing import Optional
 
 
@@ -37,7 +38,7 @@ def parse_drawio(path: str) -> ET.Element:
     """Parse a .drawio XML file. Returns the root <mxfile> element."""
     if not os.path.exists(path):
         raise FileNotFoundError(f"File not found: {path}")
-    tree = ET.parse(path)
+    tree = _defused_parse(path)
     return tree.getroot()
 
 

--- a/drawio/agent-harness/setup.py
+++ b/drawio/agent-harness/setup.py
@@ -36,6 +36,7 @@ setup(
     install_requires=[
         "click>=8.0.0",
         "prompt-toolkit>=3.0.0",
+        "defusedxml>=0.7.1",
     ],
     extras_require={
         "dev": [

--- a/inkscape/agent-harness/cli_anything/inkscape/utils/svg_utils.py
+++ b/inkscape/agent-harness/cli_anything/inkscape/utils/svg_utils.py
@@ -5,6 +5,7 @@ and style string helpers.
 """
 
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import parse as _defused_parse, fromstring as _defused_fromstring
 import re
 from typing import Dict, Optional, Any
 
@@ -79,12 +80,12 @@ def create_svg_element(
 
 def parse_svg(svg_string: str) -> ET.Element:
     """Parse an SVG string into an ElementTree Element."""
-    return ET.fromstring(svg_string)
+    return _defused_fromstring(svg_string)
 
 
 def parse_svg_file(path: str) -> ET.Element:
     """Parse an SVG file into an ElementTree Element."""
-    tree = ET.parse(path)
+    tree = _defused_parse(path)
     return tree.getroot()
 
 

--- a/inkscape/agent-harness/setup.py
+++ b/inkscape/agent-harness/setup.py
@@ -36,6 +36,7 @@ setup(
     install_requires=[
         "click>=8.0.0",
         "prompt-toolkit>=3.0.0",
+        "defusedxml>=0.7.1",
     ],
     extras_require={
         "dev": [

--- a/libreoffice/agent-harness/cli_anything/libreoffice/core/importer.py
+++ b/libreoffice/agent-harness/cli_anything/libreoffice/core/importer.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import zipfile
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring as _defused_fromstring
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -125,7 +126,7 @@ def import_odf(
         return project
 
     try:
-        root = ET.fromstring(content_xml)
+        root = _defused_fromstring(content_xml)
     except ET.ParseError as e:
         raise ValueError(f"Invalid ODF content.xml in: {path}") from e
     if inferred_type == "writer":
@@ -157,7 +158,7 @@ def _apply_metadata(project: Dict[str, Any], meta_xml: str, source_path: str) ->
         return
 
     try:
-        root = ET.fromstring(meta_xml)
+        root = _defused_fromstring(meta_xml)
     except ET.ParseError as e:
         raise ValueError(f"Invalid ODF meta.xml in: {source_path}") from e
 

--- a/libreoffice/agent-harness/cli_anything/libreoffice/utils/odf_utils.py
+++ b/libreoffice/agent-harness/cli_anything/libreoffice/utils/odf_utils.py
@@ -14,6 +14,7 @@ Key ODF structure:
 import os
 import zipfile
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring as _defused_fromstring
 from typing import Dict, Any, Optional
 from datetime import datetime
 
@@ -660,21 +661,21 @@ def validate_odf(path: str) -> Dict[str, Any]:
             # Validate XML in content.xml
             if "content.xml" in names:
                 try:
-                    ET.fromstring(zf.read("content.xml"))
+                    _defused_fromstring(zf.read("content.xml"))
                 except ET.ParseError as e:
                     errors.append(f"Invalid XML in content.xml: {e}")
 
             # Validate XML in styles.xml
             if "styles.xml" in names:
                 try:
-                    ET.fromstring(zf.read("styles.xml"))
+                    _defused_fromstring(zf.read("styles.xml"))
                 except ET.ParseError as e:
                     errors.append(f"Invalid XML in styles.xml: {e}")
 
             # Validate XML in meta.xml
             if "meta.xml" in names:
                 try:
-                    ET.fromstring(zf.read("meta.xml"))
+                    _defused_fromstring(zf.read("meta.xml"))
                 except ET.ParseError as e:
                     errors.append(f"Invalid XML in meta.xml: {e}")
 

--- a/libreoffice/agent-harness/setup.py
+++ b/libreoffice/agent-harness/setup.py
@@ -36,6 +36,7 @@ setup(
     install_requires=[
         "click>=8.0.0",
         "prompt-toolkit>=3.0.0",
+        "defusedxml>=0.7.1",
     ],
     extras_require={
         "dev": [

--- a/macrocli/agent-harness/cli_anything/macrocli/backends/file_transform.py
+++ b/macrocli/agent-harness/cli_anything/macrocli/backends/file_transform.py
@@ -124,7 +124,8 @@ class FileTransformBackend(Backend):
     def _xml_set_attr(self, p: dict) -> dict:
         """Set an XML element attribute matched by XPath."""
         from xml.etree import ElementTree as ET
-        tree = ET.parse(p["input_file"])
+        from defusedxml.ElementTree import parse as _defused_parse
+        tree = _defused_parse(p["input_file"])
         root = tree.getroot()
         elements = root.findall(p["xpath"])
         if not elements:
@@ -137,7 +138,8 @@ class FileTransformBackend(Backend):
     def _xml_get_attr(self, p: dict) -> dict:
         """Get an XML element attribute matched by XPath."""
         from xml.etree import ElementTree as ET
-        tree = ET.parse(p["input_file"])
+        from defusedxml.ElementTree import parse as _defused_parse
+        tree = _defused_parse(p["input_file"])
         root = tree.getroot()
         elements = root.findall(p["xpath"])
         values = [el.get(p["attr"]) for el in elements]

--- a/macrocli/agent-harness/setup.py
+++ b/macrocli/agent-harness/setup.py
@@ -38,6 +38,7 @@ setup(
         "click>=8.0.0",
         "prompt-toolkit>=3.0.0",
         "PyYAML>=6.0",
+        "defusedxml>=0.7.1",
     ],
     extras_require={
         "dev": [

--- a/musescore/agent-harness/cli_anything/musescore/utils/mscx_xml.py
+++ b/musescore/agent-harness/cli_anything/musescore/utils/mscx_xml.py
@@ -6,6 +6,7 @@ Handles reading and writing .mscz (ZIP containing .mscx XML) and
 
 import os
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import parse as _defused_parse, fromstring as _defused_fromstring
 import zipfile
 from pathlib import Path
 
@@ -91,7 +92,7 @@ def read_mscz(path: str) -> dict:
             if name.endswith(".mscx"):
                 result["mscx_filename"] = name
                 xml_bytes = zf.read(name)
-                result["mscx"] = ET.ElementTree(ET.fromstring(xml_bytes))
+                result["mscx"] = ET.ElementTree(_defused_fromstring(xml_bytes))
             elif name == "score_style.mss" or name.endswith("/score_style.mss"):
                 result["style"] = zf.read(name).decode("utf-8")
             elif name == "audiosettings.json" or name.endswith("/audiosettings.json"):
@@ -154,7 +155,7 @@ def read_mxl(path: str) -> ET.ElementTree:
         for name in zf.namelist():
             if name.endswith(".xml") and not name.startswith("META-INF"):
                 xml_bytes = zf.read(name)
-                return ET.ElementTree(ET.fromstring(xml_bytes))
+                return ET.ElementTree(_defused_fromstring(xml_bytes))
 
     raise ValueError(f"No MusicXML file found inside {path}")
 
@@ -344,6 +345,6 @@ def read_score_tree(path: str) -> ET.ElementTree:
     elif fmt == "mxl":
         return read_mxl(path)
     elif fmt == "musicxml":
-        return ET.parse(path)
+        return _defused_parse(path)
     else:
         raise ValueError(f"Cannot read XML tree from format: {fmt} ({path})")

--- a/musescore/agent-harness/setup.py
+++ b/musescore/agent-harness/setup.py
@@ -33,6 +33,7 @@ setup(
     install_requires=[
         "click>=8.0.0",
         "prompt-toolkit>=3.0.0",
+        "defusedxml>=0.7.1",
     ],
     extras_require={
         "dev": [

--- a/shotcut/agent-harness/cli_anything/shotcut/core/session.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/session.py
@@ -10,6 +10,7 @@ import time
 from pathlib import Path
 from typing import Optional
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring as _defused_fromstring
 
 from ..utils import mlt_xml
 
@@ -113,7 +114,7 @@ class Session:
         self._redo_stack.append(self._snapshot())
         prev = self._undo_stack.pop()
         mlt_xml._clear_parent_map()
-        self.root = ET.fromstring(prev)
+        self.root = _defused_fromstring(prev)
         mlt_xml._register_tree(self.root)
         self._resolve_refs()
         self._modified = bool(self._undo_stack)
@@ -126,7 +127,7 @@ class Session:
         self._undo_stack.append(self._snapshot())
         nxt = self._redo_stack.pop()
         mlt_xml._clear_parent_map()
-        self.root = ET.fromstring(nxt)
+        self.root = _defused_fromstring(nxt)
         mlt_xml._register_tree(self.root)
         self._resolve_refs()
         self._modified = True

--- a/shotcut/agent-harness/cli_anything/shotcut/utils/mlt_xml.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/utils/mlt_xml.py
@@ -7,6 +7,7 @@ xml.etree.ElementTree from the Python standard library.
 import copy
 import uuid
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import parse as _defused_parse
 from typing import Optional
 
 # Global parent mapping because ET.Element has no getparent().
@@ -51,7 +52,7 @@ def new_id(prefix: str = "producer") -> str:
 def parse_mlt(filepath: str) -> ET.Element:
     """Parse an MLT XML file and return the root element."""
     _clear_parent_map()
-    tree = ET.parse(filepath)
+    tree = _defused_parse(filepath)
     root = tree.getroot()
     _register_tree(root)
     return root

--- a/shotcut/agent-harness/setup.py
+++ b/shotcut/agent-harness/setup.py
@@ -36,6 +36,7 @@ setup(
     install_requires=[
         "click>=8.0.0",
         "prompt-toolkit>=3.0.0",
+        "defusedxml>=0.7.1",
     ],
     extras_require={
         "dev": [

--- a/zotero/agent-harness/cli_anything/zotero/core/catalog.py
+++ b/zotero/agent-harness/cli_anything/zotero/core/catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import parse as _defused_parse
 from pathlib import Path
 from typing import Any
 
@@ -236,7 +237,7 @@ def list_styles(runtime: RuntimeContext) -> list[dict[str, Any]]:
     styles: list[dict[str, Any]] = []
     for path in sorted(styles_dir.glob("*.csl")):
         try:
-            root = ET.parse(path).getroot()
+            root = _defused_parse(path).getroot()
         except ET.ParseError:
             styles.append({"path": str(path), "id": None, "title": path.stem, "valid": False})
             continue

--- a/zotero/agent-harness/setup.py
+++ b/zotero/agent-harness/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         "click>=8.0.0",
         "prompt-toolkit>=3.0.0",
+        "defusedxml>=0.7.1",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Summary
The repo's threat model (`SECURITY.md`) calls out XML/SVG content as a key attack surface and lists "ElementTree auto-escaping" as the mitigation. That sentence covers XML *output* (serialization). XML *input* (parsing) across the agent backends still goes through stdlib `xml.etree.ElementTree`. This PR routes the untrusted-input parsing call sites through `defusedxml.ElementTree` so the parser is hardened against entity-expansion attacks.

## Impact
An AI agent following the SKILL.md instructions parses files originating from untrusted sources (user prompts, uploaded files, output from other agents) — `.svg`, `.drawio`, `.mlt`, `.odt`/`.ods`/`.odp`, `.mscz`/`.mxl`/`.musicxml`, `.csl`, and arbitrary XML via the macrocli `xml_set_attr`/`xml_get_attr` actions.

A small crafted XML file can trigger:
- **Entity-expansion DoS** ("billion laughs", quadratic blowup) — Python 3.7.1+ disabled external-entity lookup on `xml.etree.ElementTree` by default, but **internal-entity expansion is still possible** and can exhaust CPU / RAM. A ~1 KB file can expand to gigabytes, locking the agent process.
- (Pre-3.7.1 Pythons, or any non-ET parser path added later) — XXE `SYSTEM` entity reads for local-file disclosure and SSRF.

Severity: **medium**. DoS on the agent harness, not RCE. CWE-776 (Improper Restriction of Recursive Entity References) / CWE-611 (Improper Restriction of XML External Entity Reference).

## Location
Production parse/fromstring call sites migrated:

- `drawio/.../utils/drawio_xml.py` — `parse_drawio()`
- `drawio/.../core/session.py` — `undo()` / `redo()` snapshot replay
- `inkscape/.../utils/svg_utils.py` — `parse_svg()`, `parse_svg_file()`
- `libreoffice/.../core/importer.py` — `content.xml` / `meta.xml` ingest
- `libreoffice/.../utils/odf_utils.py` — `validate_odf()` per-stream validation
- `macrocli/.../backends/file_transform.py` — `xml_set_attr` / `xml_get_attr` actions
- `musescore/.../utils/mscx_xml.py` — `read_mscz()`, `read_mxl()`, `read_score_tree()`
- `shotcut/.../utils/mlt_xml.py` — `parse_mlt()`
- `shotcut/.../core/session.py` — `undo()` / `redo()` snapshot replay
- `zotero/.../core/catalog.py` — `list_styles()` CSL parsing

## Fix
- Add `defusedxml>=0.7.1` to each affected harness's `setup.py`.
- Replace `ET.parse(...)` and `ET.fromstring(...)` at the call sites above with `defusedxml.ElementTree.parse` / `fromstring`.
- Leave construction-side stdlib ET (`Element`, `SubElement`, `tostring`, `register_namespace`, `ElementTree(...)`, `indent`) untouched — those don't parse untrusted input and `defusedxml` intentionally doesn't expose them.

The defusedxml API for `parse`/`fromstring` is drop-in: same call signatures, returns standard `ET.Element` objects, so downstream code (`.iter()`, `.find()`, `.findall()`, `.get()`, etc.) keeps working without changes.

## Detected by
Aeon + semgrep `p/security-audit` + `p/owasp-top-ten` + `p/python` (rules: `use-defused-xml`, `use-defused-xml-parse`).

- Severity: medium
- CWE-776 / CWE-611

## Verification
- `defusedxml.ElementTree.parse` and `.fromstring` are documented drop-in replacements (https://pypi.org/project/defusedxml/). No behavioural change on benign XML; raises `defusedxml.EntitiesForbidden` / `DTDForbidden` on hostile XML — that is the intended fail-closed behaviour (the agent rejects the file rather than parsing it).
- This PR intentionally **does not** touch test files. Tests parse known-good fixtures and don't need defusedxml; leaving them on stdlib ET keeps the diff focused on the actual attack surface.

## Out of scope (separate concerns surfaced by the same scan, not fixed here)
- 8x `urllib.request.urlopen` with dynamic URLs — needs per-call-site review (some are agent-controlled, some are constants).
- 5x `requests.*(verify=False)` in `obsidian_backend.py` — talks to localhost-only with self-signed certs by default; intentional but should validate `base_url` is loopback before disabling verification.
- 1x `pickle.load` in `unimol_tools/unimol_backend.py` — loads a metric file from an agent-controlled path; should switch to a JSON sidecar.
- 1x `exec()` in `.github/scripts/validate_root_skills.py` — repo-controlled input, low risk.

Happy to open follow-up PRs for any of these if useful.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
