### PR TITLE
Add UEAtelier — Unreal Editor 5.6/5.7 MCP self-extension workbench

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -746,6 +746,25 @@
       ]
     },
     {
+      "name": "ueatelier",
+      "display_name": "UEAtelier",
+      "version": "0.23.0",
+      "description": "Unreal Editor 5.6/5.7 MCP self-extension workbench - editor automation, build diagnostics, Task Atlas workflows, PIE smoke verification, scaffold pipeline",
+      "requires": "Unreal Engine 5.6 or 5.7 with the UEAtelier plugin extracted into <YourProject>/",
+      "homepage": "https://github.com/edwinmeng163-oss/UEAtelier",
+      "source_url": "https://github.com/edwinmeng163-oss/UEAtelier",
+      "install_cmd": "pip install git+https://github.com/edwinmeng163-oss/UEAtelier.git#subdirectory=Tools/UEAtelierCli",
+      "entry_point": "cli-anything-ueatelier",
+      "skill_md": "https://github.com/edwinmeng163-oss/UEAtelier/blob/main/Tools/UEAtelierCli/SKILL.md",
+      "category": "gamedev",
+      "contributors": [
+        {
+          "name": "edwinmeng163-oss",
+          "url": "https://github.com/edwinmeng163-oss"
+        }
+      ]
+    },
+    {
       "name": "nsight-graphics",
       "display_name": "Nsight Graphics CLI",
       "version": "0.2.0",

--- a/registry.json
+++ b/registry.json
@@ -748,7 +748,7 @@
     {
       "name": "ueatelier",
       "display_name": "UEAtelier",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "description": "Unreal Editor 5.6/5.7 MCP self-extension workbench - editor automation, build diagnostics, Task Atlas workflows, PIE smoke verification, scaffold pipeline",
       "requires": "Unreal Engine 5.6 or 5.7 with the UEAtelier plugin extracted into <YourProject>/",
       "homepage": "https://github.com/edwinmeng163-oss/UEAtelier",


### PR DESCRIPTION
Adds a registry entry for **UEAtelier**, a standalone Unreal Engine plugin + Python CLI wrapper following Option 2 from CONTRIBUTING.md (standalone repository).

## What is UEAtelier?

UEAtelier is an Unreal Engine 5.6 / 5.7 editor MCP self-extension workbench — its defining capability is that AI agents can scaffold, validate, build, test, and roll back new editor automation tools at runtime, not just call pre-shipped ones. Every self-extension pass is guarded by safety rails: audit, dry-run, backup manifest, UBT compile, fixture test suite, rollback-to-manifest, project memory, and supervisor recovery.

The registry currently ships 160 first-party MCP tools across actors, blueprint, editor, material, memory, scaffold, self-extension, skills, task-atlas, verification (PIE smoke + automation discovery/run/report + editor diagnostics), and widget categories. The plugin runs an MCP JSON-RPC server (http://127.0.0.1:8765/mcp) inside Unreal Editor.

The CLI in this PR (cli-anything-ueatelier) is a thin proxy that lets non-MCP-aware agents (shell scripts, CI bots, Cursor command mode, plain bash) drive that server — including triggering the self-extension pipeline — without speaking JSON-RPC themselves.

## Relationship to unrealinsights

`unrealinsights` (already in the registry) focuses on **profiler trace capture** for shipped builds. UEAtelier focuses on **editor automation + AI agent workflows** during development. Different angles on the Unreal ecosystem; no functional overlap. The PR places the new entry directly after `unrealinsights` so both Unreal CLIs sit together.

## CLI surface (7 command groups)

| Command | Wraps MCP tool |
|---------|----------------|
| `status` | tools/list + `unreal.editor_status` (with `unreal.editor.engine_version` fallback) |
| `tools list` / `describe` | tools/list |
| `run NAME --args-json '{}'` | tools/call (any tool) |
| `diagnostics` | `unreal.editor_diagnostics` |
| `automation list` / `run` / `report [--wait]` | `unreal.automation_*` (auto-poll) |
| `pie-smoke [--map P]` | `unreal.pie_smoke` (auto-polls report) |
| `tasks list` / `describe` / `rate` / `pin` | `unreal.task_*` (Task Atlas) |

Global flags: `--json` (machine-readable stdout), `--endpoint URL`, `--http-timeout SEC`. Env var `UEATELIER_MCP_ENDPOINT` supported.

## Self-validation (run on source repo)

- `pytest Tools/UEAtelierCli -v`: **22 passed** (includes 5 new/updated status tests added in v0.23.1; mocked HTTP, no editor required)
- `pip install -e Tools/UEAtelierCli`: PASS on Python 3.13
- `cli-anything-ueatelier --version`: `cli-anything-ueatelier, version 0.23.1`
- Unreachable-endpoint smoke: `{"error":"endpoint_unreachable","endpoint":"...","hint":"..."}` + exit code 2, no Python traceback
- Mac UE 5.7 build: clean; Win zip auto-built via GitHub Actions
- SKILL.md: matches the `cli-anything-blender` shape (YAML frontmatter, prerequisites, install, quick-start, full reference, JSON mode, env vars, limitations, agent guidance)

## SKILL.md

[Tools/UEAtelierCli/SKILL.md](https://github.com/edwinmeng163-oss/UEAtelier/blob/main/Tools/UEAtelierCli/SKILL.md)

## Latest releases

- [v0.23.1](https://github.com/edwinmeng163-oss/UEAtelier/releases/tag/v0.23.1) — CLI-only hotfix (no plugin zip; install via `pip install --upgrade` of the CLI subdirectory)
- [v0.23.0](https://github.com/edwinmeng163-oss/UEAtelier/releases/tag/v0.23.0) — full release with Mac + Win plugin zips attached

Happy to address any review feedback. Thanks for the CLI-Anything Hub — discoverability via `cli-hub install` is exactly the path we wanted.
