### PR TITLE
feat: add obsidian-agent-cli to public registry

### DIFF
--- a/public_registry.json
+++ b/public_registry.json
@@ -373,8 +373,8 @@
       "homepage": "https://obsidian.md",
       "source_url": "https://github.com/ProxyLandLLC/obsidian-agent-cli",
       "install_cmd": "pip install obsidian-agent-cli",
-      "entry_point": "obsidian",
-      "skill_md": "https://github.com/ProxyLandLLC/obsidian-agent-cli/blob/master/SKILL.md",
+      "entry_point": "obsidian-agent",
+      "skill_md": "https://github.com/ProxyLandLLC/obsidian-agent-cli/blob/v0.1.0/SKILL.md",
       "contributors": [
         {
           "url": "https://github.com/ProxyLandLLC",

--- a/public_registry.json
+++ b/public_registry.json
@@ -362,6 +362,25 @@
           "url": "https://github.com/MartaKar"
         }
       ]
+    },
+    {
+      "name": "obsidian-agent-cli",
+      "display_name": "Obsidian CLI",
+      "version": "0.1.0",
+      "description": "Full-featured CLI for Obsidian — manage notes, canvases, Excalidraw diagrams, Kanban boards, periodic notes, git, tasks, and more. Includes an AI agent skill for persistent knowledge capture and project memory.",
+      "category": "productivity",
+      "requires": "Obsidian desktop app, Local REST API community plugin",
+      "homepage": "https://obsidian.md",
+      "source_url": "https://github.com/ProxyLandLLC/obsidian-agent-cli",
+      "install_cmd": "pip install obsidian-agent-cli",
+      "entry_point": "obsidian",
+      "skill_md": "https://github.com/ProxyLandLLC/obsidian-agent-cli/blob/master/SKILL.md",
+      "contributors": [
+        {
+          "url": "https://github.com/ProxyLandLLC",
+          "name": "ProxyLandLLC"
+        }
+      ]
     }
   ]
 }

--- a/public_registry.json
+++ b/public_registry.json
@@ -366,7 +366,7 @@
     {
       "name": "obsidian-agent-cli",
       "display_name": "Obsidian CLI",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "Full-featured CLI for Obsidian — manage notes, canvases, Excalidraw diagrams, Kanban boards, periodic notes, git, tasks, and more. Includes an AI agent skill for persistent knowledge capture and project memory.",
       "category": "productivity",
       "requires": "Obsidian desktop app, Local REST API community plugin",
@@ -374,7 +374,7 @@
       "source_url": "https://github.com/ProxyLandLLC/obsidian-agent-cli",
       "install_cmd": "pip install obsidian-agent-cli",
       "entry_point": "obsidian-agent",
-      "skill_md": "https://github.com/ProxyLandLLC/obsidian-agent-cli/blob/v0.1.0/SKILL.md",
+      "skill_md": "https://github.com/ProxyLandLLC/obsidian-agent-cli/blob/v0.1.1/SKILL.md",
       "contributors": [
         {
           "url": "https://github.com/ProxyLandLLC",


### PR DESCRIPTION
## New Standalone CLI: obsidian-agent-cli

### Summary
Adds [obsidian-agent-cli](https://github.com/ProxyLandLLC/obsidian-agent-cli) to the public registry — a full-featured CLI for Obsidian that includes an AI agent skill for persistent knowledge capture across sessions.

### Checklist
- [x] CLI is installable via `pip install obsidian-agent-cli` (published on PyPI)
- [x] `SKILL.md` exists in the external repo
- [x] External repo has its own test suite (202 tests, all passing)
- [x] Registry entry includes `source_url` pointing to the external repo
- [x] Registry entry includes `skill_md` with full URL to the external SKILL.md
- [x] `install_cmd` tested locally and works

### Tool Details
- **Package:** `pip install obsidian-agent-cli`
- **Entry point:** `obsidian`
- **Source:** https://github.com/ProxyLandLLC/obsidian-agent-cli
- **PyPI:** https://pypi.org/project/obsidian-agent-cli/
- **Category:** productivity
- **Requires:** Obsidian desktop app, Local REST API community plugin