### PR TITLE
fix(browser): migrate DOMShell MCP integration to @apireno/domshell 2.0.0

### DIFF
--- a/browser/agent-harness/HARNESS.md
+++ b/browser/agent-harness/HARNESS.md
@@ -58,21 +58,28 @@ DOMShell 2.0.0+ exposes a single MCP tool:
 |------|-------------|
 | `domshell_execute` | Runs a shell-style command string. Multi-line input is supported — each line runs in order in the same shell state. |
 
-The harness builds command strings from the public CLI commands:
+The harness builds command strings from the public CLI commands. Harness
+absolute paths (leading `/`) are anchored at the tab root via
+`cd %here%` since DOMShell's lane cwd may have drifted; relative paths
+are passed through unchanged.
 
-| CLI Command | Command string sent to `domshell_execute` |
-|-------------|--------------------------------------------|
-| `fs ls <path>` | `ls <path>` |
-| `fs cd <path>` | `cd <path>` |
-| `fs cat <path>` | `cat <path>` |
-| `fs grep <pat>` | `grep <pat>` |
-| `fs grep <pat> <path>` | `cd <path>\ngrep <pat>\ncd <prev>` (single call) |
-| `act click <path>` | `click <path>` |
-| `act type <path> <text>` | `focus <path>\ntype <text>` (single call) |
+| CLI Command (path is absolute) | Command string sent to `domshell_execute` |
+|--------------------------------|--------------------------------------------|
+| `fs ls /<sub>` | `cd %here%/<sub>` then bare `ls`, then `cd <restore>` (single multi-line call) |
+| `fs cd /<sub>` | `cd %here%/<sub>` (single line — `cd` is the desired new state) |
+| `fs cat /<sub>` | `cd %here%`, `cat <sub>`, `cd <restore>` (single multi-line call) |
+| `fs grep <pat>` | `grep <pat>` (operates on lane cwd) |
+| `fs grep <pat> /<sub>` | `cd %here%/<sub>`, `grep <pat>`, `cd <restore>` (single multi-line call) |
+| `act click /<sub>` | `cd %here%`, `click <sub>`, `cd <restore>` (single multi-line call) |
+| `act type /<sub> <text>` | `cd %here%`, `focus <sub>`, `cd <restore>` — then, on success, `type <text>` (two calls, shared lane via `group_id`) |
 | `page open <url>` | `open <url>` |
 | `page reload` | `refresh` |
 | `page back` | `back` |
 | `page forward` | `forward` |
+
+`<restore>` resolves to `cd %here%/<harness-working-dir>` (or `cd %here%`
+when the harness is at the tab root) so the lane's cwd ends up where
+the harness expects.
 
 ## Key Design Decisions
 

--- a/browser/agent-harness/HARNESS.md
+++ b/browser/agent-harness/HARNESS.md
@@ -38,9 +38,15 @@ DOMShell is an npm package that exposes Chrome's Accessibility Tree via MCP:
 ### Installation
 
 **Requires `@apireno/domshell` 2.0.2 or newer.** The harness uses
-`group_id="shared"` and `group_id="new"` keywords introduced in 2.0.2 to
-declare lane intent explicitly (silences the deprecation warning that 2.0.2
-added for omitted `group_id`; will become a hard error in DOMShell 3.0.0).
+`group_id="new"` to declare lane intent explicitly on the first call of
+each session and reuses the captured lane id on subsequent calls (silences
+the deprecation warning that 2.0.2 added for omitted `group_id`; will
+become a hard error in DOMShell 3.0.0). For direct daemon-mode callers
+without a harness `Session`, the same scheme runs at module level — the
+first call captures a lane id into `_daemon_lane_id` and subsequent calls
+reuse it, preserving browser state across daemon-mode no-session calls
+(see `domshell_backend.py`'s `_daemon_lane_id` declaration for the
+stale-lane failure mode).
 
 ```bash
 npx @apireno/domshell --version   # should report 2.0.2 or higher

--- a/browser/agent-harness/HARNESS.md
+++ b/browser/agent-harness/HARNESS.md
@@ -39,7 +39,7 @@ DOMShell is an npm package that exposes Chrome's Accessibility Tree via MCP:
 
 ```bash
 # Verify DOMShell is available (2.0.0 or newer required)
-npx @apireno/domshell@2.0.0 --version
+npx @apireno/domshell --version
 
 # Install Chrome extension
 # https://chromewebstore.google.com/detail/domshell

--- a/browser/agent-harness/HARNESS.md
+++ b/browser/agent-harness/HARNESS.md
@@ -37,22 +37,28 @@ DOMShell is an npm package that exposes Chrome's Accessibility Tree via MCP:
 
 ### Installation
 
+**Requires `@apireno/domshell` 2.0.2 or newer.** The harness uses
+`group_id="shared"` and `group_id="new"` keywords introduced in 2.0.2 to
+declare lane intent explicitly (silences the deprecation warning that 2.0.2
+added for omitted `group_id`; will become a hard error in DOMShell 3.0.0).
+
 ```bash
-# Verify DOMShell is available (2.0.0 or newer required)
-npx @apireno/domshell --version
+npx @apireno/domshell --version   # should report 2.0.2 or higher
 
 # Install Chrome extension
 # https://chromewebstore.google.com/detail/domshell
 ```
 
-**Minimum version: `@apireno/domshell@2.0.0`.** DOMShell 2.0.0 (May 2026)
-consolidated the MCP tool surface from 38 per-command tools to a single
-`domshell_execute` tool. The harness targets this consolidated tool, so no
-opt-in `--granular` server flag is required.
+The standard `npx @apireno/domshell` invocation pulls the latest published
+version automatically; no manual pinning is required.
+
+DOMShell 2.0.0 (May 2026) consolidated the MCP tool surface from 38
+per-command tools to a single `domshell_execute` tool. The harness targets
+this consolidated tool, so no opt-in `--granular` server flag is required.
 
 ### MCP Tool
 
-DOMShell 2.0.0+ exposes a single MCP tool:
+DOMShell 2.0.2+ exposes a single MCP tool:
 
 | Tool | Description |
 |------|-------------|

--- a/browser/agent-harness/HARNESS.md
+++ b/browser/agent-harness/HARNESS.md
@@ -38,29 +38,41 @@ DOMShell is an npm package that exposes Chrome's Accessibility Tree via MCP:
 ### Installation
 
 ```bash
-# Verify DOMShell is available
-npx @apireno/domshell --version
+# Verify DOMShell is available (2.0.0 or newer required)
+npx @apireno/domshell@2.0.0 --version
 
 # Install Chrome extension
 # https://chromewebstore.google.com/detail/domshell
 ```
 
-### MCP Tools
+**Minimum version: `@apireno/domshell@2.0.0`.** DOMShell 2.0.0 (May 2026)
+consolidated the MCP tool surface from 38 per-command tools to a single
+`domshell_execute` tool. The harness targets this consolidated tool, so no
+opt-in `--granular` server flag is required.
 
-DOMShell exposes these MCP tools:
+### MCP Tool
 
-| Tool | Description | CLI Command |
-|------|-------------|-------------|
-| `domshell_ls` | List directory contents | `fs ls` |
-| `domshell_cd` | Change directory | `fs cd` |
-| `domshell_cat` | Read element content | `fs cat` |
-| `domshell_grep` | Search for pattern | `fs grep` |
-| `domshell_click` | Click element | `act click` |
-| `domshell_type` | Type text | `act type` |
-| `domshell_open` | Navigate to URL | `page open` |
-| `domshell_reload` | Reload page | `page reload` |
-| `domshell_back` | Navigate back | `page back` |
-| `domshell_forward` | Navigate forward | `page forward` |
+DOMShell 2.0.0+ exposes a single MCP tool:
+
+| Tool | Description |
+|------|-------------|
+| `domshell_execute` | Runs a shell-style command string. Multi-line input is supported — each line runs in order in the same shell state. |
+
+The harness builds command strings from the public CLI commands:
+
+| CLI Command | Command string sent to `domshell_execute` |
+|-------------|--------------------------------------------|
+| `fs ls <path>` | `ls <path>` |
+| `fs cd <path>` | `cd <path>` |
+| `fs cat <path>` | `cat <path>` |
+| `fs grep <pat>` | `grep <pat>` |
+| `fs grep <pat> <path>` | `cd <path>\ngrep <pat>\ncd <prev>` (single call) |
+| `act click <path>` | `click <path>` |
+| `act type <path> <text>` | `focus <path>\ntype <text>` (single call) |
+| `page open <url>` | `open <url>` |
+| `page reload` | `refresh` |
+| `page back` | `back` |
+| `page forward` | `forward` |
 
 ## Key Design Decisions
 

--- a/browser/agent-harness/cli_anything/browser/browser_cli.py
+++ b/browser/agent-harness/cli_anything/browser/browser_cli.py
@@ -304,7 +304,7 @@ def act_click(path):
     """Click an element at the given path."""
     sess = get_session()
     use_daemon = sess.daemon_mode
-    result = backend.click(path, use_daemon=use_daemon)
+    result = backend.click(path, use_daemon=use_daemon, session=sess)
     output(result, f"Clicked: {path}")
 
 
@@ -316,7 +316,7 @@ def act_type(path, text):
     """Type text into an input element."""
     sess = get_session()
     use_daemon = sess.daemon_mode
-    result = backend.type_text(path, text, use_daemon=use_daemon)
+    result = backend.type_text(path, text, use_daemon=use_daemon, session=sess)
     output(result, f"Typed into: {path}")
 
 

--- a/browser/agent-harness/cli_anything/browser/browser_cli.py
+++ b/browser/agent-harness/cli_anything/browser/browser_cli.py
@@ -226,6 +226,13 @@ def fs_ls(path):
     if _json_output:
         output(result)
     else:
+        # Surface DOMShell errors (e.g. `fs ls /nonexistent`) before
+        # falling into the empty-entries "No elements" branch — without
+        # this, an error from the kernel was hidden behind a misleading
+        # "No elements at …" message. (Codex P2 R4 on commit 5790651.)
+        if "error" in result:
+            click.echo(result["error"], err=True)
+            return
         entries = result.get("entries", [])
         if not entries:
             click.echo(f"No elements at {path or sess.working_dir}")
@@ -273,6 +280,13 @@ def fs_grep(pattern, path):
     if _json_output:
         output(result)
     else:
+        # Surface DOMShell errors before the empty-matches "No matches"
+        # branch — same fix shape as fs_ls. Without this, an anchor cd
+        # failure on rooted grep was hidden behind "No matches".
+        # (Codex P2 R4 on commit 5790651.)
+        if "error" in result:
+            click.echo(result["error"], err=True)
+            return
         matches = result.get("matches", [])
         if not matches:
             click.echo(f"No matches for '{pattern}'")

--- a/browser/agent-harness/cli_anything/browser/core/fs.py
+++ b/browser/agent-harness/cli_anything/browser/core/fs.py
@@ -32,7 +32,7 @@ def list_elements(session: "Session", path: str = "") -> dict:
     """
     target_path = path if path else session.working_dir
     use_daemon = session.daemon_mode
-    return backend.ls(target_path, use_daemon=use_daemon)
+    return backend.ls(target_path, use_daemon=use_daemon, session=session)
 
 
 def change_directory(session: "Session", path: str) -> dict:
@@ -69,7 +69,7 @@ def change_directory(session: "Session", path: str) -> dict:
             path = session.working_dir.rstrip("/") + "/" + path
 
     use_daemon = session.daemon_mode
-    result = backend.cd(path, use_daemon=use_daemon)
+    result = backend.cd(path, use_daemon=use_daemon, session=session)
     # Only update working_dir if backend succeeded
     if isinstance(result, dict) and "error" not in result:
         new_working_dir = result.get("path", path)
@@ -93,7 +93,7 @@ def read_element(session: "Session", path: str = "") -> dict:
     """
     target_path = path if path else session.working_dir
     use_daemon = session.daemon_mode
-    return backend.cat(target_path, use_daemon=use_daemon)
+    return backend.cat(target_path, use_daemon=use_daemon, session=session)
 
 
 def grep_elements(session: "Session", pattern: str, path: str = "") -> dict:
@@ -115,5 +115,9 @@ def grep_elements(session: "Session", pattern: str, path: str = "") -> dict:
     use_daemon = session.daemon_mode
     prev = session.working_dir or "/"
     return backend.grep(
-        pattern, path=target_path, prev=prev, use_daemon=use_daemon
+        pattern,
+        path=target_path,
+        prev=prev,
+        use_daemon=use_daemon,
+        session=session,
     )

--- a/browser/agent-harness/cli_anything/browser/core/fs.py
+++ b/browser/agent-harness/cli_anything/browser/core/fs.py
@@ -113,16 +113,7 @@ def grep_elements(session: "Session", pattern: str, path: str = "") -> dict:
     """
     target_path = path if path else session.working_dir
     use_daemon = session.daemon_mode
-
-    # DOMShell's grep searches from the server-side CWD. To root the search
-    # at the requested path, cd there first, grep, then restore.
-    if target_path and target_path != "/":
-        cd_result = backend.cd(target_path, use_daemon=use_daemon)
-        if hasattr(cd_result, 'isError') and cd_result.isError:
-            return cd_result
-
-    try:
-        return backend.grep(pattern, use_daemon=use_daemon)
-    finally:
-        if target_path and target_path != "/":
-            backend.cd(session.working_dir or "/", use_daemon=use_daemon)
+    prev = session.working_dir or "/"
+    return backend.grep(
+        pattern, path=target_path, prev=prev, use_daemon=use_daemon
+    )

--- a/browser/agent-harness/cli_anything/browser/core/page.py
+++ b/browser/agent-harness/cli_anything/browser/core/page.py
@@ -42,7 +42,7 @@ def open_page(session: "Session", url: str) -> dict:
         raise ValueError(error_msg)
 
     use_daemon = session.daemon_mode
-    result = backend.open_url(url, use_daemon=use_daemon)
+    result = backend.open_url(url, use_daemon=use_daemon, session=session)
     session.set_url(url)
     session.set_working_dir("/")  # Reset to root on new page
     return result
@@ -62,7 +62,7 @@ def reload_page(session: "Session") -> dict:
         {"status": "reloaded", "url": "https://example.com"}
     """
     use_daemon = session.daemon_mode
-    result = backend.reload(use_daemon=use_daemon)
+    result = backend.reload(use_daemon=use_daemon, session=session)
     return result
 
 
@@ -80,7 +80,7 @@ def go_back(session: "Session") -> dict:
         {"url": "https://previous.com", "status": "navigated"}
     """
     use_daemon = session.daemon_mode
-    result = backend.back(use_daemon=use_daemon)
+    result = backend.back(use_daemon=use_daemon, session=session)
 
     # Update session state if backend returned a URL
     if isinstance(result, dict) and "url" in result:
@@ -103,7 +103,7 @@ def go_forward(session: "Session") -> dict:
         {"url": "https://next.com", "status": "navigated"}
     """
     use_daemon = session.daemon_mode
-    result = backend.forward(use_daemon=use_daemon)
+    result = backend.forward(use_daemon=use_daemon, session=session)
 
     # Update session state if backend returned a URL
     if isinstance(result, dict) and "url" in result:

--- a/browser/agent-harness/cli_anything/browser/core/session.py
+++ b/browser/agent-harness/cli_anything/browser/core/session.py
@@ -21,6 +21,11 @@ class Session:
     - history: Stack of URLs for back navigation
     - forward_stack: Stack of URLs for forward navigation
     - daemon_mode: Whether persistent daemon connection is active
+    - domshell_lane_id: The DOMShell 2.x lane (Chrome tab-group) the harness
+      has been pinned to. ``None`` until the first ``_call_execute`` reply
+      arrives carrying a ``[lane: <id>]`` marker; thereafter passed as
+      ``group_id`` on every subsequent call so browser state (current tab,
+      cwd, focus) persists across REPL commands in non-daemon mode.
     """
 
     current_url: str = ""
@@ -28,6 +33,7 @@ class Session:
     history: list[str] = field(default_factory=list)
     forward_stack: list[str] = field(default_factory=list)
     daemon_mode: bool = False
+    domshell_lane_id: Optional[str] = None
 
     def set_url(self, url: str, record_history: bool = True) -> None:
         """Set the current URL and update history.
@@ -95,4 +101,5 @@ class Session:
             "history_length": len(self.history),
             "forward_stack_length": len(self.forward_stack),
             "daemon_mode": self.daemon_mode,
+            "domshell_lane_id": self.domshell_lane_id,
         }

--- a/browser/agent-harness/cli_anything/browser/tests/test_core.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_core.py
@@ -216,7 +216,7 @@ class TestFsModule:
 
             result = fs.list_elements(sess)
 
-            mock_ls.assert_called_once_with("/main", use_daemon=False)
+            mock_ls.assert_called_once_with("/main", use_daemon=False, session=sess)
 
     def test_list_elements_with_path(self):
         """Listing elements with explicit path overrides working_dir."""
@@ -228,7 +228,7 @@ class TestFsModule:
 
             result = fs.list_elements(sess, "/div")
 
-            mock_ls.assert_called_once_with("/div", use_daemon=False)
+            mock_ls.assert_called_once_with("/div", use_daemon=False, session=sess)
 
     def test_list_elements_empty_path_uses_working_dir(self):
         """Listing with empty path uses session working_dir."""
@@ -240,7 +240,7 @@ class TestFsModule:
 
             result = fs.list_elements(sess, "")
 
-            mock_ls.assert_called_once_with("/main", use_daemon=False)
+            mock_ls.assert_called_once_with("/main", use_daemon=False, session=sess)
 
     def test_change_directory_absolute_path(self):
         """Changing to absolute path updates working_dir."""
@@ -252,7 +252,7 @@ class TestFsModule:
             result = fs.change_directory(sess, "/main")
 
             assert sess.working_dir == "/main"
-            mock_cd.assert_called_once_with("/main", use_daemon=False)
+            mock_cd.assert_called_once_with("/main", use_daemon=False, session=sess)
 
     def test_change_directory_relative_parent(self):
         """Changing to .. goes up one level."""
@@ -265,7 +265,7 @@ class TestFsModule:
             result = fs.change_directory(sess, "..")
 
             assert sess.working_dir == "/main"
-            mock_cd.assert_called_once_with("/main", use_daemon=False)
+            mock_cd.assert_called_once_with("/main", use_daemon=False, session=sess)
 
     def test_change_directory_parent_from_root(self):
         """Changing to .. from root stays at root."""
@@ -300,7 +300,7 @@ class TestFsModule:
             result = fs.change_directory(sess, "div[0]")
 
             assert sess.working_dir == "/main/div[0]"
-            mock_cd.assert_called_once_with("/main/div[0]", use_daemon=False)
+            mock_cd.assert_called_once_with("/main/div[0]", use_daemon=False, session=sess)
 
     def test_read_element(self):
         """Reading element calls backend."""
@@ -315,7 +315,7 @@ class TestFsModule:
 
             result = fs.read_element(sess, "/main/button[0]")
 
-            mock_cat.assert_called_once_with("/main/button[0]", use_daemon=False)
+            mock_cat.assert_called_once_with("/main/button[0]", use_daemon=False, session=sess)
 
     def test_read_element_empty_path_uses_working_dir(self):
         """Reading with empty path uses session working_dir."""
@@ -327,7 +327,7 @@ class TestFsModule:
 
             result = fs.read_element(sess, "")
 
-            mock_cat.assert_called_once_with("/main", use_daemon=False)
+            mock_cat.assert_called_once_with("/main", use_daemon=False, session=sess)
 
     def test_grep_elements(self):
         """Grepping calls backend with pattern and session cwd as path."""
@@ -341,7 +341,7 @@ class TestFsModule:
             result = fs.grep_elements(sess, "Login")
 
             mock_grep.assert_called_once_with(
-                "Login", path="/", prev="/", use_daemon=False
+                "Login", path="/", prev="/", use_daemon=False, session=sess
             )
 
     def test_grep_elements_with_path(self):
@@ -354,7 +354,7 @@ class TestFsModule:
             result = fs.grep_elements(sess, "Login", "/main")
 
             mock_grep.assert_called_once_with(
-                "Login", path="/main", prev="/", use_daemon=False
+                "Login", path="/main", prev="/", use_daemon=False, session=sess
             )
 
 
@@ -373,7 +373,7 @@ class TestDaemonMode:
 
             result = fs.list_elements(sess)
 
-            mock_ls.assert_called_once_with("/", use_daemon=True)
+            mock_ls.assert_called_once_with("/", use_daemon=True, session=sess)
 
     def test_normal_mode_does_not_use_daemon(self):
         """Commands don't use daemon mode when session.daemon_mode is False."""
@@ -385,4 +385,4 @@ class TestDaemonMode:
 
             result = fs.list_elements(sess)
 
-            mock_ls.assert_called_once_with("/", use_daemon=False)
+            mock_ls.assert_called_once_with("/", use_daemon=False, session=sess)

--- a/browser/agent-harness/cli_anything/browser/tests/test_core.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_core.py
@@ -386,3 +386,56 @@ class TestDaemonMode:
             result = fs.list_elements(sess)
 
             mock_ls.assert_called_once_with("/", use_daemon=False, session=sess)
+
+
+# ── CLI-layer error surfacing (Codex P2 R4) ─────────────────────────
+
+
+class TestCLIErrorSurfacing:
+    """The non-JSON branches of `fs ls` and `fs grep` previously fell
+    straight into ``result.get("entries"/"matches", [])`` and surfaced
+    "No elements at …" / "No matches for …" for DOMShell errors. Codex
+    P2 R4 on PR #308 commit 5790651 required surfacing the error
+    message instead.
+    """
+
+    def _invoke(self, mod_target, error_result, argv):
+        """Mock the dependency check + the fs_mod target, invoke CLI."""
+        from click.testing import CliRunner
+        from cli_anything.browser.browser_cli import cli
+
+        with patch(
+            "cli_anything.browser.browser_cli.backend.is_available",
+            return_value=(True, "ok"),
+        ), patch(
+            f"cli_anything.browser.browser_cli.fs_mod.{mod_target}",
+            return_value=error_result,
+        ):
+            return CliRunner().invoke(cli, argv)
+
+    def test_fs_ls_surfaces_error_in_non_json_output(self):
+        """`fs ls` on a path DOMShell errors against should display the
+        error message — not the misleading "No elements at <path>".
+        """
+        error_result = {
+            "error": "ls: nonexistent: No such directory",
+            "output": "ls: nonexistent: No such directory",
+        }
+        result = self._invoke(
+            "list_elements", error_result, ["fs", "ls", "/nonexistent"],
+        )
+        # click.echo(err=True) goes to stderr; CliRunner captures both.
+        assert "No such directory" in result.output
+        assert "No elements" not in result.output
+
+    def test_fs_grep_surfaces_error_in_non_json_output(self):
+        """Mirror for `fs grep`. Codex P2 R4 regression test."""
+        error_result = {
+            "error": "cd: /nonexistent: No such directory",
+            "output": "cd: /nonexistent: No such directory",
+        }
+        result = self._invoke(
+            "grep_elements", error_result, ["fs", "grep", "Login", "/nonexistent"],
+        )
+        assert "No such directory" in result.output
+        assert "No matches" not in result.output

--- a/browser/agent-harness/cli_anything/browser/tests/test_core.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_core.py
@@ -330,8 +330,8 @@ class TestFsModule:
             mock_cat.assert_called_once_with("/main", use_daemon=False)
 
     def test_grep_elements(self):
-        """Grepping calls backend with pattern."""
-        sess = Session()
+        """Grepping calls backend with pattern and session cwd as path."""
+        sess = Session()  # working_dir defaults to "/"
 
         with patch("cli_anything.browser.core.fs.backend.grep") as mock_grep:
             mock_grep.return_value = {
@@ -340,23 +340,22 @@ class TestFsModule:
 
             result = fs.grep_elements(sess, "Login")
 
-            mock_grep.assert_called_once_with("Login", use_daemon=False)
+            mock_grep.assert_called_once_with(
+                "Login", path="/", prev="/", use_daemon=False
+            )
 
     def test_grep_elements_with_path(self):
-        """Grepping with path cds to that path first, then restores."""
+        """Grepping with an explicit path forwards it to backend.grep."""
         sess = Session()
 
-        with patch("cli_anything.browser.core.fs.backend.grep") as mock_grep, \
-             patch("cli_anything.browser.core.fs.backend.cd") as mock_cd:
+        with patch("cli_anything.browser.core.fs.backend.grep") as mock_grep:
             mock_grep.return_value = {"matches": ["/main/button[0]"]}
-            mock_cd.return_value = {"path": "/main"}
 
             result = fs.grep_elements(sess, "Login", "/main")
 
-            mock_grep.assert_called_once_with("Login", use_daemon=False)
-            assert mock_cd.call_count == 2
-            mock_cd.assert_any_call("/main", use_daemon=False)
-            mock_cd.assert_any_call("/", use_daemon=False)
+            mock_grep.assert_called_once_with(
+                "Login", path="/main", prev="/", use_daemon=False
+            )
 
 
 # ── Daemon Mode Tests ────────────────────────────────────────────

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -26,57 +26,53 @@ def test_grep_unrooted_produces_single_grep_call(mock_call):
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_grep_rooted_produces_three_calls_in_order(mock_call):
-    """Rooted grep dispatches cd → grep → cd-back, in that order."""
+def test_grep_rooted_emits_single_multiline_call(mock_call):
+    """Rooted grep is ONE multi-line ``cd / grep / cd back`` execute call.
+
+    Each ``_call_execute`` in non-daemon mode opens a fresh MCP session
+    that lands in its own DOMShell 2.x lane, so splitting cd / grep /
+    restore across separate calls would lose the cwd between them. The
+    three lines must travel in one ``domshell_execute`` call to share
+    a lane.
+    """
     mock_call.return_value = {}
 
     backend.grep("Login", path="/main", prev="/")
 
     assert mock_call.call_args_list == [
-        call("cd /main", False),
-        call("grep Login", False),
-        call("cd /", False),
+        call("cd /main\ngrep Login\ncd /", False),
     ]
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_grep_rooted_restores_cwd_when_grep_raises(mock_call):
-    """If grep errors mid-flight, the trailing cd-back still runs (try/finally)."""
-    mock_call.side_effect = [
-        {},                            # cd /main → success
-        RuntimeError("grep blew up"),  # grep → raise
-        {},                            # cd / (restore) — required
-    ]
+def test_grep_rooted_uses_single_call_for_lane_isolation(mock_call):
+    """Documents the lane-isolation contract: ONE call, not three.
 
-    with pytest.raises(RuntimeError, match="grep blew up"):
-        backend.grep("Login", path="/main", prev="/")
+    The trailing ``cd prev`` is delivered as the final line of the same
+    multi-line command and runs even if ``grep`` errors, per DOMShell's
+    documented continue-on-error semantics
+    (`apireno/DOMShell#46 <https://github.com/apireno/DOMShell/issues/46>`_).
+    """
+    mock_call.return_value = {}
 
-    assert mock_call.call_count == 3
-    assert mock_call.call_args_list[-1] == call("cd /", False)
+    backend.grep("Login", path="/main", prev="/")
 
-
-@patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_grep_rooted_short_circuits_when_cd_errors(mock_call):
-    """If the initial cd reports an error, grep is skipped and no restore is sent."""
-    mock_call.return_value = {"isError": True, "error": "no such path"}
-
-    result = backend.grep("Login", path="/missing", prev="/")
-
-    # Only the initial cd ran; grep + restore were skipped.
-    assert mock_call.call_args_list == [call("cd /missing", False)]
-    assert result == {"isError": True, "error": "no such path"}
+    assert mock_call.call_count == 1
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_grep_rooted_quotes_path_with_spaces(mock_call):
-    """Paths with whitespace are shell-quoted before interpolation."""
+    """Paths with whitespace are shell-quoted inside the multi-line command."""
     mock_call.return_value = {}
 
     backend.grep("Login", path="/path with spaces", prev="/")
 
-    cd_cmd = mock_call.call_args_list[0].args[0]
-    # shlex.quote single-quotes anything containing whitespace.
-    assert cd_cmd == "cd '/path with spaces'"
+    cmd = mock_call.call_args.args[0]
+    # shlex.quote single-quotes anything containing whitespace; the rest
+    # of the multi-line layout (grep + cd back) stays intact.
+    assert cmd.startswith("cd '/path with spaces'\n")
+    assert "\ngrep Login\n" in cmd
+    assert cmd.endswith("\ncd /")
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -1,0 +1,167 @@
+"""Wire-format tests for cli_anything.browser.utils.domshell_backend.
+
+These tests patch the async ``_call_execute`` helper and assert the exact
+command string sent to the DOMShell ``domshell_execute`` tool, so wire-format
+regressions (quoting, command names, multi-line layout, restore ordering)
+fail loudly.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, call, patch
+
+from cli_anything.browser.utils import domshell_backend as backend
+
+
+# ── grep: command string and call sequencing ──────────────────────────
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_unrooted_produces_single_grep_call(mock_call):
+    """Unrooted grep dispatches one ``grep <pattern>`` call."""
+    mock_call.return_value = {}
+
+    backend.grep("Login")
+
+    assert mock_call.call_args_list == [call("grep Login", False)]
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_rooted_produces_three_calls_in_order(mock_call):
+    """Rooted grep dispatches cd → grep → cd-back, in that order."""
+    mock_call.return_value = {}
+
+    backend.grep("Login", path="/main", prev="/")
+
+    assert mock_call.call_args_list == [
+        call("cd /main", False),
+        call("grep Login", False),
+        call("cd /", False),
+    ]
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_rooted_restores_cwd_when_grep_raises(mock_call):
+    """If grep errors mid-flight, the trailing cd-back still runs (try/finally)."""
+    mock_call.side_effect = [
+        {},                            # cd /main → success
+        RuntimeError("grep blew up"),  # grep → raise
+        {},                            # cd / (restore) — required
+    ]
+
+    with pytest.raises(RuntimeError, match="grep blew up"):
+        backend.grep("Login", path="/main", prev="/")
+
+    assert mock_call.call_count == 3
+    assert mock_call.call_args_list[-1] == call("cd /", False)
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_rooted_short_circuits_when_cd_errors(mock_call):
+    """If the initial cd reports an error, grep is skipped and no restore is sent."""
+    mock_call.return_value = {"isError": True, "error": "no such path"}
+
+    result = backend.grep("Login", path="/missing", prev="/")
+
+    # Only the initial cd ran; grep + restore were skipped.
+    assert mock_call.call_args_list == [call("cd /missing", False)]
+    assert result == {"isError": True, "error": "no such path"}
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_rooted_quotes_path_with_spaces(mock_call):
+    """Paths with whitespace are shell-quoted before interpolation."""
+    mock_call.return_value = {}
+
+    backend.grep("Login", path="/path with spaces", prev="/")
+
+    cd_cmd = mock_call.call_args_list[0].args[0]
+    # shlex.quote single-quotes anything containing whitespace.
+    assert cd_cmd == "cd '/path with spaces'"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_pattern_with_shell_metacharacters_quoted(mock_call):
+    """Patterns with shell metacharacters get quoted (no injection via grep)."""
+    mock_call.return_value = {}
+
+    backend.grep("$(rm -rf /)")
+
+    grep_cmd = mock_call.call_args_list[0].args[0]
+    # shlex.quote will single-quote the dangerous payload.
+    assert grep_cmd == "grep '$(rm -rf /)'"
+
+
+def test_grep_rejects_positional_path():
+    """grep(pattern, path) — positional path raises TypeError.
+
+    Pre-migration callers writing ``grep("Login", True)`` to mean
+    ``use_daemon=True`` must not silently get ``path=True``.
+    """
+    with pytest.raises(TypeError):
+        backend.grep("Login", True)  # type: ignore[misc]
+
+
+def test_grep_rejects_positional_use_daemon():
+    """Even the third positional slot is blocked."""
+    with pytest.raises(TypeError):
+        backend.grep("Login", "/main", "/", True)  # type: ignore[misc]
+
+
+def test_grep_keyword_use_daemon_still_works():
+    """Keyword call against the new signature still type-checks at call time."""
+    with patch.object(backend, "_call_execute", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = {}
+        backend.grep("Login", use_daemon=True)
+        assert mock_call.call_args_list == [call("grep Login", True)]
+
+
+# ── type_text: focus+type pairing and newline injection guard ─────────
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_type_text_emits_focus_then_type_in_one_call(mock_call):
+    """type_text builds a single multi-line ``focus … \\ntype …`` execute call."""
+    mock_call.return_value = {}
+
+    backend.type_text("search_input", "machine learning")
+
+    assert mock_call.call_args_list == [
+        call("focus search_input\ntype 'machine learning'", False),
+    ]
+
+
+def test_type_text_rejects_newline_in_text():
+    """``\\n`` in text would inject a new DOMShell command — must raise."""
+    with pytest.raises(ValueError, match="newline"):
+        backend.type_text("search_input", "line1\nline2")
+
+
+def test_type_text_rejects_carriage_return_in_text():
+    """``\\r`` is just as dangerous as ``\\n`` for DOMShell's line splitter."""
+    with pytest.raises(ValueError, match="newline"):
+        backend.type_text("search_input", "line1\rline2")
+
+
+def test_type_text_rejects_newline_in_path():
+    """A newline in the path argument also injects — guard both fields."""
+    with pytest.raises(ValueError, match="newline"):
+        backend.type_text("input\nclick /admin", "anything")
+
+
+# ── grep: newline guard on rooted multi-step path ─────────────────────
+
+
+def test_grep_rejects_newline_in_path():
+    """Rooted grep interpolates path into a multi-line cd/grep/cd — reject newlines."""
+    with pytest.raises(ValueError, match="newline"):
+        backend.grep("Login", path="/main\nclick /admin", prev="/")
+
+
+def test_grep_rejects_newline_in_pattern():
+    with pytest.raises(ValueError, match="newline"):
+        backend.grep("Login\nclick /admin", path="/main", prev="/")
+
+
+def test_grep_rejects_newline_in_prev():
+    with pytest.raises(ValueError, match="newline"):
+        backend.grep("Login", path="/main", prev="/\nclick /admin")

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -1106,8 +1106,18 @@ def test_call_execute_includes_group_id_when_lane_is_set():
     assert arguments == {"command": "ls /", "group_id": "lane-7"}
 
 
-def test_call_execute_omits_group_id_when_lane_is_none():
-    """First-call shape: no stored lane → no group_id; DOMShell auto-assigns."""
+def test_call_execute_passes_group_id_new_when_lane_is_none():
+    """First-call shape: no stored lane → ``group_id="new"``; DOMShell
+    creates an isolated lane and returns the id, which we capture for
+    next time.
+
+    Migration note (PR #308 follow-up to DOMShell 2.0.2): we used to omit
+    ``group_id`` on the first call entirely, which DOMShell 2.x mapped
+    to a fresh lane silently. 2.0.2 deprecated that path — omitting now
+    emits a [DEPRECATION] warning on every reply (will be a hard error
+    in 3.0.0). Passing ``"new"`` makes the intent explicit and silences
+    the warning.
+    """
     sess = Session()  # lane is None
     fake_tool = AsyncMock(return_value=_make_result("✓\n[lane: brand-new]"))
 
@@ -1128,7 +1138,7 @@ def test_call_execute_omits_group_id_when_lane_is_none():
         _aio.run(backend._call_execute("ls /", session=sess))
 
     arguments = fake_tool.call_args.args[1]
-    assert "group_id" not in arguments
+    assert arguments.get("group_id") == "new"
     # The auto-assigned lane gets captured for next time.
     assert sess.domshell_lane_id == "brand-new"
 

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -22,7 +22,8 @@ def test_grep_unrooted_produces_single_grep_call(mock_call):
 
     backend.grep("Login")
 
-    assert mock_call.call_args_list == [call("grep Login", False)]
+    # session=None when no session is passed (default).
+    assert mock_call.call_args_list == [call("grep Login", False, session=None)]
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -40,7 +41,7 @@ def test_grep_rooted_emits_single_multiline_call(mock_call):
     backend.grep("Login", path="/main", prev="/")
 
     assert mock_call.call_args_list == [
-        call("cd /main\ngrep Login\ncd /", False),
+        call("cd /main\ngrep Login\ncd /", False, session=None),
     ]
 
 
@@ -108,7 +109,7 @@ def test_grep_keyword_use_daemon_still_works():
     with patch.object(backend, "_call_execute", new_callable=AsyncMock) as mock_call:
         mock_call.return_value = {}
         backend.grep("Login", use_daemon=True)
-        assert mock_call.call_args_list == [call("grep Login", True)]
+        assert mock_call.call_args_list == [call("grep Login", True, session=None)]
 
 
 # ── type_text: focus+type pairing and newline injection guard ─────────
@@ -122,7 +123,7 @@ def test_type_text_emits_focus_then_type_in_one_call(mock_call):
     backend.type_text("search_input", "machine learning")
 
     assert mock_call.call_args_list == [
-        call("focus search_input\ntype 'machine learning'", False),
+        call("focus search_input\ntype 'machine learning'", False, session=None),
     ]
 
 
@@ -218,3 +219,196 @@ def test_cd_rejects_newlines(mock_call):
     mock_call.return_value = {}
     with pytest.raises(ValueError, match="[Nn]ewline"):
         backend.cd("/main\nclick /admin")
+
+
+# ── DOMShell lane persistence across _call_execute calls ─────────────
+#
+# DOMShell 2.x assigns a fresh lane (Chrome tab-group) to every new MCP
+# session. In non-daemon mode each _call_execute opens its own stdio
+# ClientSession, so without explicit group_id every command would land
+# in a brand-new lane and lose browser state from the previous call.
+# The fix: parse the trailing "[lane: <id>]" marker DOMShell appends to
+# each reply, store it on the harness Session, and pass group_id=<id>
+# on every subsequent call.
+
+
+from types import SimpleNamespace
+
+from cli_anything.browser.core.session import Session
+
+
+def _make_result(text: str):
+    """Build a fake CallToolResult whose ``content[0].text`` is ``text``."""
+    return SimpleNamespace(content=[SimpleNamespace(text=text)])
+
+
+# ── _extract_lane_id ────────────────────────────────────────────────
+
+
+def test_extract_lane_id_parses_trailing_marker():
+    assert backend._extract_lane_id(_make_result("✓ ls done\n[lane: 12345]")) == "12345"
+
+
+def test_extract_lane_id_handles_trailing_whitespace():
+    assert backend._extract_lane_id(_make_result("✓ ls done\n[lane: lane-abc]\n")) == "lane-abc"
+
+
+def test_extract_lane_id_ignores_shared_marker():
+    """`[lane: shared]` is DOMShell's no-isolation sentinel — must not pin to it."""
+    assert backend._extract_lane_id(_make_result("✓ ls done\n[lane: shared]")) is None
+
+
+def test_extract_lane_id_returns_none_when_marker_absent():
+    assert backend._extract_lane_id(_make_result("✓ ls done")) is None
+
+
+def test_extract_lane_id_returns_none_for_empty_text():
+    assert backend._extract_lane_id(_make_result("")) is None
+
+
+def test_extract_lane_id_returns_none_when_content_missing():
+    assert backend._extract_lane_id(SimpleNamespace()) is None
+
+
+# ── lane capture + propagation ──────────────────────────────────────
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_first_call_omits_group_id_and_captures_lane(mock_call):
+    """A session with no stored lane: first call has no group_id, captures the returned lane."""
+    sess = Session()  # domshell_lane_id starts as None
+    mock_call.return_value = _make_result("✓\n[lane: 12345]")
+
+    backend.click("submit_btn", session=sess)
+
+    # The session= kwarg the wrapper passes is the Session object itself;
+    # _call_execute is responsible for translating session.domshell_lane_id
+    # into the wire-format group_id. We only assert the call signature here.
+    assert mock_call.call_args == call("click submit_btn", False, session=sess)
+    # _call_execute is mocked, so we exercise _capture_lane directly to
+    # verify the parser hookup that the real _call_execute would do.
+    backend._capture_lane(sess, mock_call.return_value)
+    assert sess.domshell_lane_id == "12345"
+
+
+def test_capture_lane_updates_session():
+    sess = Session()
+    backend._capture_lane(sess, _make_result("✓\n[lane: lane-XYZ]"))
+    assert sess.domshell_lane_id == "lane-XYZ"
+
+
+def test_capture_lane_no_op_when_session_is_none():
+    """Direct backend callers without a session must not crash."""
+    backend._capture_lane(None, _make_result("✓\n[lane: 12345]"))  # no exception
+
+
+def test_capture_lane_no_op_when_marker_missing():
+    sess = Session()
+    sess.domshell_lane_id = "preexisting"
+    backend._capture_lane(sess, _make_result("✓ done"))
+    # No marker → don't clobber the previously-captured lane.
+    assert sess.domshell_lane_id == "preexisting"
+
+
+def test_capture_lane_ignores_shared_marker():
+    sess = Session()
+    sess.domshell_lane_id = "preexisting"
+    backend._capture_lane(sess, _make_result("✓\n[lane: shared]"))
+    assert sess.domshell_lane_id == "preexisting"
+
+
+# ── End-to-end: lane reuse on subsequent calls ───────────────────────
+
+
+def test_call_execute_includes_group_id_when_lane_is_set():
+    """When session.domshell_lane_id is set, _call_execute sends it as group_id.
+
+    We bypass the stdio_client / ClientSession plumbing entirely by patching
+    them — what we want to assert is the arguments dict that gets passed to
+    ``call_tool``.
+    """
+    sess = Session()
+    sess.domshell_lane_id = "lane-7"
+
+    fake_tool = AsyncMock(return_value=_make_result("✓\n[lane: lane-7]"))
+
+    fake_mcp_session = AsyncMock()
+    fake_mcp_session.__aenter__.return_value = fake_mcp_session
+    fake_mcp_session.__aexit__.return_value = None
+    fake_mcp_session.initialize = AsyncMock()
+    fake_mcp_session.call_tool = fake_tool
+
+    fake_stdio = AsyncMock()
+    fake_stdio.__aenter__.return_value = (object(), object())
+    fake_stdio.__aexit__.return_value = None
+
+    with patch.object(backend, "stdio_client", return_value=fake_stdio), \
+         patch.object(backend, "ClientSession", return_value=fake_mcp_session), \
+         patch.object(backend, "_build_server_args", return_value=[]):
+        import asyncio as _aio
+        _aio.run(backend._call_execute("ls /", session=sess))
+
+    name, arguments = fake_tool.call_args.args
+    assert name == "domshell_execute"
+    assert arguments == {"command": "ls /", "group_id": "lane-7"}
+
+
+def test_call_execute_omits_group_id_when_lane_is_none():
+    """First-call shape: no stored lane → no group_id; DOMShell auto-assigns."""
+    sess = Session()  # lane is None
+    fake_tool = AsyncMock(return_value=_make_result("✓\n[lane: brand-new]"))
+
+    fake_mcp_session = AsyncMock()
+    fake_mcp_session.__aenter__.return_value = fake_mcp_session
+    fake_mcp_session.__aexit__.return_value = None
+    fake_mcp_session.initialize = AsyncMock()
+    fake_mcp_session.call_tool = fake_tool
+
+    fake_stdio = AsyncMock()
+    fake_stdio.__aenter__.return_value = (object(), object())
+    fake_stdio.__aexit__.return_value = None
+
+    with patch.object(backend, "stdio_client", return_value=fake_stdio), \
+         patch.object(backend, "ClientSession", return_value=fake_mcp_session), \
+         patch.object(backend, "_build_server_args", return_value=[]):
+        import asyncio as _aio
+        _aio.run(backend._call_execute("ls /", session=sess))
+
+    arguments = fake_tool.call_args.args[1]
+    assert "group_id" not in arguments
+    # The auto-assigned lane gets captured for next time.
+    assert sess.domshell_lane_id == "brand-new"
+
+
+def test_distinct_sessions_have_isolated_lanes():
+    """Two sessions track lanes independently — no cross-contamination."""
+    s1 = Session()
+    s2 = Session()
+    backend._capture_lane(s1, _make_result("✓\n[lane: lane-A]"))
+    backend._capture_lane(s2, _make_result("✓\n[lane: lane-B]"))
+    assert s1.domshell_lane_id == "lane-A"
+    assert s2.domshell_lane_id == "lane-B"
+
+
+# ── Keyword-only enforcement on session= ─────────────────────────────
+
+
+def test_session_is_keyword_only_on_click():
+    """Discipline matches grep's earlier keyword-only fix."""
+    with pytest.raises(TypeError):
+        backend.click("submit_btn", False, None)  # type: ignore[misc]
+
+
+def test_session_is_keyword_only_on_ls():
+    with pytest.raises(TypeError):
+        backend.ls("/", False, None)  # type: ignore[misc]
+
+
+def test_session_is_keyword_only_on_type_text():
+    with pytest.raises(TypeError):
+        backend.type_text("input", "hello", False, None)  # type: ignore[misc]
+
+
+def test_session_is_keyword_only_on_open_url():
+    with pytest.raises(TypeError):
+        backend.open_url("https://example.com", False, None)  # type: ignore[misc]

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -455,10 +455,29 @@ def test_type_text_relative_path_focus_failure_skips_type(mock_call):
     assert result.content[0].text == "Error: focus: No such element"
 
 
-def test_type_text_raises_without_session():
-    """The two halves must share a lane; require a session up front."""
+def test_type_text_raises_without_session_in_non_daemon_mode():
+    """Non-daemon mode: the two halves must share a lane via group_id,
+    which requires a session. Without one, raise.
+    """
     with pytest.raises(ValueError, match="session"):
-        backend.type_text("search_input", "text", session=None)
+        backend.type_text(
+            "search_input", "text", use_daemon=False, session=None,
+        )
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_type_text_allows_no_session_in_daemon_mode(mock_call):
+    """Daemon mode shares lane via the persistent connection — session
+    isn't required. Locks in the contract Copilot flagged.
+    """
+    mock_call.return_value = _make_result("✓\n[lane: 1]")
+
+    # No exception. Relative path → two calls (focus + type).
+    backend.type_text("search_input", "hello", use_daemon=True, session=None)
+
+    assert mock_call.call_count == 2
+    assert mock_call.call_args_list[0].args[0] == "focus search_input"
+    assert mock_call.call_args_list[1].args[0] == "type hello"
 
 
 def test_type_text_raises_with_empty_path():

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -18,63 +18,125 @@ from cli_anything.browser.utils import domshell_backend as backend
 # ── Path translation: harness `/` vs DOMShell `~/` ───────────────────
 
 
-def test_translate_path_root_maps_to_empty():
-    """Harness `/` (focused-tab AX root) → DOMShell empty (lane cwd)."""
-    assert backend._translate_path("/") == ""
-    assert backend._translate_path("") == ""
+def test_translate_path_root_is_absolute_empty():
+    """`/` → ("", True). Absolute target with no further subdir."""
+    assert backend._translate_path("/") == ("", True)
 
 
-def test_translate_path_strips_leading_slash():
-    assert backend._translate_path("/main") == "main"
-    assert backend._translate_path("/main/article") == "main/article"
+def test_translate_path_empty_is_relative_empty():
+    """`""` → ("", False). Bare/relative no-op; caller decides what to do."""
+    assert backend._translate_path("") == ("", False)
+
+
+def test_translate_path_strips_all_leading_slashes():
+    """`//main` collapses to `("main", True)` via lstrip."""
+    assert backend._translate_path("/main") == ("main", True)
+    assert backend._translate_path("//main") == ("main", True)
+    assert backend._translate_path("///main") == ("main", True)
 
 
 def test_translate_path_preserves_relative():
     """Relative paths pass through unchanged — DOMShell handles them."""
-    assert backend._translate_path("main") == "main"
-    assert backend._translate_path("..") == ".."
-    assert backend._translate_path(".") == "."
+    assert backend._translate_path("main") == ("main", False)
+    assert backend._translate_path("..") == ("..", False)
+    assert backend._translate_path(".") == (".", False)
+
+
+# ── ls / cd / cat / click: absolute paths anchor at %here% ───────────
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_ls_root_sends_bare_ls(mock_call):
-    """`ls /` (harness) → bare `ls` (DOMShell), operating on lane cwd."""
+def test_ls_absolute_path_wraps_with_cd_anchor_and_restore(mock_call):
+    """`ls /main` from a `/main` session: cd-anchor + bare ls + restore."""
     mock_call.return_value = _make_result("[lane: 1]")
-    backend.ls("/")
-    assert mock_call.call_args.args[0] == "ls"
+    sess = _make_session(working_dir="/main")
+    backend.ls("/main", session=sess)
+    cmd = mock_call.call_args.args[0]
+    assert "cd %here%/main" in cmd
+    assert "\nls\n" in cmd
+    assert cmd.endswith("cd %here%/main")
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_ls_subpath_strips_leading_slash(mock_call):
+def test_ls_root_from_drifted_cwd_anchors_at_here(mock_call):
+    """The Codex P1 case: `ls /` from a drifted `/main` cwd anchors at tab root."""
     mock_call.return_value = _make_result("[lane: 1]")
-    backend.ls("/main")
+    sess = _make_session(working_dir="/main")
+    backend.ls("/", session=sess)
+    cmd = mock_call.call_args.args[0]
+    assert cmd == "cd %here%\nls\ncd %here%/main"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_ls_relative_path_no_wrap(mock_call):
+    """Relative `ls main` runs against lane cwd — no anchor, no restore."""
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.ls("main")
     assert mock_call.call_args.args[0] == "ls main"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_ls_absolute_path_with_spaces_quoted(mock_call):
+    """The `%here%/<deeper>` token is shell-quoted as one unit.
+
+    Upstream-smoked: `cd '%here%/<path>'` works in DOMShell 2.0.x — so
+    whitespace and other shell metachars in absolute targets are safe.
+    """
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.ls("/path with spaces", session=_make_session(working_dir="/"))
+    cmd = mock_call.call_args.args[0]
+    assert "cd '%here%/path with spaces'" in cmd
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_cd_root_uses_here(mock_call):
-    """`cd /` (harness) → `cd %here%` (DOMShell jump-to-tab-root)."""
+    """`cd /` → `cd %here%`. Single line — cd's purpose IS the new state."""
     mock_call.return_value = _make_result("[lane: 1]")
     backend.cd("/")
     assert mock_call.call_args.args[0] == "cd %here%"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_cd_subpath_strips_leading_slash(mock_call):
+def test_cd_absolute_is_single_line_no_restore(mock_call):
+    """`cd /main` → `cd %here%/main`. One line, no restore."""
     mock_call.return_value = _make_result("[lane: 1]")
-    backend.cd("/main/div[0]")
-    assert mock_call.call_args.args[0] == "cd 'main/div[0]'"
+    backend.cd("/main")
+    assert mock_call.call_args.args[0] == "cd %here%/main"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_cat_strips_leading_slash(mock_call):
+def test_cd_subpath_with_indexing(mock_call):
+    """Brackets are shell-metachars — `_here_path` quotes the full token."""
     mock_call.return_value = _make_result("[lane: 1]")
-    backend.cat("/main/button[0]")
-    assert mock_call.call_args.args[0] == "cat 'main/button[0]'"
+    backend.cd("/main/div[0]")
+    assert mock_call.call_args.args[0] == "cd '%here%/main/div[0]'"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cd_relative_quoted(mock_call):
+    """Relative `cd main` is quoted via _q (handles spaces / metachars)."""
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.cd("main")
+    assert mock_call.call_args.args[0] == "cd main"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cat_absolute_path_wraps(mock_call):
+    """`cat /main/btn`: anchor at tab root, run relative cat, restore."""
+    mock_call.return_value = _make_result("[lane: 1]")
+    sess = _make_session(working_dir="/")
+    backend.cat("/main/btn", session=sess)
+    assert mock_call.call_args.args[0] == "cd %here%\ncat main/btn\ncd %here%"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cat_relative_no_wrap(mock_call):
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.cat("main/btn")
+    assert mock_call.call_args.args[0] == "cat main/btn"
 
 
 def test_cat_root_raises_value_error():
-    """Calling cat against the tab root is a programming error — fail clearly."""
     with pytest.raises(ValueError, match="element name is required"):
         backend.cat("/")
     with pytest.raises(ValueError, match="element name is required"):
@@ -82,10 +144,21 @@ def test_cat_root_raises_value_error():
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_click_strips_leading_slash(mock_call):
+def test_click_absolute_path_wraps(mock_call):
     mock_call.return_value = _make_result("[lane: 1]")
-    backend.click("/main/button[0]")
-    assert mock_call.call_args.args[0] == "click 'main/button[0]'"
+    sess = _make_session(working_dir="/main")
+    backend.click("/main/button[0]", session=sess)
+    assert (
+        mock_call.call_args.args[0]
+        == "cd %here%\nclick 'main/button[0]'\ncd %here%/main"
+    )
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_click_relative_no_wrap(mock_call):
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.click("button[0]")
+    assert mock_call.call_args.args[0] == "click 'button[0]'"
 
 
 def test_click_root_raises_value_error():
@@ -95,20 +168,32 @@ def test_click_root_raises_value_error():
         backend.click("")
 
 
-def test_type_text_root_raises_value_error():
-    """Focusing the tab root is a programming error — same class as cat/click."""
-    with pytest.raises(ValueError, match="element name is required"):
-        backend.type_text("/", "hello")
-    with pytest.raises(ValueError, match="element name is required"):
-        backend.type_text("", "hello")
+# ── grep absolute-path anchoring ─────────────────────────────────────
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_grep_rooted_with_subpath_prev_keeps_translated_restore(mock_call):
-    """A non-`/` prev should also be translated, not sent verbatim."""
+def test_grep_rooted_absolute_anchors_at_here(mock_call):
+    """Rooted grep with absolute path anchors at tab root + restores wd."""
     mock_call.return_value = _make_result("[lane: 1]")
-    backend.grep("Login", path="/main/dialog", prev="/main")
-    assert mock_call.call_args.args[0] == "cd main/dialog\ngrep Login\ncd main"
+    backend.grep(
+        "Login", path="/main", prev="/", session=_make_session(working_dir="/"),
+    )
+    assert (
+        mock_call.call_args.args[0]
+        == "cd %here%/main\ngrep Login\ncd %here%"
+    )
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_rooted_absolute_restores_to_session_wd(mock_call):
+    """Restore line follows session.working_dir, not the `prev` kwarg, when
+    the path is absolute — the lane cwd needs to end up where the harness
+    thinks it is, regardless of what `prev` was originally."""
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.grep(
+        "Login", path="/main", prev="/", session=_make_session(working_dir="/main"),
+    )
+    assert mock_call.call_args.args[0].endswith("cd %here%/main")
 
 
 # ── _is_error helper ─────────────────────────────────────────────────
@@ -163,10 +248,10 @@ def test_grep_rooted_emits_single_multiline_call(mock_call):
 
     backend.grep("Login", path="/main", prev="/")
 
-    # Harness `/main` translates to DOMShell `main`; harness `/` (the
-    # default prev) translates to `cd %here%`.
+    # Absolute path anchors at %here%/main; restore comes from
+    # _restore_cwd_cmd(session=None) → `cd %here%` (defaults to harness `/`).
     assert mock_call.call_args_list == [
-        call("cd main\ngrep Login\ncd %here%", False, session=None),
+        call("cd %here%/main\ngrep Login\ncd %here%", False, session=None),
     ]
 
 
@@ -188,16 +273,16 @@ def test_grep_rooted_uses_single_call_for_lane_isolation(mock_call):
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_grep_rooted_quotes_path_with_spaces(mock_call):
-    """Paths with whitespace are shell-quoted inside the multi-line command."""
+    """Absolute paths with whitespace are quoted as `cd '%here%/path with spaces'`.
+
+    Upstream-smoked: DOMShell's `cd` accepts the quoted form cleanly.
+    """
     mock_call.return_value = {}
 
     backend.grep("Login", path="/path with spaces", prev="/")
 
     cmd = mock_call.call_args.args[0]
-    # _translate_path strips the leading "/", then shlex.quote single-
-    # quotes the remainder; the multi-line layout (grep + cd back) stays
-    # intact, with the restore using `cd %here%` for the harness-`/` prev.
-    assert cmd.startswith("cd 'path with spaces'\n")
+    assert cmd.startswith("cd '%here%/path with spaces'\n")
     assert "\ngrep Login\n" in cmd
     assert cmd.endswith("\ncd %here%")
 
@@ -242,7 +327,7 @@ def test_grep_keyword_use_daemon_still_works():
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_type_text_uses_two_separate_calls(mock_call):
+def test_type_text_emits_focus_then_type_with_session(mock_call):
     """type_text issues focus + type as two separate execute calls.
 
     The split is for safety: DOMShell's multi-line splitter continues
@@ -250,30 +335,65 @@ def test_type_text_uses_two_separate_calls(mock_call):
     would dispatch keys into stale focus if ``focus`` failed. Two calls
     with an error check between them prevents that.
     """
+    sess = _make_session(working_dir="/")
     mock_call.return_value = _make_result("✓ Focused\n[lane: 1]")
 
-    backend.type_text("search_input", "machine learning")
+    backend.type_text("search_input", "machine learning", session=sess)
 
     assert mock_call.call_count == 2
+    # Relative path → no anchor wrap.
     assert mock_call.call_args_list[0].args[0] == "focus search_input"
     assert mock_call.call_args_list[1].args[0] == "type 'machine learning'"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_type_text_absolute_path_wraps_focus(mock_call):
+    """Absolute focus path is anchored at %here% and restores wd."""
+    sess = _make_session(working_dir="/main")
+    mock_call.return_value = _make_result("✓\n[lane: 1]")
+
+    backend.type_text("/main/input", "text", session=sess)
+
+    assert mock_call.call_count == 2
+    assert (
+        mock_call.call_args_list[0].args[0]
+        == "cd %here%\nfocus main/input\ncd %here%/main"
+    )
+    assert mock_call.call_args_list[1].args[0] == "type text"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_type_text_skips_type_on_focus_error(mock_call):
     """If focus errors, type MUST NOT run — would land in stale focus."""
+    sess = _make_session(working_dir="/")
     mock_call.side_effect = [
         _make_result("Error: focus: No such element"),
         _make_result("✓ Typed"),  # should NOT be reached
     ]
 
-    result = backend.type_text("/stale/path", "secret_password")
+    result = backend.type_text("/stale/path", "secret_password", session=sess)
 
     # Only the focus call was made; the focus result was returned.
     assert mock_call.call_count == 1
-    assert mock_call.call_args_list[0].args[0] == "focus stale/path"
+    # Absolute path → wrapped in anchor + restore.
+    assert mock_call.call_args_list[0].args[0] == (
+        "cd %here%\nfocus stale/path\ncd %here%"
+    )
     # The focus result is returned verbatim so callers see the error.
     assert result.content[0].text == "Error: focus: No such element"
+
+
+def test_type_text_raises_without_session():
+    """The two halves must share a lane; require a session up front."""
+    with pytest.raises(ValueError, match="session"):
+        backend.type_text("search_input", "text", session=None)
+
+
+def test_type_text_raises_with_empty_path():
+    with pytest.raises(ValueError, match="input path is required"):
+        backend.type_text("", "text", session=_make_session())
+    with pytest.raises(ValueError, match="input path is required"):
+        backend.type_text("/", "text", session=_make_session())
 
 
 def test_type_text_rejects_newline_in_text():
@@ -379,6 +499,20 @@ def test_cd_rejects_newlines(mock_call):
 # The fix: parse the trailing "[lane: <id>]" marker DOMShell appends to
 # each reply, store it on the harness Session, and pass group_id=<id>
 # on every subsequent call.
+
+
+def _make_session(
+    working_dir: str = "/",
+    daemon_mode: bool = False,
+    lane_id=None,
+):
+    """Build a minimal session fixture compatible with the backend's
+    ``getattr``-style access (working_dir, daemon_mode, domshell_lane_id)."""
+    return SimpleNamespace(
+        working_dir=working_dir,
+        daemon_mode=daemon_mode,
+        domshell_lane_id=lane_id,
+    )
 
 
 def _make_result(text: str):
@@ -572,10 +706,13 @@ def test_session_is_keyword_only_on_open_url():
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_use_daemon_positional_on_ls(mock_call):
-    mock_call.return_value = {}
+    mock_call.return_value = _make_result("[lane: 1]")
     backend.ls("/", True)  # use_daemon=True positionally
-    # Harness `/` translates to "" so ls sends the bare command.
-    assert mock_call.call_args == call("ls", True, session=None)
+    # Absolute `/` with no session → anchor at %here%, bare ls, restore
+    # to %here% (the default for session=None).
+    assert mock_call.call_args == call(
+        "cd %here%\nls\ncd %here%", True, session=None,
+    )
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -594,11 +731,15 @@ def test_use_daemon_positional_on_reload(mock_call):
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_use_daemon_positional_on_type_text(mock_call):
-    """Positional ``use_daemon`` flows through both halves of the split."""
+    """Positional ``use_daemon`` flows through both halves of the split.
+
+    type_text now requires a session, so pass one explicitly.
+    """
+    sess = _make_session(working_dir="/")
     mock_call.return_value = _make_result("✓\n[lane: 1]")
-    backend.type_text("input", "hello", True)
+    backend.type_text("input", "hello", True, session=sess)
     # Two calls (focus then type), both with use_daemon=True positionally.
     assert mock_call.call_args_list == [
-        call("focus input", True, session=None),
-        call("type hello", True, session=None),
+        call("focus input", True, session=sess),
+        call("type hello", True, session=sess),
     ]

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -165,3 +165,60 @@ def test_grep_rejects_newline_in_pattern():
 def test_grep_rejects_newline_in_prev():
     with pytest.raises(ValueError, match="newline"):
         backend.grep("Login", path="/main", prev="/\nclick /admin")
+
+
+# ── Centralized newline guard in _q ──────────────────────────────────
+#
+# The per-wrapper _assert_single_line calls above cover type_text and
+# rooted grep with field-named error messages. The newline check inside
+# _q itself catches the same class of injection for every OTHER wrapper
+# that flows user input through the quoting layer (open_url, click, cd,
+# cat, unrooted grep, etc.) — without needing a per-call guard at each
+# site.
+
+
+def test_q_rejects_line_feeds():
+    with pytest.raises(ValueError, match="[Nn]ewline"):
+        backend._q("foo\nbar")
+
+
+def test_q_rejects_carriage_returns():
+    with pytest.raises(ValueError, match="[Nn]ewline"):
+        backend._q("foo\rbar")
+
+
+def test_q_accepts_normal_strings():
+    """Plain strings pass through to shlex.quote unchanged."""
+    assert backend._q("simple") == "simple"
+    assert backend._q("hello world") == "'hello world'"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_unrooted_grep_pattern_rejects_newlines(mock_call):
+    """The unrooted grep path was not field-guarded — _q catches it."""
+    mock_call.return_value = {}
+    with pytest.raises(ValueError, match="[Nn]ewline"):
+        backend.grep("evil\nclick /admin")
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_open_url_rejects_newlines(mock_call):
+    """open_url has no per-call _assert_single_line — _q must catch it."""
+    mock_call.return_value = {}
+    with pytest.raises(ValueError, match="[Nn]ewline"):
+        backend.open_url("https://example.com\nclick /admin")
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_click_rejects_newlines(mock_call):
+    """click is covered structurally by _q without a per-call guard."""
+    mock_call.return_value = {}
+    with pytest.raises(ValueError, match="[Nn]ewline"):
+        backend.click("/main/button[0]\nclick /admin")
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cd_rejects_newlines(mock_call):
+    mock_call.return_value = {}
+    with pytest.raises(ValueError, match="[Nn]ewline"):
+        backend.cd("/main\nclick /admin")

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -216,6 +216,24 @@ def test_is_error_detects_error_prefixed_text():
     assert backend._is_error(_make_result("✓ Focused\n[lane: 1]")) is False
 
 
+def test_is_error_strips_ansi_red_wrapper():
+    """DOMShell colours errors red — strip ANSI before prefix-matching.
+
+    Without this, a coloured error like `\\x1b[31mError: ...\\x1b[0m`
+    would be misread as success (its first chars are `\\x1b[31m`, not
+    `error`), letting downstream safety chains proceed.
+    """
+    assert backend._is_error(
+        _make_result("\x1b[31mError: focus: No such element\x1b[0m")
+    ) is True
+    # Plain `Error:` still detected.
+    assert backend._is_error(_make_result("Error: oops")) is True
+    # Mixed ANSI prefix without "Error" stays False.
+    assert backend._is_error(
+        _make_result("\x1b[32m✓ All good\x1b[0m")
+    ) is False
+
+
 def test_is_error_handles_missing_content():
     assert backend._is_error(SimpleNamespace()) is False
 
@@ -347,38 +365,92 @@ def test_type_text_emits_focus_then_type_with_session(mock_call):
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_type_text_absolute_path_wraps_focus(mock_call):
-    """Absolute focus path is anchored at %here% and restores wd."""
+def test_type_text_absolute_path_uses_four_separate_calls(mock_call):
+    """Absolute focus path: anchor → focus → type → restore, all distinct.
+
+    type_text is a safety chain, NOT a cleanup-line idiom: it must HALT
+    on focus failure rather than continue past it. Wrapping focus in a
+    multi-line ``cd %here%\\nfocus\\ncd <restore>`` would re-introduce
+    the continue-on-error trap (the anchor's leading "✓" masks the
+    focus error in the combined response). Split into four separate
+    _call_execute calls, all sharing the persisted lane via session.
+    """
     sess = _make_session(working_dir="/main")
     mock_call.return_value = _make_result("✓\n[lane: 1]")
 
-    backend.type_text("/main/input", "text", session=sess)
+    backend.type_text("/main/input", "hello", session=sess)
 
-    assert mock_call.call_count == 2
-    assert (
-        mock_call.call_args_list[0].args[0]
-        == "cd %here%\nfocus main/input\ncd %here%/main"
-    )
-    assert mock_call.call_args_list[1].args[0] == "type text"
+    assert mock_call.call_count == 4
+    assert mock_call.call_args_list[0].args[0] == "cd %here%"
+    assert mock_call.call_args_list[1].args[0] == "focus main/input"
+    assert mock_call.call_args_list[2].args[0] == "type hello"
+    assert mock_call.call_args_list[3].args[0] == "cd %here%/main"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_type_text_skips_type_on_focus_error(mock_call):
-    """If focus errors, type MUST NOT run — would land in stale focus."""
+def test_type_text_absolute_path_focus_failure_skips_type_and_restores(mock_call):
+    """The Codex P2 safety case: a stale absolute focus path must halt
+    before type can dispatch keys into whatever was previously focused.
+    The restore still runs so the lane cwd ends up where the harness
+    expects.
+    """
+    sess = _make_session(working_dir="/main")
+    mock_call.side_effect = [
+        _make_result("✓ Entered tab 123\n[lane: 1]"),                 # cd anchor ok
+        _make_result("\x1b[31mError: focus: No such element\x1b[0m"),  # focus fails
+        _make_result("✓ Typed\n[lane: 1]"),                            # MUST NOT be reached
+        _make_result("✓\n[lane: 1]"),                                   # restore
+    ]
+
+    backend.type_text("/main/missing", "secret_password", session=sess)
+
+    # Three calls: anchor, focus, restore. Type is skipped because the
+    # focus error halts the safety chain before keys are dispatched.
+    assert mock_call.call_count == 3
+    assert mock_call.call_args_list[0].args[0] == "cd %here%"
+    assert mock_call.call_args_list[1].args[0] == "focus main/missing"
+    assert mock_call.call_args_list[2].args[0] == "cd %here%/main"
+    # Critically — the "type secret_password" command was never sent.
+    for call_args in mock_call.call_args_list:
+        assert "type" not in call_args.args[0].split("\n")[0]
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_type_text_anchor_failure_does_not_attempt_focus(mock_call):
+    """If even the anchor cd fails (e.g. chrome:// not debuggable),
+    neither focus nor type runs. No restore needed because we never
+    moved off the original cwd.
+    """
+    sess = _make_session(working_dir="/")
+    mock_call.return_value = _make_result(
+        "\x1b[31mError: chrome:// not debuggable\x1b[0m"
+    )
+
+    backend.type_text("/some/path", "text", session=sess)
+
+    assert mock_call.call_count == 1
+    assert mock_call.call_args_list[0].args[0] == "cd %here%"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_type_text_relative_path_focus_failure_skips_type(mock_call):
+    """Relative path focus failure: no anchor (no drift to restore), so
+    just `focus`, then halt. Type MUST NOT run.
+
+    The absolute-path equivalent (with anchor + restore) is covered by
+    test_type_text_absolute_path_focus_failure_skips_type_and_restores.
+    """
     sess = _make_session(working_dir="/")
     mock_call.side_effect = [
         _make_result("Error: focus: No such element"),
         _make_result("✓ Typed"),  # should NOT be reached
     ]
 
-    result = backend.type_text("/stale/path", "secret_password", session=sess)
+    result = backend.type_text("stale_input", "secret_password", session=sess)
 
     # Only the focus call was made; the focus result was returned.
     assert mock_call.call_count == 1
-    # Absolute path → wrapped in anchor + restore.
-    assert mock_call.call_args_list[0].args[0] == (
-        "cd %here%\nfocus stale/path\ncd %here%"
-    )
+    assert mock_call.call_args_list[0].args[0] == "focus stale_input"
     # The focus result is returned verbatim so callers see the error.
     assert result.content[0].text == "Error: focus: No such element"
 

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -6,9 +6,12 @@ regressions (quoting, command names, multi-line layout, restore ordering)
 fail loudly.
 """
 
-import pytest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, call, patch
 
+import pytest
+
+from cli_anything.browser.core.session import Session
 from cli_anything.browser.utils import domshell_backend as backend
 
 
@@ -232,11 +235,6 @@ def test_cd_rejects_newlines(mock_call):
 # on every subsequent call.
 
 
-from types import SimpleNamespace
-
-from cli_anything.browser.core.session import Session
-
-
 def _make_result(text: str):
     """Build a fake CallToolResult whose ``content[0].text`` is ``text``."""
     return SimpleNamespace(content=[SimpleNamespace(text=text)])
@@ -391,10 +389,15 @@ def test_distinct_sessions_have_isolated_lanes():
 
 
 # ── Keyword-only enforcement on session= ─────────────────────────────
+#
+# Only ``session`` is keyword-only; ``use_daemon`` stays positional so
+# pre-2.0.0 callers like ``ls("/", True)`` keep working. ``grep`` is a
+# deliberate exception (fully keyword-only after the round-1 review).
 
 
 def test_session_is_keyword_only_on_click():
-    """Discipline matches grep's earlier keyword-only fix."""
+    """Trailing positional `None` is interpreted as a 3rd positional arg
+    that the wrapper doesn't accept — must raise TypeError."""
     with pytest.raises(TypeError):
         backend.click("submit_btn", False, None)  # type: ignore[misc]
 
@@ -412,3 +415,40 @@ def test_session_is_keyword_only_on_type_text():
 def test_session_is_keyword_only_on_open_url():
     with pytest.raises(TypeError):
         backend.open_url("https://example.com", False, None)  # type: ignore[misc]
+
+
+# ── Positional `use_daemon` stays valid ──────────────────────────────
+#
+# These guard against accidentally pulling ``use_daemon`` behind the ``*``
+# in the future. Pre-2.0.0 calls written as ``ls("/", True)`` must not
+# regress to ``TypeError``.
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_use_daemon_positional_on_ls(mock_call):
+    mock_call.return_value = {}
+    backend.ls("/", True)  # use_daemon=True positionally
+    assert mock_call.call_args == call("ls /", True, session=None)
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_use_daemon_positional_on_click(mock_call):
+    mock_call.return_value = {}
+    backend.click("submit_btn", True)
+    assert mock_call.call_args == call("click submit_btn", True, session=None)
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_use_daemon_positional_on_reload(mock_call):
+    mock_call.return_value = {}
+    backend.reload(True)
+    assert mock_call.call_args == call("refresh", True, session=None)
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_use_daemon_positional_on_type_text(mock_call):
+    mock_call.return_value = {}
+    backend.type_text("input", "hello", True)
+    assert mock_call.call_args == call(
+        "focus input\ntype hello", True, session=None
+    )

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -46,25 +46,32 @@ def test_translate_path_preserves_relative():
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_ls_absolute_path_wraps_with_cd_anchor_and_restore(mock_call):
-    """`ls /main` from a `/main` session: cd-anchor + bare ls + restore."""
+def test_ls_absolute_path_uses_three_separate_calls(mock_call):
+    """Split-and-check: anchor → bare ls → restore, three distinct calls.
+
+    Anchor success is load-bearing — if the cd fails, ls would run in
+    the wrong cwd. Tested separately by
+    test_ls_anchor_failure_short_circuits.
+    """
     mock_call.return_value = _make_result("[lane: 1]")
     sess = _make_session(working_dir="/main")
     backend.ls("/main", session=sess)
-    cmd = mock_call.call_args.args[0]
-    assert "cd %here%/main" in cmd
-    assert "\nls\n" in cmd
-    assert cmd.endswith("cd %here%/main")
+    assert mock_call.call_count == 3
+    assert mock_call.call_args_list[0].args[0] == "cd %here%/main"  # anchor
+    assert mock_call.call_args_list[1].args[0] == "ls"               # op
+    assert mock_call.call_args_list[2].args[0] == "cd %here%/main"  # restore
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_ls_root_from_drifted_cwd_anchors_at_here(mock_call):
-    """The Codex P1 case: `ls /` from a drifted `/main` cwd anchors at tab root."""
+    """The Codex P1 case: `ls /` from a drifted `/main` cwd."""
     mock_call.return_value = _make_result("[lane: 1]")
     sess = _make_session(working_dir="/main")
     backend.ls("/", session=sess)
-    cmd = mock_call.call_args.args[0]
-    assert cmd == "cd %here%\nls\ncd %here%/main"
+    assert mock_call.call_count == 3
+    assert mock_call.call_args_list[0].args[0] == "cd %here%"         # anchor at tab root
+    assert mock_call.call_args_list[1].args[0] == "ls"                # bare ls
+    assert mock_call.call_args_list[2].args[0] == "cd %here%/main"   # back to /main
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -84,8 +91,8 @@ def test_ls_absolute_path_with_spaces_quoted(mock_call):
     """
     mock_call.return_value = _make_result("[lane: 1]")
     backend.ls("/path with spaces", session=_make_session(working_dir="/"))
-    cmd = mock_call.call_args.args[0]
-    assert "cd '%here%/path with spaces'" in cmd
+    # Anchor (first call) is the quoted form.
+    assert mock_call.call_args_list[0].args[0] == "cd '%here%/path with spaces'"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -121,12 +128,15 @@ def test_cd_relative_quoted(mock_call):
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_cat_absolute_path_wraps(mock_call):
-    """`cat /main/btn`: anchor at tab root, run relative cat, restore."""
+def test_cat_absolute_path_uses_three_separate_calls(mock_call):
+    """`cat /main/btn`: anchor at tab root → cat main/btn → restore."""
     mock_call.return_value = _make_result("[lane: 1]")
     sess = _make_session(working_dir="/")
     backend.cat("/main/btn", session=sess)
-    assert mock_call.call_args.args[0] == "cd %here%\ncat main/btn\ncd %here%"
+    assert mock_call.call_count == 3
+    assert mock_call.call_args_list[0].args[0] == "cd %here%"
+    assert mock_call.call_args_list[1].args[0] == "cat main/btn"
+    assert mock_call.call_args_list[2].args[0] == "cd %here%"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -144,14 +154,14 @@ def test_cat_root_raises_value_error():
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_click_absolute_path_wraps(mock_call):
+def test_click_absolute_path_uses_three_separate_calls(mock_call):
     mock_call.return_value = _make_result("[lane: 1]")
     sess = _make_session(working_dir="/main")
     backend.click("/main/button[0]", session=sess)
-    assert (
-        mock_call.call_args.args[0]
-        == "cd %here%\nclick 'main/button[0]'\ncd %here%/main"
-    )
+    assert mock_call.call_count == 3
+    assert mock_call.call_args_list[0].args[0] == "cd %here%"
+    assert mock_call.call_args_list[1].args[0] == "click 'main/button[0]'"
+    assert mock_call.call_args_list[2].args[0] == "cd %here%/main"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -172,28 +182,193 @@ def test_click_root_raises_value_error():
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_grep_rooted_absolute_anchors_at_here(mock_call):
-    """Rooted grep with absolute path anchors at tab root + restores wd."""
+def test_grep_rooted_absolute_uses_three_separate_calls(mock_call):
+    """Rooted grep (absolute): anchor → grep → restore, three distinct calls."""
     mock_call.return_value = _make_result("[lane: 1]")
     backend.grep(
         "Login", path="/main", prev="/", session=_make_session(working_dir="/"),
     )
-    assert (
-        mock_call.call_args.args[0]
-        == "cd %here%/main\ngrep Login\ncd %here%"
-    )
+    assert mock_call.call_count == 3
+    assert mock_call.call_args_list[0].args[0] == "cd %here%/main"
+    assert mock_call.call_args_list[1].args[0] == "grep Login"
+    assert mock_call.call_args_list[2].args[0] == "cd %here%"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_grep_rooted_absolute_restores_to_session_wd(mock_call):
-    """Restore line follows session.working_dir, not the `prev` kwarg, when
-    the path is absolute — the lane cwd needs to end up where the harness
-    thinks it is, regardless of what `prev` was originally."""
+    """Restore (third call) follows session.working_dir, not the `prev`
+    kwarg, when the path is absolute — the lane cwd needs to end up
+    where the harness thinks it is."""
     mock_call.return_value = _make_result("[lane: 1]")
     backend.grep(
         "Login", path="/main", prev="/", session=_make_session(working_dir="/main"),
     )
-    assert mock_call.call_args.args[0].endswith("cd %here%/main")
+    assert mock_call.call_args_list[2].args[0] == "cd %here%/main"
+
+
+# ── Anchor-failure short-circuit (the Codex P2 case per-wrapper) ─────
+#
+# If the anchor `cd` fails, the operation must NOT run — it would
+# resolve against the wrong cwd and produce wrong-target results. Each
+# wrapper that uses split-and-check mirrors `type_text`'s
+# anchor-failure pattern.
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_ls_anchor_failure_short_circuits(mock_call):
+    """ls absolute-path anchor failure → only the anchor call ran."""
+    mock_call.return_value = _make_result(
+        "\x1b[31mError: chrome:// not debuggable\x1b[0m"
+    )
+    sess = _make_session(working_dir="/")
+    result = backend.ls("/main", session=sess)
+    assert mock_call.call_count == 1
+    assert mock_call.call_args_list[0].args[0] == "cd %here%/main"
+    assert "error" in result
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cat_anchor_failure_short_circuits(mock_call):
+    mock_call.return_value = _make_result(
+        "\x1b[31mError: no such path\x1b[0m"
+    )
+    sess = _make_session(working_dir="/")
+    result = backend.cat("/main/btn", session=sess)
+    assert mock_call.call_count == 1
+    assert mock_call.call_args_list[0].args[0] == "cd %here%"
+    assert "error" in result
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_click_anchor_failure_short_circuits(mock_call):
+    """Critical for click: a misdirected click could trigger an
+    unintended action. Anchor must halt before the click runs.
+    """
+    mock_call.return_value = _make_result(
+        "\x1b[31mError: chrome:// not debuggable\x1b[0m"
+    )
+    sess = _make_session(working_dir="/")
+    result = backend.click("/main/button[0]", session=sess)
+    assert mock_call.call_count == 1
+    assert mock_call.call_args_list[0].args[0] == "cd %here%"
+    assert "error" in result
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_rooted_anchor_failure_short_circuits(mock_call):
+    """Rooted grep with anchor failure → grep doesn't run (wrong-scope
+    matches would be misleading). Restore also skipped because we
+    never moved off the original cwd.
+    """
+    mock_call.return_value = _make_result(
+        "\x1b[31mError: no such path /missing\x1b[0m"
+    )
+    sess = _make_session(working_dir="/")
+    result = backend.grep("Login", path="/missing", prev="/", session=sess)
+    assert mock_call.call_count == 1
+    assert mock_call.call_args_list[0].args[0] == "cd %here%/missing"
+    assert "error" in result
+
+
+# ── _parse_execute_result: dict shapes per command ───────────────────
+#
+# DOMShell 2.x returns text content; the CLI was written for the
+# pre-2.0 per-command tools that returned dicts. These tests lock in
+# the translator's per-command shape contract so the CLI doesn't break
+# on `result.get(...)` calls.
+
+
+def test_parse_execute_result_ls_extracts_entries():
+    result = _make_result("button[0]\nlink[1]\nimg[2]\n[lane: 7]")
+    parsed = backend._parse_execute_result(result, "ls")
+    assert parsed["entries"] == [
+        {"name": "button[0]", "role": "", "path": "button[0]"},
+        {"name": "link[1]", "role": "", "path": "link[1]"},
+        {"name": "img[2]", "role": "", "path": "img[2]"},
+    ]
+    # Lane marker is stripped from the raw text.
+    assert "[lane:" not in parsed["raw"]
+
+
+def test_parse_execute_result_ls_empty_text_returns_empty_entries():
+    parsed = backend._parse_execute_result(_make_result("[lane: 7]"), "ls")
+    assert parsed == {"entries": [], "raw": ""}
+
+
+def test_parse_execute_result_grep_extracts_matches():
+    result = _make_result(
+        "/main/button[0]\n/main/link[1]\n[lane: 7]"
+    )
+    parsed = backend._parse_execute_result(result, "grep")
+    assert parsed["matches"] == ["/main/button[0]", "/main/link[1]"]
+    assert "[lane:" not in parsed["raw"]
+
+
+def test_parse_execute_result_error_returns_error_dict():
+    """Errors get `error` AND `output` keys — the CLI checks `"error" in
+    result` for cd-style guards but also pretty-prints `output`."""
+    result = _make_result(
+        "\x1b[31mError: no such element\x1b[0m\n[lane: 7]"
+    )
+    parsed = backend._parse_execute_result(result, "ls")
+    assert "error" in parsed
+    assert parsed["error"].startswith("\x1b[31mError")
+    assert parsed["output"] == parsed["error"]
+
+
+def test_parse_execute_result_default_for_other_commands():
+    """cat/click/focus/type/open/refresh/back/forward all fall through
+    to the generic ``{"output": text}`` shape."""
+    for cmd in ("cat", "click", "focus", "type", "open", "refresh", "back", "forward"):
+        parsed = backend._parse_execute_result(
+            _make_result("done\n[lane: 1]"), cmd,
+        )
+        assert parsed == {"output": "done"}
+
+
+# ── End-to-end: wrappers return parsed dicts (not CallToolResult) ────
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_ls_returns_entries_dict(mock_call):
+    """`backend.ls(...)` must return ``{"entries": [...]}`` so the CLI
+    doesn't AttributeError on `result.get("entries", [])`. This is the
+    Codex P1 shipped regression."""
+    mock_call.return_value = _make_result("button[0]\n[lane: 1]")
+    result = backend.ls("main")
+    assert "entries" in result
+    assert isinstance(result["entries"], list)
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_returns_matches_dict(mock_call):
+    mock_call.return_value = _make_result("/main/btn[0]\n[lane: 1]")
+    result = backend.grep("Login")
+    assert "matches" in result
+    assert result["matches"] == ["/main/btn[0]"]
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cd_returns_dict_with_output(mock_call):
+    """`backend.cd(...)` returns a dict so `isinstance(result, dict)`
+    in fs.change_directory works and `result.get("path", path)` falls
+    back cleanly."""
+    mock_call.return_value = _make_result("✓ Entered main\n[lane: 1]")
+    result = backend.cd("/main")
+    assert isinstance(result, dict)
+    assert "error" not in result
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cd_error_returns_error_dict(mock_call):
+    """`fs.change_directory` checks `"error" not in result` — make sure
+    error paths surface the error key so the harness's working-dir
+    update is correctly skipped."""
+    mock_call.return_value = _make_result(
+        "\x1b[31mError: no such path\x1b[0m"
+    )
+    result = backend.cd("/missing")
+    assert "error" in result
 
 
 # ── _is_error helper ─────────────────────────────────────────────────
@@ -253,40 +428,24 @@ def test_grep_unrooted_produces_single_grep_call(mock_call):
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_grep_rooted_emits_single_multiline_call(mock_call):
-    """Rooted grep is ONE multi-line ``cd / grep / cd back`` execute call.
+def test_grep_rooted_emits_three_call_sequence(mock_call):
+    """Rooted grep is THREE separate ``_call_execute`` calls: anchor →
+    grep → restore. Anchor success is load-bearing (would search the
+    wrong subtree on cwd drift), so we can't fold this into a single
+    multi-line continue-on-error call.
 
-    Each ``_call_execute`` in non-daemon mode opens a fresh MCP session
-    that lands in its own DOMShell 2.x lane, so splitting cd / grep /
-    restore across separate calls would lose the cwd between them. The
-    three lines must travel in one ``domshell_execute`` call to share
-    a lane.
+    Lane sharing across the three calls is preserved via
+    ``session.domshell_lane_id`` — see round-4 lane-persistence tests.
     """
-    mock_call.return_value = {}
+    mock_call.return_value = _make_result("[lane: 1]")
 
     backend.grep("Login", path="/main", prev="/")
 
-    # Absolute path anchors at %here%/main; restore comes from
-    # _restore_cwd_cmd(session=None) → `cd %here%` (defaults to harness `/`).
     assert mock_call.call_args_list == [
-        call("cd %here%/main\ngrep Login\ncd %here%", False, session=None),
+        call("cd %here%/main", False, session=None),
+        call("grep Login", False, session=None),
+        call("cd %here%", False, session=None),
     ]
-
-
-@patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_grep_rooted_uses_single_call_for_lane_isolation(mock_call):
-    """Documents the lane-isolation contract: ONE call, not three.
-
-    The trailing ``cd prev`` is delivered as the final line of the same
-    multi-line command and runs even if ``grep`` errors, per DOMShell's
-    documented continue-on-error semantics
-    (`apireno/DOMShell#46 <https://github.com/apireno/DOMShell/issues/46>`_).
-    """
-    mock_call.return_value = {}
-
-    backend.grep("Login", path="/main", prev="/")
-
-    assert mock_call.call_count == 1
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -295,14 +454,16 @@ def test_grep_rooted_quotes_path_with_spaces(mock_call):
 
     Upstream-smoked: DOMShell's `cd` accepts the quoted form cleanly.
     """
-    mock_call.return_value = {}
+    mock_call.return_value = _make_result("[lane: 1]")
 
     backend.grep("Login", path="/path with spaces", prev="/")
 
-    cmd = mock_call.call_args.args[0]
-    assert cmd.startswith("cd '%here%/path with spaces'\n")
-    assert "\ngrep Login\n" in cmd
-    assert cmd.endswith("\ncd %here%")
+    # Three-call sequence — quoting applies to the anchor (first call).
+    assert mock_call.call_args_list == [
+        call("cd '%here%/path with spaces'", False, session=None),
+        call("grep Login", False, session=None),
+        call("cd %here%", False, session=None),
+    ]
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -451,8 +612,11 @@ def test_type_text_relative_path_focus_failure_skips_type(mock_call):
     # Only the focus call was made; the focus result was returned.
     assert mock_call.call_count == 1
     assert mock_call.call_args_list[0].args[0] == "focus stale_input"
-    # The focus result is returned verbatim so callers see the error.
-    assert result.content[0].text == "Error: focus: No such element"
+    # The focus result is parsed (CLI consumes dicts, not CallToolResult).
+    assert result == {
+        "error": "Error: focus: No such element",
+        "output": "Error: focus: No such element",
+    }
 
 
 def test_type_text_raises_without_session_in_non_daemon_mode():
@@ -799,11 +963,13 @@ def test_session_is_keyword_only_on_open_url():
 def test_use_daemon_positional_on_ls(mock_call):
     mock_call.return_value = _make_result("[lane: 1]")
     backend.ls("/", True)  # use_daemon=True positionally
-    # Absolute `/` with no session → anchor at %here%, bare ls, restore
-    # to %here% (the default for session=None).
-    assert mock_call.call_args == call(
-        "cd %here%\nls\ncd %here%", True, session=None,
-    )
+    # Absolute `/` with no session → 3-call sequence, use_daemon=True
+    # flows through all three calls.
+    assert mock_call.call_args_list == [
+        call("cd %here%", True, session=None),
+        call("ls", True, session=None),
+        call("cd %here%", True, session=None),
+    ]
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -15,6 +15,126 @@ from cli_anything.browser.core.session import Session
 from cli_anything.browser.utils import domshell_backend as backend
 
 
+# ── Path translation: harness `/` vs DOMShell `~/` ───────────────────
+
+
+def test_translate_path_root_maps_to_empty():
+    """Harness `/` (focused-tab AX root) → DOMShell empty (lane cwd)."""
+    assert backend._translate_path("/") == ""
+    assert backend._translate_path("") == ""
+
+
+def test_translate_path_strips_leading_slash():
+    assert backend._translate_path("/main") == "main"
+    assert backend._translate_path("/main/article") == "main/article"
+
+
+def test_translate_path_preserves_relative():
+    """Relative paths pass through unchanged — DOMShell handles them."""
+    assert backend._translate_path("main") == "main"
+    assert backend._translate_path("..") == ".."
+    assert backend._translate_path(".") == "."
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_ls_root_sends_bare_ls(mock_call):
+    """`ls /` (harness) → bare `ls` (DOMShell), operating on lane cwd."""
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.ls("/")
+    assert mock_call.call_args.args[0] == "ls"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_ls_subpath_strips_leading_slash(mock_call):
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.ls("/main")
+    assert mock_call.call_args.args[0] == "ls main"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cd_root_uses_here(mock_call):
+    """`cd /` (harness) → `cd %here%` (DOMShell jump-to-tab-root)."""
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.cd("/")
+    assert mock_call.call_args.args[0] == "cd %here%"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cd_subpath_strips_leading_slash(mock_call):
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.cd("/main/div[0]")
+    assert mock_call.call_args.args[0] == "cd 'main/div[0]'"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cat_strips_leading_slash(mock_call):
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.cat("/main/button[0]")
+    assert mock_call.call_args.args[0] == "cat 'main/button[0]'"
+
+
+def test_cat_root_raises_value_error():
+    """Calling cat against the tab root is a programming error — fail clearly."""
+    with pytest.raises(ValueError, match="element name is required"):
+        backend.cat("/")
+    with pytest.raises(ValueError, match="element name is required"):
+        backend.cat("")
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_click_strips_leading_slash(mock_call):
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.click("/main/button[0]")
+    assert mock_call.call_args.args[0] == "click 'main/button[0]'"
+
+
+def test_click_root_raises_value_error():
+    with pytest.raises(ValueError, match="element name is required"):
+        backend.click("/")
+    with pytest.raises(ValueError, match="element name is required"):
+        backend.click("")
+
+
+def test_type_text_root_raises_value_error():
+    """Focusing the tab root is a programming error — same class as cat/click."""
+    with pytest.raises(ValueError, match="element name is required"):
+        backend.type_text("/", "hello")
+    with pytest.raises(ValueError, match="element name is required"):
+        backend.type_text("", "hello")
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_rooted_with_subpath_prev_keeps_translated_restore(mock_call):
+    """A non-`/` prev should also be translated, not sent verbatim."""
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.grep("Login", path="/main/dialog", prev="/main")
+    assert mock_call.call_args.args[0] == "cd main/dialog\ngrep Login\ncd main"
+
+
+# ── _is_error helper ─────────────────────────────────────────────────
+
+
+def test_is_error_detects_isError_attribute():
+    assert backend._is_error(SimpleNamespace(isError=True)) is True
+    assert backend._is_error(SimpleNamespace(isError=False)) is False
+
+
+def test_is_error_detects_dict_keys():
+    assert backend._is_error({"isError": True}) is True
+    assert backend._is_error({"error": "boom"}) is True
+    assert backend._is_error({"path": "/main"}) is False
+
+
+def test_is_error_detects_error_prefixed_text():
+    assert backend._is_error(_make_result("Error: no such element")) is True
+    assert backend._is_error(_make_result("ERROR: case insensitive")) is True
+    assert backend._is_error(_make_result("✓ Focused\n[lane: 1]")) is False
+
+
+def test_is_error_handles_missing_content():
+    assert backend._is_error(SimpleNamespace()) is False
+
+
 # ── grep: command string and call sequencing ──────────────────────────
 
 
@@ -43,8 +163,10 @@ def test_grep_rooted_emits_single_multiline_call(mock_call):
 
     backend.grep("Login", path="/main", prev="/")
 
+    # Harness `/main` translates to DOMShell `main`; harness `/` (the
+    # default prev) translates to `cd %here%`.
     assert mock_call.call_args_list == [
-        call("cd /main\ngrep Login\ncd /", False, session=None),
+        call("cd main\ngrep Login\ncd %here%", False, session=None),
     ]
 
 
@@ -72,11 +194,12 @@ def test_grep_rooted_quotes_path_with_spaces(mock_call):
     backend.grep("Login", path="/path with spaces", prev="/")
 
     cmd = mock_call.call_args.args[0]
-    # shlex.quote single-quotes anything containing whitespace; the rest
-    # of the multi-line layout (grep + cd back) stays intact.
-    assert cmd.startswith("cd '/path with spaces'\n")
+    # _translate_path strips the leading "/", then shlex.quote single-
+    # quotes the remainder; the multi-line layout (grep + cd back) stays
+    # intact, with the restore using `cd %here%` for the harness-`/` prev.
+    assert cmd.startswith("cd 'path with spaces'\n")
     assert "\ngrep Login\n" in cmd
-    assert cmd.endswith("\ncd /")
+    assert cmd.endswith("\ncd %here%")
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -119,15 +242,38 @@ def test_grep_keyword_use_daemon_still_works():
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_type_text_emits_focus_then_type_in_one_call(mock_call):
-    """type_text builds a single multi-line ``focus … \\ntype …`` execute call."""
-    mock_call.return_value = {}
+def test_type_text_uses_two_separate_calls(mock_call):
+    """type_text issues focus + type as two separate execute calls.
+
+    The split is for safety: DOMShell's multi-line splitter continues
+    past per-line errors, so a single ``focus path\\ntype text`` call
+    would dispatch keys into stale focus if ``focus`` failed. Two calls
+    with an error check between them prevents that.
+    """
+    mock_call.return_value = _make_result("✓ Focused\n[lane: 1]")
 
     backend.type_text("search_input", "machine learning")
 
-    assert mock_call.call_args_list == [
-        call("focus search_input\ntype 'machine learning'", False, session=None),
+    assert mock_call.call_count == 2
+    assert mock_call.call_args_list[0].args[0] == "focus search_input"
+    assert mock_call.call_args_list[1].args[0] == "type 'machine learning'"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_type_text_skips_type_on_focus_error(mock_call):
+    """If focus errors, type MUST NOT run — would land in stale focus."""
+    mock_call.side_effect = [
+        _make_result("Error: focus: No such element"),
+        _make_result("✓ Typed"),  # should NOT be reached
     ]
+
+    result = backend.type_text("/stale/path", "secret_password")
+
+    # Only the focus call was made; the focus result was returned.
+    assert mock_call.call_count == 1
+    assert mock_call.call_args_list[0].args[0] == "focus stale/path"
+    # The focus result is returned verbatim so callers see the error.
+    assert result.content[0].text == "Error: focus: No such element"
 
 
 def test_type_text_rejects_newline_in_text():
@@ -428,7 +574,8 @@ def test_session_is_keyword_only_on_open_url():
 def test_use_daemon_positional_on_ls(mock_call):
     mock_call.return_value = {}
     backend.ls("/", True)  # use_daemon=True positionally
-    assert mock_call.call_args == call("ls /", True, session=None)
+    # Harness `/` translates to "" so ls sends the bare command.
+    assert mock_call.call_args == call("ls", True, session=None)
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -447,8 +594,11 @@ def test_use_daemon_positional_on_reload(mock_call):
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_use_daemon_positional_on_type_text(mock_call):
-    mock_call.return_value = {}
+    """Positional ``use_daemon`` flows through both halves of the split."""
+    mock_call.return_value = _make_result("✓\n[lane: 1]")
     backend.type_text("input", "hello", True)
-    assert mock_call.call_args == call(
-        "focus input\ntype hello", True, session=None
-    )
+    # Two calls (focus then type), both with use_daemon=True positionally.
+    assert mock_call.call_args_list == [
+        call("focus input", True, session=None),
+        call("type hello", True, session=None),
+    ]

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -275,6 +275,96 @@ def test_grep_rooted_anchor_failure_short_circuits(mock_call):
     assert "error" in result
 
 
+# ── Absolute split-and-check requires session in non-daemon mode ─────
+#
+# Without a session (and without daemon mode), each `_call_execute` lands
+# in a fresh DOMShell lane — the anchor cd's cwd doesn't carry over to
+# the operation, producing wrong-scope output. Raise up front to surface
+# the misuse instead of silently producing wrong results. (Mirrors
+# `type_text`'s round-6.1 guard; propagated to ls/cat/click/grep in
+# round 7.2 per Codex P2 #2.)
+
+
+def test_ls_absolute_without_session_raises_in_non_daemon():
+    with pytest.raises(ValueError, match="session"):
+        backend.ls("/main", session=None)
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_ls_absolute_with_daemon_no_session_works(mock_call):
+    """Daemon mode shares lane via the persistent connection — no
+    session required."""
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.ls("/main", use_daemon=True, session=None)
+    # 3-call split-and-check still happens.
+    assert mock_call.call_count == 3
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_ls_relative_without_session_works(mock_call):
+    """Relative path runs as a single call — no anchor, no lane drift
+    risk, so session=None is fine in non-daemon mode."""
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.ls("main", session=None)
+    assert mock_call.call_count == 1
+
+
+def test_cat_absolute_without_session_raises_in_non_daemon():
+    with pytest.raises(ValueError, match="session"):
+        backend.cat("/main/btn", session=None)
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cat_relative_without_session_works(mock_call):
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.cat("main/btn", session=None)
+    assert mock_call.call_count == 1
+
+
+def test_click_absolute_without_session_raises_in_non_daemon():
+    with pytest.raises(ValueError, match="session"):
+        backend.click("/main/button[0]", session=None)
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_click_relative_without_session_works(mock_call):
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.click("button[0]", session=None)
+    assert mock_call.call_count == 1
+
+
+def test_grep_rooted_absolute_without_session_raises_in_non_daemon():
+    """Rooted grep with absolute path requires session for lane consistency."""
+    with pytest.raises(ValueError, match="session"):
+        backend.grep("Login", path="/main", prev="/", session=None)
+
+
+def test_grep_rooted_relative_without_session_raises_in_non_daemon():
+    """Rooted grep with RELATIVE path also requires session — both
+    branches issue 3 separate calls and depend on shared lane state.
+    """
+    with pytest.raises(ValueError, match="session"):
+        backend.grep("Login", path="dialog", prev="/main", session=None)
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_rooted_relative_with_daemon_no_session_works(mock_call):
+    """Daemon mode shares lane via the persistent connection — no
+    session required even for relative-rooted grep."""
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.grep("Login", path="dialog", prev="/main", use_daemon=True, session=None)
+    # 3-call split-and-check still happens.
+    assert mock_call.call_count == 3
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_unrooted_without_session_works(mock_call):
+    """Unrooted grep is a single call — no session required."""
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.grep("Login", session=None)
+    assert mock_call.call_count == 1
+
+
 # ── _parse_execute_result: dict shapes per command ───────────────────
 #
 # DOMShell 2.x returns text content; the CLI was written for the
@@ -325,14 +415,85 @@ def test_parse_execute_result_error_returns_error_dict():
     assert parsed["output"] == parsed["error"]
 
 
-def test_parse_execute_result_default_for_other_commands():
-    """cat/click/focus/type/open/refresh/back/forward all fall through
-    to the generic ``{"output": text}`` shape."""
-    for cmd in ("cat", "click", "focus", "type", "open", "refresh", "back", "forward"):
+def test_parse_execute_result_default_for_non_nav_commands():
+    """cat/click/focus/type/refresh fall through to the generic
+    ``{"output": text}`` shape (nav commands get their own branch —
+    see test_parse_execute_result_nav_*)."""
+    for cmd in ("cat", "click", "focus", "type", "refresh"):
         parsed = backend._parse_execute_result(
             _make_result("done\n[lane: 1]"), cmd,
         )
         assert parsed == {"output": "done"}
+
+
+# ── Nav commands (back/forward/navigate/open): URL/title extraction ──
+
+
+def test_parse_execute_result_nav_extracts_url_and_title():
+    """back/forward/navigate/open extract `url` and `title` so
+    page.go_back/go_forward's `"url" in result` guards fire and
+    session.set_url updates correctly. (Codex P2 #1.)
+    """
+    fixture = _make_result(
+        "✓ Navigated back\n"
+        "URL: https://example.com/page\n"
+        "Title: Example Page\n"
+        "[lane: 7]"
+    )
+    for cmd in ("back", "forward", "navigate", "open"):
+        parsed = backend._parse_execute_result(fixture, cmd)
+        assert parsed["url"] == "https://example.com/page"
+        assert parsed["title"] == "Example Page"
+        # The raw output is preserved alongside.
+        assert "✓ Navigated back" in parsed["output"]
+
+
+def test_parse_execute_result_nav_omits_url_when_missing():
+    """Malformed/early response without URL line → `output` only, no crash."""
+    parsed = backend._parse_execute_result(_make_result("✓ done\n[lane: 1]"), "back")
+    assert parsed == {"output": "✓ done"}
+    assert "url" not in parsed
+    assert "title" not in parsed
+
+
+def test_parse_execute_result_nav_extracts_url_without_title():
+    """A response with URL but no Title line still extracts the URL."""
+    parsed = backend._parse_execute_result(
+        _make_result("URL: https://example.com/x\n[lane: 1]"), "open",
+    )
+    assert parsed["url"] == "https://example.com/x"
+    assert "title" not in parsed
+
+
+def test_parse_execute_result_nav_title_handles_trailing_whitespace():
+    """Title regex strips trailing newline/whitespace."""
+    parsed = backend._parse_execute_result(
+        _make_result(
+            "URL: https://example.com\n"
+            "Title: Spaced Title   \n"
+            "[lane: 1]"
+        ),
+        "open",
+    )
+    assert parsed["title"] == "Spaced Title"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_back_returns_dict_with_url_key(mock_call):
+    """End-to-end: backend.back() returns a dict with `url` so
+    page.go_back's guard fires. (The Codex P2 #1 regression case.)
+    """
+    sess = _make_session(working_dir="/")
+    mock_call.return_value = _make_result(
+        "✓ Navigated back\n"
+        "URL: https://previous.com\n"
+        "Title: Previous\n"
+        "[lane: 1]"
+    )
+    result = backend.back(session=sess)
+    assert "url" in result
+    assert result["url"] == "https://previous.com"
+    assert result["title"] == "Previous"
 
 
 # ── End-to-end: wrappers return parsed dicts (not CallToolResult) ────
@@ -473,13 +634,14 @@ def test_grep_rooted_emits_three_call_sequence(mock_call):
     ``session.domshell_lane_id`` — see round-4 lane-persistence tests.
     """
     mock_call.return_value = _make_result("[lane: 1]")
+    sess = _make_session(working_dir="/")
 
-    backend.grep("Login", path="/main", prev="/")
+    backend.grep("Login", path="/main", prev="/", session=sess)
 
     assert mock_call.call_args_list == [
-        call("cd %here%/main", False, session=None),
-        call("grep Login", False, session=None),
-        call("cd %here%", False, session=None),
+        call("cd %here%/main", False, session=sess),
+        call("grep Login", False, session=sess),
+        call("cd %here%", False, session=sess),
     ]
 
 
@@ -490,14 +652,15 @@ def test_grep_rooted_quotes_path_with_spaces(mock_call):
     Upstream-smoked: DOMShell's `cd` accepts the quoted form cleanly.
     """
     mock_call.return_value = _make_result("[lane: 1]")
+    sess = _make_session(working_dir="/")
 
-    backend.grep("Login", path="/path with spaces", prev="/")
+    backend.grep("Login", path="/path with spaces", prev="/", session=sess)
 
     # Three-call sequence — quoting applies to the anchor (first call).
     assert mock_call.call_args_list == [
-        call("cd '%here%/path with spaces'", False, session=None),
-        call("grep Login", False, session=None),
-        call("cd %here%", False, session=None),
+        call("cd '%here%/path with spaces'", False, session=sess),
+        call("grep Login", False, session=sess),
+        call("cd %here%", False, session=sess),
     ]
 
 

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -190,7 +190,7 @@ def test_grep_rooted_absolute_uses_three_separate_calls(mock_call):
     )
     assert mock_call.call_count == 3
     assert mock_call.call_args_list[0].args[0] == "cd %here%/main"
-    assert mock_call.call_args_list[1].args[0] == "grep Login"
+    assert mock_call.call_args_list[1].args[0] == "grep -r Login"
     assert mock_call.call_args_list[2].args[0] == "cd %here%"
 
 
@@ -614,13 +614,35 @@ def test_is_error_handles_missing_content():
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_grep_unrooted_produces_single_grep_call(mock_call):
-    """Unrooted grep dispatches one ``grep <pattern>`` call."""
+    """Unrooted grep dispatches one ``grep -r <pattern>`` call."""
     mock_call.return_value = {}
 
     backend.grep("Login")
 
     # session=None when no session is passed (default).
-    assert mock_call.call_args_list == [call("grep Login", False, session=None)]
+    assert mock_call.call_args_list == [call("grep -r Login", False, session=None)]
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_unrooted_uses_recursive_flag(mock_call):
+    """Regression: pre-migration ``domshell_grep`` defaulted to
+    recursive=True; the unrooted branch must preserve that by passing
+    ``-r`` so nested matches aren't silently missed.
+    """
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.grep("Login")
+    assert mock_call.call_args.args[0] == "grep -r Login"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_grep_rooted_uses_recursive_flag(mock_call):
+    """Regression: the rooted branch's middle call (the grep itself)
+    must also pass ``-r``. The 3-call sequence is cd / grep -r / cd-back.
+    """
+    mock_call.return_value = _make_result("[lane: 1]")
+    backend.grep("Login", path="main", session=_make_session())
+    # grep is the middle of the 3-call sequence.
+    assert mock_call.call_args_list[1].args[0] == "grep -r Login"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -640,7 +662,7 @@ def test_grep_rooted_emits_three_call_sequence(mock_call):
 
     assert mock_call.call_args_list == [
         call("cd %here%/main", False, session=sess),
-        call("grep Login", False, session=sess),
+        call("grep -r Login", False, session=sess),
         call("cd %here%", False, session=sess),
     ]
 
@@ -659,7 +681,7 @@ def test_grep_rooted_quotes_path_with_spaces(mock_call):
     # Three-call sequence — quoting applies to the anchor (first call).
     assert mock_call.call_args_list == [
         call("cd '%here%/path with spaces'", False, session=sess),
-        call("grep Login", False, session=sess),
+        call("grep -r Login", False, session=sess),
         call("cd %here%", False, session=sess),
     ]
 
@@ -673,7 +695,7 @@ def test_grep_pattern_with_shell_metacharacters_quoted(mock_call):
 
     grep_cmd = mock_call.call_args_list[0].args[0]
     # shlex.quote will single-quote the dangerous payload.
-    assert grep_cmd == "grep '$(rm -rf /)'"
+    assert grep_cmd == "grep -r '$(rm -rf /)'"
 
 
 def test_grep_rejects_positional_path():
@@ -697,7 +719,7 @@ def test_grep_keyword_use_daemon_still_works():
     with patch.object(backend, "_call_execute", new_callable=AsyncMock) as mock_call:
         mock_call.return_value = {}
         backend.grep("Login", use_daemon=True)
-        assert mock_call.call_args_list == [call("grep Login", True, session=None)]
+        assert mock_call.call_args_list == [call("grep -r Login", True, session=None)]
 
 
 # ── type_text: focus+type pairing and newline injection guard ─────────

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -146,11 +146,32 @@ def test_cat_relative_no_wrap(mock_call):
     assert mock_call.call_args.args[0] == "cat main/btn"
 
 
-def test_cat_root_raises_value_error():
-    with pytest.raises(ValueError, match="element name is required"):
-        backend.cat("/")
-    with pytest.raises(ValueError, match="element name is required"):
-        backend.cat("")
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cat_root_path_does_not_raise_and_returns_parseable_result(mock_call):
+    """backend.cat("/") and backend.cat("") at the absolute root should
+    NOT raise a Python ValueError. Pre-migration behavior was to send
+    ``cat ''`` to DOMShell and surface its ``Usage: cat <name>`` error
+    string; the round-5 Python-side guard converted the kernel error
+    into a ValueError, which broke ``fs.read_element(session, "")``
+    callers landed at ``/``. @yuh-yang R3 blocker 1 required restoring
+    pre-migration behavior — guard removed, both inputs now reach
+    DOMShell, which has the same ``if (!targetName)`` check and
+    returns its standard Usage error.
+    """
+    mock_call.return_value = _make_result(
+        "\x1b[31mUsage: cat <name> (see cat --help)\x1b[0m\n[lane: shared]"
+    )
+    sess = _make_session(working_dir="/")  # satisfies absolute branch's session check
+
+    # MUST NOT raise — that was the regression.
+    result_root = backend.cat("/", session=sess)
+    result_empty = backend.cat("")
+
+    # Both surface DOMShell's error as a parsed dict, not a Python exception.
+    for r in (result_root, result_empty):
+        assert isinstance(r, dict)
+        # _parse_execute_result detects ANSI red → routes through error path.
+        assert "error" in r
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -903,6 +924,20 @@ def test_grep_rejects_newline_in_pattern():
         backend.grep("Login\nclick /admin", path="/main", prev="/")
 
 
+def test_grep_rejects_hyphen_prefixed_pattern():
+    """DOMShell's parseArgs treats any arg starting with "-" as a flag,
+    so the grep wrapper can't pass hyphen-prefixed search strings as
+    patterns. The wrapper raises ValueError with a clear message so
+    users see the limitation immediately rather than getting DOMShell's
+    generic Usage reply. Real fix needs upstream parseArgs ``--``
+    support; tracked upstream. (@yuh-yang R3 blocker 3, Path B.)
+    """
+    with pytest.raises(ValueError, match="patterns starting with '-'"):
+        backend.grep("-disabled")
+    with pytest.raises(ValueError, match="patterns starting with '-'"):
+        backend.grep("--content")
+
+
 def test_grep_rejects_newline_in_prev():
     with pytest.raises(ValueError, match="newline"):
         backend.grep("Login", path="/main", prev="/\nclick /admin")
@@ -1150,34 +1185,67 @@ def test_call_execute_passes_group_id_new_when_lane_is_none():
     assert sess.domshell_lane_id == "brand-new"
 
 
-def test_call_execute_passes_group_id_shared_for_daemon_mode_without_session():
-    """Daemon mode + no session: route to the default per-connection lane
-    via ``group_id="shared"``. The daemon's persistent stdio connection
-    keeps that lane sticky across calls, so direct callers like
-    ``open_url(use_daemon=True)`` followed by ``ls(use_daemon=True)``
-    share browser state without needing a Session object to carry a
-    lane id.
+def test_call_execute_daemon_no_session_first_call_passes_new_and_captures_lane():
+    """Daemon mode + no session, first call: passes ``group_id="new"``
+    and captures the lane id from the response into the module-level
+    ``_daemon_lane_id`` for subsequent calls. Replaces the previous
+    ``"shared"`` behavior (commit 99d1182) per @yuh-yang R3 blocker 2.
 
-    Migration note (PR #308 follow-up): the initial 2.0.2 migration
-    commit (be62f843b5) passed ``group_id="new"`` in this case, which
-    broke the daemon workflow by creating a fresh isolated lane per
-    call. Caught by Codex P2. Fix re-routes daemon-no-session calls to
-    ``"shared"``.
+    The R2 "shared" branch claimed per-connection-default stickiness
+    that holds when the persistent daemon connection is alive but
+    breaks in the fall-back spawn path (each call gets its own
+    per-MCP-session default lane). The captured-id approach works
+    consistently across both paths because Chrome tab-group ids
+    persist at the browser level, regardless of MCP session.
     """
-    fake_tool = AsyncMock(return_value=_make_result("✓\n[lane: daemon-default]"))
+    # Reset module state (other tests may have populated it).
+    backend._daemon_lane_id = None
 
-    fake_mcp_session = AsyncMock()
-    fake_mcp_session.call_tool = fake_tool
+    try:
+        fake_tool = AsyncMock(
+            return_value=_make_result("✓\n[lane: daemon-captured-99]")
+        )
+        fake_mcp_session = AsyncMock()
+        fake_mcp_session.call_tool = fake_tool
 
-    # Simulate a live daemon session — the same path open_url / ls take
-    # when called with use_daemon=True but no Session.
-    with patch.object(backend, "_daemon_session", fake_mcp_session):
-        import asyncio as _aio
-        _aio.run(backend._call_execute("ls /", use_daemon=True, session=None))
+        with patch.object(backend, "_daemon_session", fake_mcp_session):
+            import asyncio as _aio
+            _aio.run(backend._call_execute("ls /", use_daemon=True, session=None))
 
-    name, arguments = fake_tool.call_args.args
-    assert name == "domshell_execute"
-    assert arguments.get("group_id") == "shared"
+        name, arguments = fake_tool.call_args.args
+        assert name == "domshell_execute"
+        assert arguments.get("group_id") == "new"
+        assert backend._daemon_lane_id == "daemon-captured-99"
+    finally:
+        backend._daemon_lane_id = None
+
+
+def test_call_execute_daemon_no_session_subsequent_calls_reuse_captured_lane():
+    """Once ``_daemon_lane_id`` is set, daemon-no-session calls pass
+    that id as ``group_id`` instead of ``"new"`` — preserves browser
+    state across calls regardless of whether the daemon's stdio is
+    alive or whether we've fallen back to fresh spawns per call.
+    Capture stays stable; no clobber on subsequent calls.
+    """
+    backend._daemon_lane_id = "preexisting-77"
+
+    try:
+        fake_tool = AsyncMock(
+            return_value=_make_result("✓\n[lane: preexisting-77]")
+        )
+        fake_mcp_session = AsyncMock()
+        fake_mcp_session.call_tool = fake_tool
+
+        with patch.object(backend, "_daemon_session", fake_mcp_session):
+            import asyncio as _aio
+            _aio.run(backend._call_execute("ls /", use_daemon=True, session=None))
+
+        name, arguments = fake_tool.call_args.args
+        assert arguments.get("group_id") == "preexisting-77"
+        # Capture stays the same — no clobber on subsequent calls.
+        assert backend._daemon_lane_id == "preexisting-77"
+    finally:
+        backend._daemon_lane_id = None
 
 
 def test_distinct_sessions_have_isolated_lanes():

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -216,9 +216,14 @@ def test_grep_rooted_absolute_restores_to_session_wd(mock_call):
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_ls_anchor_failure_short_circuits(mock_call):
-    """ls absolute-path anchor failure → only the anchor call ran."""
+    """ls absolute-path anchor failure → only the anchor call ran.
+
+    Uses DOMShell's actual error shape: ANSI-red-wrapped, command-
+    prefixed ("cd: ...") — not the imaginary "Error: ..." prefix that
+    silently bypassed ``_is_error`` for several rounds.
+    """
     mock_call.return_value = _make_result(
-        "\x1b[31mError: chrome:// not debuggable\x1b[0m"
+        "\x1b[31mcd: tab 12345 is outside the session group\x1b[0m"
     )
     sess = _make_session(working_dir="/")
     result = backend.ls("/main", session=sess)
@@ -230,7 +235,7 @@ def test_ls_anchor_failure_short_circuits(mock_call):
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_cat_anchor_failure_short_circuits(mock_call):
     mock_call.return_value = _make_result(
-        "\x1b[31mError: no such path\x1b[0m"
+        "\x1b[31mcd: chrome:// not debuggable\x1b[0m"
     )
     sess = _make_session(working_dir="/")
     result = backend.cat("/main/btn", session=sess)
@@ -245,7 +250,7 @@ def test_click_anchor_failure_short_circuits(mock_call):
     unintended action. Anchor must halt before the click runs.
     """
     mock_call.return_value = _make_result(
-        "\x1b[31mError: chrome:// not debuggable\x1b[0m"
+        "\x1b[31mcd: chrome:// not debuggable\x1b[0m"
     )
     sess = _make_session(working_dir="/")
     result = backend.click("/main/button[0]", session=sess)
@@ -261,7 +266,7 @@ def test_grep_rooted_anchor_failure_short_circuits(mock_call):
     never moved off the original cwd.
     """
     mock_call.return_value = _make_result(
-        "\x1b[31mError: no such path /missing\x1b[0m"
+        "\x1b[31mcd: /missing: No such directory\x1b[0m"
     )
     sess = _make_session(working_dir="/")
     result = backend.grep("Login", path="/missing", prev="/", session=sess)
@@ -306,13 +311,17 @@ def test_parse_execute_result_grep_extracts_matches():
 
 def test_parse_execute_result_error_returns_error_dict():
     """Errors get `error` AND `output` keys — the CLI checks `"error" in
-    result` for cd-style guards but also pretty-prints `output`."""
+    result` for cd-style guards but also pretty-prints `output`.
+
+    Uses the actual DOMShell error shape: ANSI-red-wrapped, command-
+    prefixed (``ls: ...``).
+    """
     result = _make_result(
-        "\x1b[31mError: no such element\x1b[0m\n[lane: 7]"
+        "\x1b[31mls: main: No such directory\x1b[0m\n[lane: 7]"
     )
     parsed = backend._parse_execute_result(result, "ls")
     assert "error" in parsed
-    assert parsed["error"].startswith("\x1b[31mError")
+    assert parsed["error"].startswith("\x1b[31mls:")
     assert parsed["output"] == parsed["error"]
 
 
@@ -363,9 +372,10 @@ def test_cd_returns_dict_with_output(mock_call):
 def test_cd_error_returns_error_dict(mock_call):
     """`fs.change_directory` checks `"error" not in result` — make sure
     error paths surface the error key so the harness's working-dir
-    update is correctly skipped."""
+    update is correctly skipped. Uses the actual DOMShell error shape.
+    """
     mock_call.return_value = _make_result(
-        "\x1b[31mError: no such path\x1b[0m"
+        "\x1b[31mcd: /missing: No such directory\x1b[0m"
     )
     result = backend.cd("/missing")
     assert "error" in result
@@ -385,28 +395,53 @@ def test_is_error_detects_dict_keys():
     assert backend._is_error({"path": "/main"}) is False
 
 
-def test_is_error_detects_error_prefixed_text():
-    assert backend._is_error(_make_result("Error: no such element")) is True
-    assert backend._is_error(_make_result("ERROR: case insensitive")) is True
-    assert backend._is_error(_make_result("✓ Focused\n[lane: 1]")) is False
-
-
-def test_is_error_strips_ansi_red_wrapper():
-    """DOMShell colours errors red — strip ANSI before prefix-matching.
-
-    Without this, a coloured error like `\\x1b[31mError: ...\\x1b[0m`
-    would be misread as success (its first chars are `\\x1b[31m`, not
-    `error`), letting downstream safety chains proceed.
+def test_is_error_detects_ansi_red_wrapper():
+    """Common DOMShell error shape: ANSI red around a command-prefixed
+    message. These do NOT start with the literal "error" — the earlier
+    detection that ANSI-stripped first then ``startswith("error")``
+    failed every one of these, silently regressing the safety chain
+    across every wrapper. Catch on the ``\\x1b[31m`` red marker
+    instead.
     """
     assert backend._is_error(
-        _make_result("\x1b[31mError: focus: No such element\x1b[0m")
+        _make_result("\x1b[31mcd: foo: No such directory\x1b[0m")
     ) is True
-    # Plain `Error:` still detected.
-    assert backend._is_error(_make_result("Error: oops")) is True
-    # Mixed ANSI prefix without "Error" stays False.
     assert backend._is_error(
-        _make_result("\x1b[32m✓ All good\x1b[0m")
+        _make_result("\x1b[31mfocus: No such element\x1b[0m")
+    ) is True
+    assert backend._is_error(
+        _make_result("\x1b[31mls: main: No such directory\x1b[0m")
+    ) is True
+    assert backend._is_error(
+        _make_result("\x1b[31mcd: tab 12345 is outside the session group\x1b[0m")
+    ) is True
+
+
+def test_is_error_detects_explicit_error_prefix_without_ansi():
+    """Fallback: rarer non-coloured errors or pre-stripped input still
+    detected via ``"error:"`` prefix.
+    """
+    assert backend._is_error(_make_result("Error: bad command")) is True
+    assert backend._is_error(_make_result("ERROR: case insensitive")) is True
+
+
+def test_is_error_does_not_flag_success_in_other_colors():
+    """Anti-false-positive: only ``\\x1b[31m`` (red) signals an error.
+    Success commonly wraps in ``\\x1b[32m`` (green) — must not flag.
+    """
+    assert backend._is_error(
+        _make_result("\x1b[32m✓ ok\x1b[0m")
     ) is False
+    assert backend._is_error(
+        _make_result("✓ command completed")
+    ) is False
+    assert backend._is_error(
+        _make_result("✓ Focused\n[lane: 1]")
+    ) is False
+
+
+def test_is_error_handles_empty():
+    assert backend._is_error(_make_result("")) is False
 
 
 def test_is_error_handles_missing_content():
@@ -557,10 +592,10 @@ def test_type_text_absolute_path_focus_failure_skips_type_and_restores(mock_call
     """
     sess = _make_session(working_dir="/main")
     mock_call.side_effect = [
-        _make_result("✓ Entered tab 123\n[lane: 1]"),                 # cd anchor ok
-        _make_result("\x1b[31mError: focus: No such element\x1b[0m"),  # focus fails
-        _make_result("✓ Typed\n[lane: 1]"),                            # MUST NOT be reached
-        _make_result("✓\n[lane: 1]"),                                   # restore
+        _make_result("✓ Entered tab 123\n[lane: 1]"),                  # cd anchor ok
+        _make_result("\x1b[31mfocus: No such element\x1b[0m"),          # focus fails
+        _make_result("✓ Typed\n[lane: 1]"),                             # MUST NOT be reached
+        _make_result("✓\n[lane: 1]"),                                    # restore
     ]
 
     backend.type_text("/main/missing", "secret_password", session=sess)
@@ -584,7 +619,7 @@ def test_type_text_anchor_failure_does_not_attempt_focus(mock_call):
     """
     sess = _make_session(working_dir="/")
     mock_call.return_value = _make_result(
-        "\x1b[31mError: chrome:// not debuggable\x1b[0m"
+        "\x1b[31mcd: chrome:// not debuggable\x1b[0m"
     )
 
     backend.type_text("/some/path", "text", session=sess)
@@ -603,7 +638,7 @@ def test_type_text_relative_path_focus_failure_skips_type(mock_call):
     """
     sess = _make_session(working_dir="/")
     mock_call.side_effect = [
-        _make_result("Error: focus: No such element"),
+        _make_result("\x1b[31mfocus: No such element\x1b[0m"),  # focus fails
         _make_result("✓ Typed"),  # should NOT be reached
     ]
 
@@ -614,8 +649,8 @@ def test_type_text_relative_path_focus_failure_skips_type(mock_call):
     assert mock_call.call_args_list[0].args[0] == "focus stale_input"
     # The focus result is parsed (CLI consumes dicts, not CallToolResult).
     assert result == {
-        "error": "Error: focus: No such element",
-        "output": "Error: focus: No such element",
+        "error": "\x1b[31mfocus: No such element\x1b[0m",
+        "output": "\x1b[31mfocus: No such element\x1b[0m",
     }
 
 

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -1143,6 +1143,36 @@ def test_call_execute_passes_group_id_new_when_lane_is_none():
     assert sess.domshell_lane_id == "brand-new"
 
 
+def test_call_execute_passes_group_id_shared_for_daemon_mode_without_session():
+    """Daemon mode + no session: route to the default per-connection lane
+    via ``group_id="shared"``. The daemon's persistent stdio connection
+    keeps that lane sticky across calls, so direct callers like
+    ``open_url(use_daemon=True)`` followed by ``ls(use_daemon=True)``
+    share browser state without needing a Session object to carry a
+    lane id.
+
+    Migration note (PR #308 follow-up): the initial 2.0.2 migration
+    commit (be62f843b5) passed ``group_id="new"`` in this case, which
+    broke the daemon workflow by creating a fresh isolated lane per
+    call. Caught by Codex P2. Fix re-routes daemon-no-session calls to
+    ``"shared"``.
+    """
+    fake_tool = AsyncMock(return_value=_make_result("✓\n[lane: daemon-default]"))
+
+    fake_mcp_session = AsyncMock()
+    fake_mcp_session.call_tool = fake_tool
+
+    # Simulate a live daemon session — the same path open_url / ls take
+    # when called with use_daemon=True but no Session.
+    with patch.object(backend, "_daemon_session", fake_mcp_session):
+        import asyncio as _aio
+        _aio.run(backend._call_execute("ls /", use_daemon=True, session=None))
+
+    name, arguments = fake_tool.call_args.args
+    assert name == "domshell_execute"
+    assert arguments.get("group_id") == "shared"
+
+
 def test_distinct_sessions_have_isolated_lanes():
     """Two sessions track lanes independently — no cross-contamination."""
     s1 = Session()

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -1027,8 +1027,15 @@ def test_extract_lane_id_returns_none_when_content_missing():
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_first_call_omits_group_id_and_captures_lane(mock_call):
-    """A session with no stored lane: first call has no group_id, captures the returned lane."""
+def test_first_call_passes_wrapper_signature_and_captures_lane(mock_call):
+    """A session with no stored lane: the wrapper passes (command,
+    use_daemon, session=sess) into ``_call_execute``; the wire-format
+    ``group_id`` selection (``"new"`` for non-daemon first calls,
+    ``"shared"`` for daemon-mode-no-session) happens inside
+    ``_call_execute`` itself and is covered by the dedicated
+    wire-payload tests below. This test only asserts the wrapper-level
+    call signature plus the ``_capture_lane`` parser hookup.
+    """
     sess = Session()  # domshell_lane_id starts as None
     mock_call.return_value = _make_result("✓\n[lane: 12345]")
 

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -499,15 +499,23 @@ async def _call_execute(
     global _daemon_session, _daemon_read, _daemon_write
 
     arguments: dict[str, Any] = {"command": command}
-    # Reuse the previously-captured DOMShell lane so this call lands in the
-    # same Chrome tab-group as the prior commands in this session. Without
-    # this, every fresh stdio ClientSession would be assigned a brand-new
-    # lane and `page open` / `fs ls` etc. would run in disjoint browser
-    # state. The very first call leaves group_id unset so DOMShell
-    # auto-assigns; _capture_lane stores that id on the session for the
-    # next call.
+    # Lane handling for non-daemon mode: every fresh stdio ClientSession
+    # would otherwise be assigned a brand-new lane, scattering `page open`
+    # / `fs ls` / etc. across disjoint browser state. So we name the lane
+    # explicitly on every call:
+    #   • subsequent calls   → group_id=<previously captured lane id>
+    #   • very first call    → group_id="new" — DOMShell creates a fresh
+    #     isolated lane and returns its id in the [lane: ...] marker,
+    #     which `_capture_lane` stores on the session for next time.
+    # DOMShell 2.0.2 deprecated omitting `group_id` entirely (emits a
+    # [DEPRECATION] warning in the reply; hard error in 3.0.0). Passing
+    # "new" on the first call matches our actual intent — we want our own
+    # private lane, not the shared one — and silences the deprecation
+    # warning across every REPL session.
     if session is not None and getattr(session, "domshell_lane_id", None):
         arguments["group_id"] = session.domshell_lane_id
+    else:
+        arguments["group_id"] = "new"
 
     if use_daemon and _daemon_session is not None:
         # Use persistent daemon connection

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -156,30 +156,6 @@ def _assert_single_line(field: str, value: str) -> None:
         )
 
 
-def _is_error(result: Any) -> bool:
-    """Best-effort check that a ``domshell_execute`` result represents an error.
-
-    Inspects ``isError`` if the MCP SDK populated it; otherwise scans the
-    concatenated text content for a leading "error". Robust to both the
-    raw ``CallToolResult`` object and the dict shapes used in unit tests.
-    """
-    if hasattr(result, "isError") and result.isError:
-        return True
-    if isinstance(result, dict):
-        if result.get("isError"):
-            return True
-        if "error" in result:
-            return True
-    text = ""
-    content = getattr(result, "content", None)
-    if content:
-        for c in content:
-            piece = getattr(c, "text", None)
-            if piece:
-                text += piece
-    return text.strip().lower().startswith("error")
-
-
 async def _call_execute(command: str, use_daemon: bool = False) -> Any:
     """Run a DOMShell command via the single `domshell_execute` MCP tool.
 
@@ -361,12 +337,15 @@ def grep(
     """Search for pattern in the accessibility tree.
 
     When ``path`` is provided and is not ``/``, the search is rooted at that
-    path: ``cd`` into it, ``grep``, then ``cd`` back to ``prev``. The three
-    steps run as separate ``domshell_execute`` calls with the restore in a
-    ``finally`` block, so the cwd is restored even if ``grep`` errors
-    mid-flight. (A single multi-line call would be one round-trip instead of
-    three, but it relies on DOMShell's currently-undocumented continue-past-
-    error behavior — see PR review.)
+    path: ``cd`` into it, ``grep``, then ``cd`` back to ``prev`` — sent as one
+    multi-line ``domshell_execute`` call so all three lines share an MCP
+    session (and therefore a DOMShell lane / cwd). Each ``_call_execute`` in
+    non-daemon mode opens a fresh stdio session that lands in its own
+    DOMShell 2.x lane, so splitting cd/grep/restore across separate calls
+    would lose the cwd between them. The trailing ``cd prev`` is delivered as
+    the final line of the same command and runs even if ``grep`` errors —
+    DOMShell's multi-line splitter continues past errors (see
+    `apireno/DOMShell#46 <https://github.com/apireno/DOMShell/issues/46>`_).
 
     ``path``, ``prev``, and ``use_daemon`` are keyword-only to prevent silent
     breakage of callers written against the pre-migration positional
@@ -389,17 +368,12 @@ def grep(
         >>> grep("Login", path="/main")
         {"matches": ["/main/button[0]"]}
     """
+    _assert_single_line("pattern", pattern)
     if path and path != "/":
         _assert_single_line("path", path)
         _assert_single_line("prev", prev)
-        _assert_single_line("pattern", pattern)
-        cd_result = asyncio.run(_call_execute(f"cd {_q(path)}", use_daemon))
-        if _is_error(cd_result):
-            return cd_result
-        try:
-            return asyncio.run(_call_execute(f"grep {_q(pattern)}", use_daemon))
-        finally:
-            asyncio.run(_call_execute(f"cd {_q(prev)}", use_daemon))
+        command = f"cd {_q(path)}\ngrep {_q(pattern)}\ncd {_q(prev)}"
+        return asyncio.run(_call_execute(command, use_daemon))
     return asyncio.run(_call_execute(f"grep {_q(pattern)}", use_daemon))
 
 

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -121,6 +121,46 @@ def _q(arg: str) -> str:
     return shlex.quote(arg)
 
 
+def _assert_single_line(field: str, value: str) -> None:
+    """Reject newline characters in a user-supplied string.
+
+    DOMShell's ``domshell_execute`` splits its ``command`` argument on
+    newlines *before* shell-style quote parsing, so a literal ``\\n`` or
+    ``\\r`` inside an otherwise-quoted argument escapes the quoting and
+    starts a fresh DOMShell command. Guard at the wrapper layer for any
+    value that gets interpolated into a multi-line command string.
+    """
+    if "\n" in value or "\r" in value:
+        raise ValueError(
+            f"{field}: newline characters are not allowed (would be interpreted "
+            f"as DOMShell command separators). Got: {value!r}"
+        )
+
+
+def _is_error(result: Any) -> bool:
+    """Best-effort check that a ``domshell_execute`` result represents an error.
+
+    Inspects ``isError`` if the MCP SDK populated it; otherwise scans the
+    concatenated text content for a leading "error". Robust to both the
+    raw ``CallToolResult`` object and the dict shapes used in unit tests.
+    """
+    if hasattr(result, "isError") and result.isError:
+        return True
+    if isinstance(result, dict):
+        if result.get("isError"):
+            return True
+        if "error" in result:
+            return True
+    text = ""
+    content = getattr(result, "content", None)
+    if content:
+        for c in content:
+            piece = getattr(c, "text", None)
+            if piece:
+                text += piece
+    return text.strip().lower().startswith("error")
+
+
 async def _call_execute(command: str, use_daemon: bool = False) -> Any:
     """Run a DOMShell command via the single `domshell_execute` MCP tool.
 
@@ -294,6 +334,7 @@ def cat(path: str, use_daemon: bool = False) -> dict:
 
 def grep(
     pattern: str,
+    *,
     path: str = "",
     prev: str = "/",
     use_daemon: bool = False,
@@ -301,9 +342,16 @@ def grep(
     """Search for pattern in the accessibility tree.
 
     When ``path`` is provided and is not ``/``, the search is rooted at that
-    path: ``cd`` into it, ``grep``, then ``cd`` back to ``prev`` — sent as one
-    multi-line ``domshell_execute`` call so all three steps share shell state
-    and complete in a single MCP round-trip.
+    path: ``cd`` into it, ``grep``, then ``cd`` back to ``prev``. The three
+    steps run as separate ``domshell_execute`` calls with the restore in a
+    ``finally`` block, so the cwd is restored even if ``grep`` errors
+    mid-flight. (A single multi-line call would be one round-trip instead of
+    three, but it relies on DOMShell's currently-undocumented continue-past-
+    error behavior — see PR review.)
+
+    ``path``, ``prev``, and ``use_daemon`` are keyword-only to prevent silent
+    breakage of callers written against the pre-migration positional
+    signature ``grep(pattern, use_daemon)``.
 
     Args:
         pattern: Text pattern to search for
@@ -323,10 +371,17 @@ def grep(
         {"matches": ["/main/button[0]"]}
     """
     if path and path != "/":
-        command = f"cd {_q(path)}\ngrep {_q(pattern)}\ncd {_q(prev)}"
-    else:
-        command = f"grep {_q(pattern)}"
-    return asyncio.run(_call_execute(command, use_daemon))
+        _assert_single_line("path", path)
+        _assert_single_line("prev", prev)
+        _assert_single_line("pattern", pattern)
+        cd_result = asyncio.run(_call_execute(f"cd {_q(path)}", use_daemon))
+        if _is_error(cd_result):
+            return cd_result
+        try:
+            return asyncio.run(_call_execute(f"grep {_q(pattern)}", use_daemon))
+        finally:
+            asyncio.run(_call_execute(f"cd {_q(prev)}", use_daemon))
+    return asyncio.run(_call_execute(f"grep {_q(pattern)}", use_daemon))
 
 
 def click(path: str, use_daemon: bool = False) -> dict:
@@ -413,7 +468,15 @@ def type_text(path: str, text: str, use_daemon: bool = False) -> dict:
 
     Returns:
         Dict with action result
+
+    Raises:
+        ValueError: If ``path`` or ``text`` contains a newline. DOMShell's
+            ``domshell_execute`` treats newlines as command separators, so
+            an embedded newline would inject additional commands. Split
+            into multiple ``type_text`` calls for multi-line input.
     """
+    _assert_single_line("path", path)
+    _assert_single_line("text", text)
     command = f"focus {_q(path)}\ntype {_q(text)}"
     return asyncio.run(_call_execute(command, use_daemon))
 

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -19,6 +19,7 @@ that single tool.
 
 import asyncio
 import os
+import re
 import shlex
 import subprocess
 import shutil
@@ -140,6 +141,47 @@ def _q(arg: str) -> str:
     return shlex.quote(arg)
 
 
+# DOMShell 2.x appends a "[lane: <id>]" marker as the last line of every
+# domshell_execute reply. We parse it out and store it on the harness
+# Session so subsequent calls can pass group_id=<id> and stay pinned to
+# the same Chrome tab-group (i.e. same browser state).
+_LANE_LINE = re.compile(r"\[lane:\s*([^\]\s]+)\s*\]\s*$")
+
+
+def _extract_lane_id(result: Any) -> Optional[str]:
+    """Parse the trailing ``[lane: <id>]`` marker DOMShell appends to replies.
+
+    Returns the lane id, or ``None`` if no marker is present, the text is
+    empty, or the marker reports the default "shared" lane (which is
+    DOMShell's no-isolation sentinel and not something we want to pin to).
+    """
+    text = ""
+    content = getattr(result, "content", None)
+    if content:
+        for c in content:
+            piece = getattr(c, "text", None)
+            if piece:
+                text += piece
+    if not text:
+        return None
+    m = _LANE_LINE.search(text.strip())
+    if not m:
+        return None
+    lane = m.group(1).strip()
+    if not lane or lane == "shared":
+        return None
+    return lane
+
+
+def _capture_lane(session: Any, result: Any) -> None:
+    """Update ``session.domshell_lane_id`` from a ``_call_execute`` result."""
+    if session is None:
+        return
+    lane = _extract_lane_id(result)
+    if lane:
+        session.domshell_lane_id = lane
+
+
 def _assert_single_line(field: str, value: str) -> None:
     """Reject newline characters in a user-supplied string.
 
@@ -156,13 +198,22 @@ def _assert_single_line(field: str, value: str) -> None:
         )
 
 
-async def _call_execute(command: str, use_daemon: bool = False) -> Any:
+async def _call_execute(
+    command: str,
+    use_daemon: bool = False,
+    *,
+    session: Any = None,
+) -> Any:
     """Run a DOMShell command via the single `domshell_execute` MCP tool.
 
     Args:
         command: DOMShell command string. May contain newlines for multi-command
             execution — each line runs in order in the same shell state.
         use_daemon: If True, use persistent daemon connection (if available)
+        session: Harness ``Session`` whose ``domshell_lane_id`` should be
+            forwarded as ``group_id`` (when set) and updated from the result
+            (when DOMShell returns a ``[lane: <id>]`` marker). Pass ``None``
+            for one-off direct calls that don't need cross-call state.
 
     Returns:
         Tool result as returned by MCP server
@@ -172,12 +223,24 @@ async def _call_execute(command: str, use_daemon: bool = False) -> Any:
     """
     global _daemon_session, _daemon_read, _daemon_write
 
+    arguments: dict[str, Any] = {"command": command}
+    # Reuse the previously-captured DOMShell lane so this call lands in the
+    # same Chrome tab-group as the prior commands in this session. Without
+    # this, every fresh stdio ClientSession would be assigned a brand-new
+    # lane and `page open` / `fs ls` etc. would run in disjoint browser
+    # state. The very first call leaves group_id unset so DOMShell
+    # auto-assigns; _capture_lane stores that id on the session for the
+    # next call.
+    if session is not None and getattr(session, "domshell_lane_id", None):
+        arguments["group_id"] = session.domshell_lane_id
+
     if use_daemon and _daemon_session is not None:
         # Use persistent daemon connection
         try:
             result = await _daemon_session.call_tool(
-                "domshell_execute", {"command": command}
+                "domshell_execute", arguments
             )
+            _capture_lane(session, result)
             return result
         except Exception:
             # Daemon died, fall back to spawning new server
@@ -191,11 +254,12 @@ async def _call_execute(command: str, use_daemon: bool = False) -> Any:
 
     try:
         async with stdio_client(server_params) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                result = await session.call_tool(
-                    "domshell_execute", {"command": command}
+            async with ClientSession(read, write) as mcp_session:
+                await mcp_session.initialize()
+                result = await mcp_session.call_tool(
+                    "domshell_execute", arguments
                 )
+                _capture_lane(session, result)
                 return result
     except Exception as e:
         raise RuntimeError(
@@ -275,12 +339,13 @@ def daemon_started() -> bool:
 # `domshell_execute`. The public Python API is unchanged from the
 # pre-2.0.0 per-tool wrappers.
 
-def ls(path: str = "/", use_daemon: bool = False) -> dict:
+def ls(path: str = "/", *, use_daemon: bool = False, session: Any = None) -> dict:
     """List directory contents in the accessibility tree.
 
     Args:
         path: Path in accessibility tree (e.g., "/", "/main", "/main/div[0]")
         use_daemon: Use persistent daemon connection if available
+        session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
         Dict with 'entries' key containing list of accessible elements
@@ -290,15 +355,16 @@ def ls(path: str = "/", use_daemon: bool = False) -> dict:
         {"path": "/", "entries": [{"name": "main", "role": "landmark", ...}]}
     """
     command = f"ls {_q(path)}" if path else "ls"
-    return asyncio.run(_call_execute(command, use_daemon))
+    return asyncio.run(_call_execute(command, use_daemon, session=session))
 
 
-def cd(path: str, use_daemon: bool = False) -> dict:
+def cd(path: str, *, use_daemon: bool = False, session: Any = None) -> dict:
     """Change directory in the accessibility tree.
 
     Args:
         path: Target path
         use_daemon: Use persistent daemon connection if available
+        session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
         Dict with 'path' key confirming current location
@@ -307,15 +373,16 @@ def cd(path: str, use_daemon: bool = False) -> dict:
         >>> cd("/main/div[0]")
         {"path": "/main/div[0]", "element": {...}}
     """
-    return asyncio.run(_call_execute(f"cd {_q(path)}", use_daemon))
+    return asyncio.run(_call_execute(f"cd {_q(path)}", use_daemon, session=session))
 
 
-def cat(path: str, use_daemon: bool = False) -> dict:
+def cat(path: str, *, use_daemon: bool = False, session: Any = None) -> dict:
     """Read element content from the accessibility tree.
 
     Args:
         path: Path to element
         use_daemon: Use persistent daemon connection if available
+        session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
         Dict with element details including text, role, attributes
@@ -324,7 +391,7 @@ def cat(path: str, use_daemon: bool = False) -> dict:
         >>> cat("/main/button[0]")
         {"name": "Submit", "role": "button", "text": "Submit", ...}
     """
-    return asyncio.run(_call_execute(f"cat {_q(path)}", use_daemon))
+    return asyncio.run(_call_execute(f"cat {_q(path)}", use_daemon, session=session))
 
 
 def grep(
@@ -333,6 +400,7 @@ def grep(
     path: str = "",
     prev: str = "/",
     use_daemon: bool = False,
+    session: Any = None,
 ) -> dict:
     """Search for pattern in the accessibility tree.
 
@@ -373,16 +441,19 @@ def grep(
         _assert_single_line("path", path)
         _assert_single_line("prev", prev)
         command = f"cd {_q(path)}\ngrep {_q(pattern)}\ncd {_q(prev)}"
-        return asyncio.run(_call_execute(command, use_daemon))
-    return asyncio.run(_call_execute(f"grep {_q(pattern)}", use_daemon))
+        return asyncio.run(_call_execute(command, use_daemon, session=session))
+    return asyncio.run(
+        _call_execute(f"grep {_q(pattern)}", use_daemon, session=session)
+    )
 
 
-def click(path: str, use_daemon: bool = False) -> dict:
+def click(path: str, *, use_daemon: bool = False, session: Any = None) -> dict:
     """Click an element in the accessibility tree.
 
     Args:
         path: Path to element to click
         use_daemon: Use persistent daemon connection if available
+        session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
         Dict with action result
@@ -391,15 +462,18 @@ def click(path: str, use_daemon: bool = False) -> dict:
         >>> click("/main/button[0]")
         {"action": "click", "path": "/main/button[0]", "status": "success"}
     """
-    return asyncio.run(_call_execute(f"click {_q(path)}", use_daemon))
+    return asyncio.run(
+        _call_execute(f"click {_q(path)}", use_daemon, session=session)
+    )
 
 
-def open_url(url: str, use_daemon: bool = False) -> dict:
+def open_url(url: str, *, use_daemon: bool = False, session: Any = None) -> dict:
     """Navigate to a URL in Chrome.
 
     Args:
         url: URL to navigate to
         use_daemon: Use persistent daemon connection if available
+        session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
         Dict with navigation result
@@ -408,46 +482,57 @@ def open_url(url: str, use_daemon: bool = False) -> dict:
         >>> open_url("https://example.com")
         {"url": "https://example.com", "status": "loaded"}
     """
-    return asyncio.run(_call_execute(f"open {_q(url)}", use_daemon))
+    return asyncio.run(
+        _call_execute(f"open {_q(url)}", use_daemon, session=session)
+    )
 
 
-def reload(use_daemon: bool = False) -> dict:
+def reload(*, use_daemon: bool = False, session: Any = None) -> dict:
     """Reload the current page.
 
     Args:
         use_daemon: Use persistent daemon connection if available
+        session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
         Dict with reload result
     """
-    return asyncio.run(_call_execute("refresh", use_daemon))
+    return asyncio.run(_call_execute("refresh", use_daemon, session=session))
 
 
-def back(use_daemon: bool = False) -> dict:
+def back(*, use_daemon: bool = False, session: Any = None) -> dict:
     """Navigate back in history.
 
     Args:
         use_daemon: Use persistent daemon connection if available
+        session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
         Dict with navigation result
     """
-    return asyncio.run(_call_execute("back", use_daemon))
+    return asyncio.run(_call_execute("back", use_daemon, session=session))
 
 
-def forward(use_daemon: bool = False) -> dict:
+def forward(*, use_daemon: bool = False, session: Any = None) -> dict:
     """Navigate forward in history.
 
     Args:
         use_daemon: Use persistent daemon connection if available
+        session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
         Dict with navigation result
     """
-    return asyncio.run(_call_execute("forward", use_daemon))
+    return asyncio.run(_call_execute("forward", use_daemon, session=session))
 
 
-def type_text(path: str, text: str, use_daemon: bool = False) -> dict:
+def type_text(
+    path: str,
+    text: str,
+    *,
+    use_daemon: bool = False,
+    session: Any = None,
+) -> dict:
     """Type text into an input element.
 
     Focuses the element and types in a single ``domshell_execute`` call so
@@ -471,7 +556,7 @@ def type_text(path: str, text: str, use_daemon: bool = False) -> dict:
     _assert_single_line("path", path)
     _assert_single_line("text", text)
     command = f"focus {_q(path)}\ntype {_q(text)}"
-    return asyncio.run(_call_execute(command, use_daemon))
+    return asyncio.run(_call_execute(command, use_daemon, session=session))
 
 
 # ── Daemon control functions ───────────────────────────────────────────

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -186,27 +186,102 @@ def _capture_lane(session: Any, result: Any) -> None:
         session.domshell_lane_id = lane
 
 
-def _translate_path(harness_path: str) -> str:
-    """Translate a harness DOM path to a DOMShell command path.
+def _translate_path(harness_path: str) -> tuple[str, bool]:
+    """Translate a harness DOM path into ``(stripped, is_absolute)``.
 
     The harness models ``/`` as the focused tab's AX root. DOMShell models
-    ``~/`` (and bare ``/``) as the BROWSER root — windows and tabs.
-    Sending ``ls /`` verbatim would list tabs, not page elements. Strip
-    the leading ``/`` so harness ``/main`` becomes DOMShell ``main``
-    (relative to the lane's cwd, which IS the focused tab's AX root once
-    ``page open`` has put the lane inside the tab).
+    ``/`` and ``~/`` as the BROWSER root (windows/tabs). DOMShell also
+    keeps a per-lane cwd that persists between commands — so after
+    ``fs cd /main`` the lane cwd is no longer the tab root, and a
+    subsequent ``ls main`` (the naive strip-one-slash form) would resolve
+    against the drifted cwd as ``/main/main``. Wrong target.
 
-    - ``""`` and ``"/"`` → ``""`` (signal: operate on lane cwd; the
-      wrappers turn this into a bare command, e.g. ``ls`` or ``cd %here%``).
-    - ``"/main"`` → ``"main"``
-    - ``"/main/article"`` → ``"main/article"``
-    - ``"main"``, ``".."``, ``"."`` → passed through unchanged.
+    The fix: distinguish *absolute* from *relative* harness paths so
+    callers can wrap the operation in ``cd %here%[/deeper]\\n<op>\\ncd
+    <restore>`` for the absolute case (anchoring at the tab root), and
+    pass relative paths through unchanged (the lane cwd is the right
+    reference for them).
+
+    Uses ``lstrip("/")`` so accidental ``//main`` collapses to ``main``.
+
+    Examples:
+        ``""``          → ``("", False)``
+        ``"/"``         → ``("", True)``
+        ``"/main"``     → ``("main", True)``
+        ``"//main"``    → ``("main", True)``
+        ``"/main/btn"`` → ``("main/btn", True)``
+        ``"main"``      → ``("main", False)``
+        ``".."``        → ``("..", False)``
     """
-    if not harness_path or harness_path == "/":
-        return ""
+    # Newline guard at the translation boundary: absolute-path branches
+    # interpolate `%here%/<translated>` without going through `_q`
+    # (DOMShell's path-variable expander runs before quote parsing on
+    # `cd`, so quoting would defeat it). Catching newlines here means
+    # every wrapper that consumes the translated path is protected
+    # against injection, even if the wrapper skips `_q`.
+    if "\n" in harness_path or "\r" in harness_path:
+        raise ValueError(
+            "Newline characters are not allowed in path arguments — "
+            "DOMShell's domshell_execute treats them as command separators, "
+            f"so a newline in a path would inject additional commands. "
+            f"Got ({len(harness_path)} chars): "
+            f"{(harness_path[:80] + ('…' if len(harness_path) > 80 else ''))!r}"
+        )
+    if not harness_path:
+        return "", False
     if harness_path.startswith("/"):
-        return harness_path[1:]
-    return harness_path
+        return harness_path.lstrip("/"), True
+    return harness_path, False
+
+
+def _here_path(deeper: str) -> str:
+    """Build a ``%here%[/<deeper>]`` token, shell-quoted as a single unit.
+
+    DOMShell's ``cd`` accepts quoted ``%here%`` cleanly
+    (``cd '%here%/main'`` was upstream-smoked: ``✓ Entered tab …``), so
+    we quote uniformly via ``_q``. Whitespace, brackets, ``$`` etc. in
+    the ``<deeper>`` portion survive the wrap correctly.
+
+    For simple cases (no shell metacharacters) ``_q`` returns the input
+    unchanged, so ``_here_path("main")`` is still ``%here%/main``.
+    """
+    return _q(f"%here%/{deeper}") if deeper else _q("%here%")
+
+
+def _restore_cwd_cmd(session: Any) -> str:
+    """Build the trailing ``cd <wd>`` line for an absolute-path wrap.
+
+    Uses the harness's tracked ``working_dir`` (translated to DOMShell
+    form) so after the wrapped operation the lane's cwd matches what the
+    harness thinks it is. Without this restore, a wrapped operation
+    against ``/`` would leave the lane parked at ``%here%`` even though
+    the harness's ``working_dir`` is something like ``/main``.
+
+    The harness ``working_dir`` is always absolute in normal use, so the
+    common output shape is ``cd %here%/<stripped>``. The relative
+    branch is a defensive fallback for an unusual session shape.
+    """
+    wd = getattr(session, "working_dir", None) or "/"
+    stripped, is_abs = _translate_path(wd)
+    if is_abs:
+        return f"cd {_here_path(stripped)}"
+    return f"cd {_q(stripped)}" if stripped else f"cd {_here_path('')}"
+
+
+def _wrap_absolute(operation: str, session: Any, *, deeper: str = "") -> str:
+    """Build a ``cd %here%[/deeper]\\n<operation>\\n<restore>`` triplet.
+
+    ``deeper`` is the optional tab-root-relative subdir to ``cd`` into
+    BEFORE the operation. Used for ``ls /main`` where the operation is
+    bare ``ls`` (and the ``/main`` needs to become the anchored cwd) as
+    opposed to ``cat /main/btn`` where the operation already carries the
+    relative path and we just anchor at the tab root.
+
+    The ``%here%/<deeper>`` token is shell-quoted as a single unit via
+    ``_here_path``, so paths containing whitespace or other shell
+    metacharacters survive the wrap correctly.
+    """
+    return f"cd {_here_path(deeper)}\n{operation}\n{_restore_cwd_cmd(session)}"
 
 
 def _is_error(result: Any) -> bool:
@@ -407,8 +482,15 @@ def ls(path: str = "/", use_daemon: bool = False, *, session: Any = None) -> dic
         >>> ls("/")
         {"path": "/", "entries": [{"name": "main", "role": "landmark", ...}]}
     """
-    translated = _translate_path(path)
-    command = f"ls {_q(translated)}" if translated else "ls"
+    translated, is_absolute = _translate_path(path)
+    if is_absolute:
+        # `ls /main`: cd to %here%/main, run bare ls, restore.
+        # `ls /`:     cd to %here%,      run bare ls, restore.
+        command = _wrap_absolute("ls", session, deeper=translated)
+    elif translated:
+        command = f"ls {_q(translated)}"
+    else:
+        command = "ls"
     return asyncio.run(_call_execute(command, use_daemon, session=session))
 
 
@@ -427,11 +509,17 @@ def cd(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         >>> cd("/main/div[0]")
         {"path": "/main/div[0]", "element": {...}}
     """
-    translated = _translate_path(path)
-    # Harness `cd /` means "back to focused-tab AX root" — DOMShell's
-    # equivalent is `cd %here%`, which jumps to the tab root regardless
-    # of where the lane wandered to.
-    command = "cd %here%" if not translated else f"cd {_q(translated)}"
+    translated, is_absolute = _translate_path(path)
+    # cd is the rare case where the operation IS the new state — no
+    # restore needed. Absolute targets anchor via `cd %here%/<rest>` so
+    # the result is independent of the lane's current cwd.
+    if is_absolute:
+        command = f"cd {_here_path(translated)}"
+    elif translated:
+        command = f"cd {_q(translated)}"
+    else:
+        # Bare/empty `cd` → back to tab root.
+        command = f"cd {_here_path('')}"
     return asyncio.run(_call_execute(command, use_daemon, session=session))
 
 
@@ -450,13 +538,19 @@ def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         >>> cat("/main/button[0]")
         {"name": "Submit", "role": "button", "text": "Submit", ...}
     """
-    translated = _translate_path(path)
+    translated, is_absolute = _translate_path(path)
     if not translated:
         raise ValueError(
             "cat: an element name is required — cannot cat the tab root. "
             "Use `ls` to list the root's children, or pass a specific name."
         )
-    return asyncio.run(_call_execute(f"cat {_q(translated)}", use_daemon, session=session))
+    if is_absolute:
+        # `cat /main/btn`: anchor at tab root, run `cat main/btn` relative,
+        # restore the harness's tracked cwd.
+        command = _wrap_absolute(f"cat {_q(translated)}", session)
+    else:
+        command = f"cat {_q(translated)}"
+    return asyncio.run(_call_execute(command, use_daemon, session=session))
 
 
 def grep(
@@ -502,22 +596,39 @@ def grep(
         {"matches": ["/main/button[0]"]}
     """
     _assert_single_line("pattern", pattern)
-    translated_path = _translate_path(path)
-    translated_prev = _translate_path(prev)
-    if translated_path:
-        _assert_single_line("path", path)
-        _assert_single_line("prev", prev)
-        # Harness `/` (the default for `prev`) means "back to focused-tab
-        # AX root", which is DOMShell's `cd %here%`. Any other restore
-        # path becomes `cd <translated>`.
-        restore = (
-            f"cd {_q(translated_prev)}" if translated_prev else "cd %here%"
+    translated_path, path_abs = _translate_path(path)
+    if not translated_path:
+        # Unrooted grep — operate on lane cwd, no cd, no restore.
+        return asyncio.run(
+            _call_execute(f"grep {_q(pattern)}", use_daemon, session=session)
         )
-        command = f"cd {_q(translated_path)}\ngrep {_q(pattern)}\n{restore}"
-        return asyncio.run(_call_execute(command, use_daemon, session=session))
-    return asyncio.run(
-        _call_execute(f"grep {_q(pattern)}", use_daemon, session=session)
-    )
+
+    _assert_single_line("path", path)
+    _assert_single_line("prev", prev)
+
+    if path_abs:
+        # Absolute path: anchor at `%here%/<target>`, grep, restore to the
+        # harness's tracked working_dir (so the lane cwd doesn't drift).
+        # The `%here%/<target>` token is quoted as a single unit by
+        # `_here_path` — survives whitespace / shell metachars cleanly.
+        cd_line = f"cd {_here_path(translated_path)}"
+        restore = _restore_cwd_cmd(session)
+    else:
+        # Relative path: lane cwd is the right reference. `prev` defaults
+        # to "/" — for relative grep we just go back to whatever caller
+        # asked, shell-quoted (or `%here%/...` for absolute prev).
+        translated_prev, prev_abs = _translate_path(prev)
+        cd_line = f"cd {_q(translated_path)}"
+        if prev_abs:
+            restore = f"cd {_here_path(translated_prev)}"
+        else:
+            restore = (
+                f"cd {_q(translated_prev)}"
+                if translated_prev
+                else f"cd {_here_path('')}"
+            )
+    command = f"{cd_line}\ngrep {_q(pattern)}\n{restore}"
+    return asyncio.run(_call_execute(command, use_daemon, session=session))
 
 
 def click(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
@@ -535,14 +646,16 @@ def click(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         >>> click("/main/button[0]")
         {"action": "click", "path": "/main/button[0]", "status": "success"}
     """
-    translated = _translate_path(path)
+    translated, is_absolute = _translate_path(path)
     if not translated:
         raise ValueError(
             "click: an element name is required — cannot click the tab root."
         )
-    return asyncio.run(
-        _call_execute(f"click {_q(translated)}", use_daemon, session=session)
-    )
+    if is_absolute:
+        command = _wrap_absolute(f"click {_q(translated)}", session)
+    else:
+        command = f"click {_q(translated)}"
+    return asyncio.run(_call_execute(command, use_daemon, session=session))
 
 
 def open_url(url: str, use_daemon: bool = False, *, session: Any = None) -> dict:
@@ -644,18 +757,37 @@ def type_text(
     """
     _assert_single_line("path", path)
     _assert_single_line("text", text)
-    translated_path = _translate_path(path)
+
+    # A session is required: the focus and type halves split across two
+    # _call_execute calls, and without `session.domshell_lane_id` the
+    # second call would land in a different DOMShell lane and miss the
+    # focus state from the first.
+    if session is None:
+        raise ValueError(
+            "type_text: a session argument is required so the focus and type "
+            "calls share a DOMShell lane. Otherwise the focus state from the "
+            "first call would not apply to the second."
+        )
+
+    translated_path, is_absolute = _translate_path(path)
     if not translated_path:
         raise ValueError(
-            "type_text: an element name is required — cannot focus the tab root."
+            "type_text: an input path is required — cannot focus the tab root."
         )
+
     # Relies on DOMShell serializing commands within a lane: the `type`
     # call below cannot be preempted by another agent's `focus` on the
     # same lane between these two _call_execute boundaries. If that
     # contract ever changes upstream, this needs to revert to a single
     # multi-line call with an alternative safety story.
+    if is_absolute:
+        # Anchor + focus + restore as one multi-line call, so the focus
+        # lands against the tab root regardless of lane cwd drift.
+        focus_cmd = _wrap_absolute(f"focus {_q(translated_path)}", session)
+    else:
+        focus_cmd = f"focus {_q(translated_path)}"
     focus_result = asyncio.run(_call_execute(
-        f"focus {_q(translated_path)}", use_daemon, session=session,
+        focus_cmd, use_daemon, session=session,
     ))
     if _is_error(focus_result):
         return focus_result  # don't type — focus didn't land

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -18,6 +18,7 @@ that single tool.
 """
 
 import asyncio
+import logging
 import os
 import re
 import shlex
@@ -26,6 +27,9 @@ import shutil
 from typing import Any, Optional
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
+
+
+log = logging.getLogger(__name__)
 
 # DOMShell MCP server command
 # The harness connects to a running DOMShell server via domshell-proxy (stdio bridge).
@@ -85,7 +89,7 @@ def is_available() -> tuple[bool, str]:
 
     Examples:
         >>> is_available()
-        (True, "DOMShell v2.0.0 is available")
+        (True, "DOMShell vX.Y.Z is available")   # whatever npx resolves to
         >>> is_available()
         (False, "npx not found. Install Node.js from https://nodejs.org/")
     """
@@ -149,6 +153,12 @@ def _q(arg: str) -> str:
 # domshell_execute reply. We parse it out and store it on the harness
 # Session so subsequent calls can pass group_id=<id> and stay pinned to
 # the same Chrome tab-group (i.e. same browser state).
+#
+# The marker format is part of the DOMShell 2.x wire contract — see the
+# upstream docs (https://github.com/apireno/DOMShell, search the README
+# for "Multi-line semantics" / "lane marker"). If DOMShell ever changes
+# the marker format (e.g. to JSON, or to [group: …]), this regex needs
+# to follow.
 _LANE_LINE = re.compile(r"\[lane:\s*([^\]\s]+)\s*\]\s*$")
 
 
@@ -391,8 +401,13 @@ async def _call_execute(
             )
             _capture_lane(session, result)
             return result
-        except Exception:
-            # Daemon died, fall back to spawning new server
+        except Exception as e:
+            # Daemon died — log diagnosability and fall back to spawning
+            # a fresh server below. Silent swallow was making the daemon
+            # failure mode invisible in user reports.
+            log.warning(
+                "DOMShell daemon call failed, respawning per-command: %s", e,
+            )
             await _stop_daemon()
 
     # Spawn new MCP server process
@@ -747,8 +762,8 @@ def type_text(
 ) -> dict:
     """Type text into an input element.
 
-    Issued as two separate ``domshell_execute`` calls — ``focus``, check
-    for error, then ``type`` only if ``focus`` succeeded. Both share the
+    Issued as separate ``domshell_execute`` calls — ``focus``, check for
+    error, then ``type`` only if ``focus`` succeeded. Both share the
     persisted lane id (via ``session``), so the focus state from the
     first call carries into the second.
 
@@ -759,6 +774,16 @@ def type_text(
     failed ``focus`` followed by a successful ``type`` would dispatch
     keys into whatever was previously focused (potentially a password
     field). Halting between focus and type prevents that.
+
+    Performance note: in non-daemon mode with an absolute path this
+    issues up to four ``_call_execute`` calls (anchor ``cd``, focus,
+    type, restore ``cd``), and each opens a fresh stdio MCP session —
+    so up to four ``npx`` server spawns per call. Relative paths use
+    two calls; daemon mode reuses one persistent connection for the
+    whole chain regardless of path form. The per-call overhead is
+    accepted to keep the wrapper-level error semantics simple; a future
+    refactor could share a single ``ClientSession`` across the chain
+    (post-merge follow-up).
 
     Args:
         path: Path to input element
@@ -779,15 +804,17 @@ def type_text(
     _assert_single_line("path", path)
     _assert_single_line("text", text)
 
-    # A session is required: the focus and type halves split across two
-    # _call_execute calls, and without `session.domshell_lane_id` the
-    # second call would land in a different DOMShell lane and miss the
-    # focus state from the first.
-    if session is None:
+    # In daemon mode both halves share the persistent `_daemon_session`
+    # naturally — same MCP session means same DOMShell lane, no
+    # group_id juggling needed. Only the non-daemon path requires
+    # `session.domshell_lane_id` because each `_call_execute` opens a
+    # fresh stdio session that would land in its own lane otherwise.
+    if session is None and not use_daemon:
         raise ValueError(
-            "type_text: a session argument is required so the focus and type "
-            "calls share a DOMShell lane. Otherwise the focus state from the "
-            "first call would not apply to the second."
+            "type_text: a session argument is required in non-daemon mode "
+            "so the focus and type calls share a DOMShell lane via group_id. "
+            "(Daemon mode shares the persistent connection's lane "
+            "automatically and doesn't need session.)"
         )
 
     translated_path, is_absolute = _translate_path(path)

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -269,7 +269,19 @@ def _restore_cwd_cmd(session: Any) -> str:
 
 
 def _wrap_absolute(operation: str, session: Any, *, deeper: str = "") -> str:
-    """Build a ``cd %here%[/deeper]\\n<operation>\\n<restore>`` triplet.
+    """Build a ``cd %here%[/deeper]\\n<operation>\\n<restore>`` triplet for
+    absolute harness paths, so the operation runs against the tab root
+    regardless of lane cwd drift.
+
+    USE FOR cleanup-line idioms ONLY — operations whose error doesn't gate
+    further wrapper-side action (``ls``, ``cat``, ``click``, ``grep``).
+    DOMShell's multi-line semantics continue past per-line errors, which
+    is the correct property for "always run the restore" but the WRONG
+    property for **safety chains** where the second step depends on the
+    first step's success. For safety chains (e.g. ``type_text``'s
+    ``focus → type``), issue anchor / operation / restore as SEPARATE
+    ``_call_execute`` calls and ``_is_error``-check between them. See
+    ``type_text``'s absolute-path branch for the pattern.
 
     ``deeper`` is the optional tab-root-relative subdir to ``cd`` into
     BEFORE the operation. Used for ``ls /main`` where the operation is
@@ -284,14 +296,22 @@ def _wrap_absolute(operation: str, session: Any, *, deeper: str = "") -> str:
     return f"cd {_here_path(deeper)}\n{operation}\n{_restore_cwd_cmd(session)}"
 
 
+# CSI (ANSI) escape sequences DOMShell wraps error text in (typically red).
+# Strip them before prefix-matching "error" so an ANSI-coloured error line
+# isn't misread as success.
+_ANSI_CSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
 def _is_error(result: Any) -> bool:
     """Best-effort check that a ``domshell_execute`` result represents an error.
 
     Inspects ``isError`` if the MCP SDK populated it, then ``isError`` /
     ``error`` keys on dict-shaped test fixtures, and finally scans the
-    concatenated text content for a leading "error". Robust to the raw
-    ``CallToolResult`` and to the ``SimpleNamespace(content=[...])``
-    fixtures used in tests.
+    concatenated text content for a leading "error" — with ANSI escape
+    sequences stripped first, since DOMShell colours error lines red
+    (``\\x1b[31mError: ...\\x1b[0m``). Robust to the raw
+    ``CallToolResult`` and to ``SimpleNamespace(content=[...])`` test
+    fixtures.
     """
     if hasattr(result, "isError") and result.isError:
         return True
@@ -307,6 +327,7 @@ def _is_error(result: Any) -> bool:
             piece = getattr(c, "text", None)
             if piece:
                 text += piece
+    text = _ANSI_CSI_RE.sub("", text)
     return text.strip().lower().startswith("error")
 
 
@@ -775,25 +796,54 @@ def type_text(
             "type_text: an input path is required — cannot focus the tab root."
         )
 
-    # Relies on DOMShell serializing commands within a lane: the `type`
-    # call below cannot be preempted by another agent's `focus` on the
-    # same lane between these two _call_execute boundaries. If that
-    # contract ever changes upstream, this needs to revert to a single
-    # multi-line call with an alternative safety story.
+    # type_text is a safety chain (focus → type), NOT a cleanup-line
+    # idiom (cd → op → cd back). Cleanup-line patterns want continue-on-
+    # error so the restore always runs. Safety chains want the opposite:
+    # halt on the first step's error so the second step doesn't dispatch
+    # against stale state. Wrapping focus inside `_wrap_absolute` (a
+    # multi-line continue-on-error script) re-introduces the trap the
+    # round-4 split was designed to prevent — the anchor's leading "✓"
+    # text in the combined response masks the focus error, and `type`
+    # would land in whatever was previously focused.
+    #
+    # So for absolute paths we anchor with a SEPARATE _call_execute
+    # (one-line `cd %here%`), check for error, focus as a separate call
+    # we can _is_error-check, then type, then restore as a separate
+    # best-effort call. All four share the persisted lane via session.
     if is_absolute:
-        # Anchor + focus + restore as one multi-line call, so the focus
-        # lands against the tab root regardless of lane cwd drift.
-        focus_cmd = _wrap_absolute(f"focus {_q(translated_path)}", session)
-    else:
-        focus_cmd = f"focus {_q(translated_path)}"
+        anchor_result = asyncio.run(_call_execute(
+            f"cd {_here_path('')}", use_daemon, session=session,
+        ))
+        if _is_error(anchor_result):
+            # Anchor failed — we never moved, so no restore is needed.
+            return anchor_result
+
     focus_result = asyncio.run(_call_execute(
-        focus_cmd, use_daemon, session=session,
+        f"focus {_q(translated_path)}", use_daemon, session=session,
     ))
     if _is_error(focus_result):
-        return focus_result  # don't type — focus didn't land
-    return asyncio.run(_call_execute(
+        # Focus failed — restore cwd before returning so the lane
+        # doesn't stay parked at the anchor (only relevant when we
+        # actually moved, i.e. the absolute path branch).
+        if is_absolute:
+            asyncio.run(_call_execute(
+                _restore_cwd_cmd(session), use_daemon, session=session,
+            ))
+        return focus_result
+
+    type_result = asyncio.run(_call_execute(
         f"type {_q(text)}", use_daemon, session=session,
     ))
+
+    if is_absolute:
+        # Best-effort restore — type already succeeded, so a restore
+        # failure is cosmetic. The next harness cd will correct any
+        # drift.
+        asyncio.run(_call_execute(
+            _restore_cwd_cmd(session), use_daemon, session=session,
+        ))
+
+    return type_result
 
 
 # ── Daemon control functions ───────────────────────────────────────────

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -24,6 +24,7 @@ import re
 import shlex
 import subprocess
 import shutil
+import threading
 from typing import Any, Optional
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
@@ -80,6 +81,13 @@ _daemon_client_context: Optional[Any] = None  # Store stdio_client context manag
 # pointing to a closed group. Restart the daemon (or reset this attr)
 # to clear.
 _daemon_lane_id: Optional[str] = None
+
+# Synchronizes the first-call capture of _daemon_lane_id. Concurrent
+# callers of _call_execute in daemon mode without a session would
+# otherwise race on the `is None` check below. Lock spans only the
+# check + assignment (microsecond contention), not the MCP call.
+# (Copilot R4 on commit 5790651.)
+_daemon_lane_lock = threading.Lock()
 
 
 def _check_npx() -> bool:
@@ -553,10 +561,14 @@ async def _call_execute(
             # Daemon-level capture on first daemon-no-session call so
             # subsequent calls reuse the same lane regardless of whether
             # the daemon stays alive or we fall back to fresh spawns.
-            if use_daemon and session is None and _daemon_lane_id is None:
-                captured = _extract_lane_id(result)
-                if captured:
-                    _daemon_lane_id = captured
+            # `is None` check moved INSIDE the lock to fix the
+            # test-and-set race between concurrent callers.
+            if use_daemon and session is None:
+                with _daemon_lane_lock:
+                    if _daemon_lane_id is None:
+                        captured = _extract_lane_id(result)
+                        if captured:
+                            _daemon_lane_id = captured
             return result
         except Exception as e:
             # Daemon died — log diagnosability and fall back to spawning
@@ -564,6 +576,7 @@ async def _call_execute(
             # failure mode invisible in user reports.
             log.warning(
                 "DOMShell daemon call failed, respawning per-command: %s", e,
+                exc_info=True,
             )
             await _stop_daemon()
 
@@ -582,11 +595,14 @@ async def _call_execute(
                 )
                 _capture_lane(session, result)
                 # See daemon-path capture above for rationale — same
-                # logic applies on the fresh-spawn fall-back path.
-                if use_daemon and session is None and _daemon_lane_id is None:
-                    captured = _extract_lane_id(result)
-                    if captured:
-                        _daemon_lane_id = captured
+                # logic applies on the fresh-spawn fall-back path,
+                # including the lock-guarded test-and-set.
+                if use_daemon and session is None:
+                    with _daemon_lane_lock:
+                        if _daemon_lane_id is None:
+                            captured = _extract_lane_id(result)
+                            if captured:
+                                _daemon_lane_id = captured
                 return result
     except Exception as e:
         raise RuntimeError(

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -132,11 +132,15 @@ def _q(arg: str) -> str:
     the generic one raised here.
     """
     if "\n" in arg or "\r" in arg:
+        # Bound the echoed value so an arbitrarily large untrusted payload
+        # (e.g. a multi-line paste from the page) doesn't end up verbatim
+        # in error messages or downstream logs / telemetry.
+        preview = arg[:80] + ("…" if len(arg) > 80 else "")
         raise ValueError(
             "Newline characters are not allowed in command arguments — "
             "DOMShell's domshell_execute treats them as command separators, "
             "so a newline inside any wrapper input would inject additional "
-            f"commands. Got: {arg!r}"
+            f"commands. Got ({len(arg)} chars): {preview!r}"
         )
     return shlex.quote(arg)
 
@@ -339,7 +343,7 @@ def daemon_started() -> bool:
 # `domshell_execute`. The public Python API is unchanged from the
 # pre-2.0.0 per-tool wrappers.
 
-def ls(path: str = "/", *, use_daemon: bool = False, session: Any = None) -> dict:
+def ls(path: str = "/", use_daemon: bool = False, *, session: Any = None) -> dict:
     """List directory contents in the accessibility tree.
 
     Args:
@@ -354,11 +358,10 @@ def ls(path: str = "/", *, use_daemon: bool = False, session: Any = None) -> dic
         >>> ls("/")
         {"path": "/", "entries": [{"name": "main", "role": "landmark", ...}]}
     """
-    command = f"ls {_q(path)}" if path else "ls"
-    return asyncio.run(_call_execute(command, use_daemon, session=session))
+    return asyncio.run(_call_execute(f"ls {_q(path)}", use_daemon, session=session))
 
 
-def cd(path: str, *, use_daemon: bool = False, session: Any = None) -> dict:
+def cd(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
     """Change directory in the accessibility tree.
 
     Args:
@@ -376,7 +379,7 @@ def cd(path: str, *, use_daemon: bool = False, session: Any = None) -> dict:
     return asyncio.run(_call_execute(f"cd {_q(path)}", use_daemon, session=session))
 
 
-def cat(path: str, *, use_daemon: bool = False, session: Any = None) -> dict:
+def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
     """Read element content from the accessibility tree.
 
     Args:
@@ -447,7 +450,7 @@ def grep(
     )
 
 
-def click(path: str, *, use_daemon: bool = False, session: Any = None) -> dict:
+def click(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
     """Click an element in the accessibility tree.
 
     Args:
@@ -467,7 +470,7 @@ def click(path: str, *, use_daemon: bool = False, session: Any = None) -> dict:
     )
 
 
-def open_url(url: str, *, use_daemon: bool = False, session: Any = None) -> dict:
+def open_url(url: str, use_daemon: bool = False, *, session: Any = None) -> dict:
     """Navigate to a URL in Chrome.
 
     Args:
@@ -487,7 +490,7 @@ def open_url(url: str, *, use_daemon: bool = False, session: Any = None) -> dict
     )
 
 
-def reload(*, use_daemon: bool = False, session: Any = None) -> dict:
+def reload(use_daemon: bool = False, *, session: Any = None) -> dict:
     """Reload the current page.
 
     Args:
@@ -500,7 +503,7 @@ def reload(*, use_daemon: bool = False, session: Any = None) -> dict:
     return asyncio.run(_call_execute("refresh", use_daemon, session=session))
 
 
-def back(*, use_daemon: bool = False, session: Any = None) -> dict:
+def back(use_daemon: bool = False, *, session: Any = None) -> dict:
     """Navigate back in history.
 
     Args:
@@ -513,7 +516,7 @@ def back(*, use_daemon: bool = False, session: Any = None) -> dict:
     return asyncio.run(_call_execute("back", use_daemon, session=session))
 
 
-def forward(*, use_daemon: bool = False, session: Any = None) -> dict:
+def forward(use_daemon: bool = False, *, session: Any = None) -> dict:
     """Navigate forward in history.
 
     Args:
@@ -529,8 +532,8 @@ def forward(*, use_daemon: bool = False, session: Any = None) -> dict:
 def type_text(
     path: str,
     text: str,
-    *,
     use_daemon: bool = False,
+    *,
     session: Any = None,
 ) -> dict:
     """Type text into an input element.

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -117,7 +117,26 @@ def is_available() -> tuple[bool, str]:
 
 
 def _q(arg: str) -> str:
-    """Quote an argument for the DOMShell command parser (shell-style)."""
+    """Quote an argument for the DOMShell command parser (shell-style).
+
+    Rejects newlines: DOMShell's ``domshell_execute`` splits multi-line
+    input *before* shell-style quote parsing, so a ``\\n`` or ``\\r``
+    inside an otherwise-quoted argument still becomes a command
+    separator. Enforcing the check here means every wrapper that flows
+    user input through ``_q`` is protected by default, instead of
+    relying on per-call ``_assert_single_line`` at each call site.
+
+    Wrappers may still call ``_assert_single_line`` ahead of ``_q`` when a
+    field-named error message (e.g. ``"text: ..."``) is more useful than
+    the generic one raised here.
+    """
+    if "\n" in arg or "\r" in arg:
+        raise ValueError(
+            "Newline characters are not allowed in command arguments — "
+            "DOMShell's domshell_execute treats them as command separators, "
+            "so a newline inside any wrapper input would inject additional "
+            f"commands. Got: {arg!r}"
+        )
     return shlex.quote(arg)
 
 

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -62,6 +62,25 @@ _daemon_read: Optional[Any] = None
 _daemon_write: Optional[Any] = None
 _daemon_client_context: Optional[Any] = None  # Store stdio_client context manager
 
+# Module-level lane id captured from the first daemon-mode-no-session
+# call. Reused on every subsequent daemon-no-session call so direct
+# wrappers like `open_url(use_daemon=True)` followed by
+# `ls(use_daemon=True)` preserve browser state across calls, regardless
+# of whether the daemon's persistent stdio connection is currently
+# alive or whether we've fallen back to spawning a fresh ClientSession
+# per call. The captured id is a numeric Chrome tab-group id, which
+# persists at the browser level even across MCP session boundaries —
+# so a fresh spawn can swapToAgentLane(id) into the lane the previous
+# spawn (or a still-living daemon) created.
+#
+# Stale-lane failure mode: if the user manually closes the Chrome tab
+# group this id points to, subsequent calls will surface DOMShell's
+# "Error: no lane 'A'" with its own recovery guidance. We don't
+# auto-recover here — same shape as `session.domshell_lane_id`
+# pointing to a closed group. Restart the daemon (or reset this attr)
+# to clear.
+_daemon_lane_id: Optional[str] = None
+
 
 def _check_npx() -> bool:
     """Check if npx is available."""
@@ -496,40 +515,31 @@ async def _call_execute(
     Raises:
         RuntimeError: If MCP server is not available or tool call fails
     """
-    global _daemon_session, _daemon_read, _daemon_write
+    global _daemon_session, _daemon_read, _daemon_write, _daemon_lane_id
 
     arguments: dict[str, Any] = {"command": command}
-    # Lane handling. DOMShell 2.0.2 deprecated omitting `group_id`
-    # (emits a [DEPRECATION] warning in the reply; hard error in 3.0.0),
-    # so we name the lane explicitly on every call. Three cases:
-    #   • subsequent calls (session has captured lane) → reuse that lane.
-    #   • non-daemon first call → group_id="new" — DOMShell creates a
-    #     fresh isolated lane and returns its id in the [lane: ...]
-    #     marker, which `_capture_lane` stores on the session for next
-    #     time.
-    #   • daemon-mode first call without a Session → group_id="shared".
-    #     When the persistent daemon connection is live, the default
-    #     per-connection lane stays sticky across calls — so direct
-    #     (sessionless) daemon workflows like `open_url(use_daemon=True)`
-    #     followed by `ls(use_daemon=True)` share browser state without
-    #     needing a Session to carry a lane id.
+    # Lane handling — three sources, in priority order:
+    #   • Session with a captured lane id  → reuse that lane (REPL pattern,
+    #     state preserved across non-daemon spawn-per-call sequences).
+    #   • Daemon mode + no session + previously captured _daemon_lane_id
+    #     → reuse the daemon-level captured id. Works whether the daemon's
+    #     stdio is alive (id reused on persistent connection) or dead
+    #     (fresh spawn joins the existing Chrome tab-group by id).
+    #   • Otherwise → group_id="new". DOMShell creates a fresh isolated
+    #     lane and returns the id in the [lane: ...] marker, captured into
+    #     either session.domshell_lane_id or _daemon_lane_id for next time.
     #
-    #     In the fall-back path (daemon dead / not started — i.e.
-    #     `_daemon_session is None` below), each call spawns its own
-    #     ClientSession, which triggers its own SESSION_START on
-    #     DOMShell and gets its own per-connection default lane.
-    #     "shared" is per-MCP-session, so it still routes correctly
-    #     there — to *that spawn's* default lane — giving per-call
-    #     isolation. Same outcome as omitting `group_id` would have
-    #     pre-2.0.2, minus the [DEPRECATION] warning, and crucially one
-    #     orphan tab-group per spawn instead of two (`group_id="new"`
-    #     would create an explicit second lane on top of the
-    #     SESSION_START default — the orphan flood reverted in commit
-    #     99d1182504).
+    # The "shared" branch from the previous version of this code (commit
+    # 99d1182) is gone. It claimed the per-connection default lane stayed
+    # sticky across calls — true when the persistent daemon connection is
+    # alive, but a lie in the fall-back spawn path where each call gets a
+    # different per-MCP-session default lane. @yuh-yang's review of
+    # b684732 flagged the inconsistency. The module-level capture path
+    # below is consistent across both daemon-alive and daemon-dead.
     if session is not None and getattr(session, "domshell_lane_id", None):
         arguments["group_id"] = session.domshell_lane_id
-    elif use_daemon:
-        arguments["group_id"] = "shared"
+    elif use_daemon and _daemon_lane_id:
+        arguments["group_id"] = _daemon_lane_id
     else:
         arguments["group_id"] = "new"
 
@@ -540,6 +550,13 @@ async def _call_execute(
                 "domshell_execute", arguments
             )
             _capture_lane(session, result)
+            # Daemon-level capture on first daemon-no-session call so
+            # subsequent calls reuse the same lane regardless of whether
+            # the daemon stays alive or we fall back to fresh spawns.
+            if use_daemon and session is None and _daemon_lane_id is None:
+                captured = _extract_lane_id(result)
+                if captured:
+                    _daemon_lane_id = captured
             return result
         except Exception as e:
             # Daemon died — log diagnosability and fall back to spawning
@@ -564,6 +581,12 @@ async def _call_execute(
                     "domshell_execute", arguments
                 )
                 _capture_lane(session, result)
+                # See daemon-path capture above for rationale — same
+                # logic applies on the fresh-spawn fall-back path.
+                if use_daemon and session is None and _daemon_lane_id is None:
+                    captured = _extract_lane_id(result)
+                    if captured:
+                        _daemon_lane_id = captured
                 return result
     except Exception as e:
         raise RuntimeError(
@@ -755,11 +778,14 @@ def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         {"output": "button: Submit\\n..."}
     """
     translated, is_absolute = _translate_path(path)
-    if not translated:
-        raise ValueError(
-            "cat: an element name is required — cannot cat the tab root. "
-            "Use `ls` to list the root's children, or pass a specific name."
-        )
+    # Note: a falsy `translated` (root path `/` or empty string) is no
+    # longer rejected here. Pre-migration `fs cat` at the root surfaced
+    # DOMShell's own `Usage: cat <name>` error string; the round-5 guard
+    # converted that into a Python ValueError, which broke the
+    # `fs.read_element(session, "")` fall-through to `session.working_dir`
+    # for callers landed at `/`. Removed per @yuh-yang R3 review of
+    # `b684732` — `cat ''` reaches DOMShell, which has the same
+    # `if (!targetName)` check and returns its standard Usage error.
     if is_absolute:
         _require_session_for_split_check("cat", session, use_daemon)
         # Split-and-check: anchor at tab root, halt if anchor fails,
@@ -827,6 +853,26 @@ def grep(
         {"matches": ["/main/button[0]"], "raw": "..."}
     """
     _assert_single_line("pattern", pattern)
+
+    # DOMShell's parseArgs treats any arg starting with "-" as a flag,
+    # with no "--" end-of-options separator and no "-e <pattern>" form
+    # (verified against src/background/index.ts:1692 in DOMShell 2.0.2).
+    # So `grep -r -- -foo` and `grep -r -e -foo` both fail at the
+    # kernel — neither survives parseArgs as a positional. Until
+    # DOMShell adds "--" support in a future release, raise a clear
+    # Python-side error so the user sees the limitation immediately
+    # instead of getting DOMShell's generic "Usage:" reply.
+    # (yuh-yang R3 blocker 3, Path B — Python-side soft validation.)
+    if pattern.startswith("-"):
+        raise ValueError(
+            f"grep: patterns starting with '-' are not supported by the "
+            f"current DOMShell parser — it would parse {pattern!r} as a "
+            f"flag rather than as the search pattern. Known limitation "
+            f"tracked upstream; will be resolved when DOMShell's "
+            f"parseArgs adds `--` end-of-options support. Workaround: "
+            f"drop the leading '-' from the pattern if possible, or "
+            f"wait for the upstream fix."
+        )
     translated_path, path_abs = _translate_path(path)
     if not translated_path:
         # Unrooted grep — operate on lane cwd, no cd, no restore.

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -290,6 +290,36 @@ def _anchor_path_cmd(deeper: str = "") -> str:
     return f"cd {_here_path(deeper)}"
 
 
+def _require_session_for_split_check(
+    wrapper: str, session: Any, use_daemon: bool,
+) -> None:
+    """Raise if a split-and-check wrapper would lose lane consistency.
+
+    Split-and-check patterns (anchor → op → restore as separate
+    ``_call_execute`` calls) need all three calls in the same DOMShell
+    lane. In daemon mode the persistent connection guarantees that
+    naturally; otherwise the wrapper needs ``session.domshell_lane_id``
+    to forward via ``group_id`` on each call. Without either, the
+    anchor lands in lane A and the operation lands in lane B — same
+    lane-isolation regression as round-5's first failure mode.
+
+    The general rule: any wrapper that issues multiple
+    ``_call_execute`` calls whose correctness depends on shared lane
+    state requires a session in non-daemon mode. Mirrors the round-6.1
+    guard in ``type_text``; applied to ``ls`` / ``cat`` / ``click``
+    absolute paths and ``grep`` rooted paths (both absolute and
+    relative) in round 7.2. Centralizes the contract so future
+    multi-call wrappers can call into the same check.
+    """
+    if session is None and not use_daemon:
+        raise ValueError(
+            f"{wrapper}: a session argument is required in non-daemon "
+            "mode for rooted paths so the anchor cd and the operation "
+            "share a DOMShell lane. Either pass a Session, use an "
+            "unrooted form, or enable daemon mode."
+        )
+
+
 # CSI (ANSI) escape sequences DOMShell wraps error text in (typically red).
 # Strip them before prefix-matching "error" so an ANSI-coloured error line
 # isn't misread as success.
@@ -404,9 +434,26 @@ def _parse_execute_result(result: Any, command: str) -> dict:
         matches = [ln for ln in text.splitlines() if ln.strip()]
         return {"matches": matches, "raw": text}
 
-    # cd / cat / click / focus / type / open / refresh / back / forward
-    # all funnel through the CLI's generic dict pretty-printer; an
-    # ``{"output": text}`` shape is enough.
+    if command in ("back", "forward", "navigate", "open"):
+        # Navigation commands typically respond with a `URL: <url>`
+        # (and often `Title: <title>`) line — extract both so
+        # `page.go_back` / `page.go_forward`'s `"url" in result` guards
+        # actually fire and `session.set_url` updates correctly. (Round
+        # 7's parser made these guards permanently False; this is the
+        # Codex P2 #1 fix.) The raw `output` is preserved alongside so
+        # CLI display paths still work.
+        nav: dict = {"output": text}
+        url_match = re.search(r"URL:\s+(\S+)", text)
+        if url_match:
+            nav["url"] = url_match.group(1)
+        title_match = re.search(r"Title:\s+(.+?)(?:\r?\n|$)", text)
+        if title_match:
+            nav["title"] = title_match.group(1).strip()
+        return nav
+
+    # cd / cat / click / focus / type / refresh all funnel through the
+    # CLI's generic dict pretty-printer; an ``{"output": text}`` shape
+    # is enough.
     return {"output": text}
 
 
@@ -600,6 +647,7 @@ def ls(path: str = "/", use_daemon: bool = False, *, session: Any = None) -> dic
     """
     translated, is_absolute = _translate_path(path)
     if is_absolute:
+        _require_session_for_split_check("ls", session, use_daemon)
         # Split-and-check: the anchor's success is load-bearing — if
         # cd fails, ls would run in the wrong cwd and produce
         # wrong-target results. Three separate _call_execute calls so
@@ -689,6 +737,7 @@ def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
             "Use `ls` to list the root's children, or pass a specific name."
         )
     if is_absolute:
+        _require_session_for_split_check("cat", session, use_daemon)
         # Split-and-check: anchor at tab root, halt if anchor fails,
         # otherwise run relative cat, restore. Anchor success is
         # load-bearing — without it cat resolves the relative path
@@ -771,6 +820,12 @@ def grep(
     # useful error regardless of which branch consumes it.
     _assert_single_line("prev", prev)
 
+    # Both rooted branches (absolute and relative) issue 3 separate
+    # `_call_execute` calls — anchor cd, grep, restore cd — and depend on
+    # all three landing in the same DOMShell lane. Check session here so
+    # the requirement applies uniformly.
+    _require_session_for_split_check("grep", session, use_daemon)
+
     # Split-and-check. Anchor success is load-bearing: if the cd
     # to the rooting path fails, grep would search against the wrong
     # cwd and produce wrong-scope matches.
@@ -820,6 +875,7 @@ def click(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
             "click: an element name is required — cannot click the tab root."
         )
     if is_absolute:
+        _require_session_for_split_check("click", session, use_daemon)
         # Split-and-check: anchor at tab root, halt if anchor fails,
         # otherwise click the relative path, restore. Anchor success is
         # load-bearing — clicking the wrong element if cwd has drifted
@@ -851,22 +907,22 @@ def open_url(url: str, use_daemon: bool = False, *, session: Any = None) -> dict
         session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
-        Dict shaped ``{"output": str}`` on success, or
-        ``{"error": str, "output": str}`` on failure.
+        Dict shaped ``{"output": str, "url": str, "title": str}`` on
+        success, or ``{"error": str, "output": str}`` on failure.
 
-        Note no ``"url"`` key. ``page.open_page`` already calls
-        ``session.set_url(url)`` from the input arg unconditionally, so
-        this isn't a regression for ``open_url`` callers. But the same
-        absence applies to ``back()`` / ``forward()`` — ``page.go_back``
-        and ``page.go_forward`` guard their ``session.set_url`` updates
-        on ``"url" in result``, and that guard now always evaluates
-        False (it was already False against the pre-parse
-        ``CallToolResult`` shape, so no behavior change vs main, but
-        worth knowing for future parser refinement).
+        ``url`` and ``title`` are extracted from the DOMShell response
+        text via regex (lines starting ``URL:`` / ``Title:``) — they're
+        present when DOMShell emits those lines, omitted otherwise.
+        ``page.open_page`` doesn't depend on ``url`` (it always calls
+        ``session.set_url(url)`` from the input arg), but the same
+        parser is used by ``back`` / ``forward`` whose ``page``-layer
+        callers DO depend on ``"url" in result``.
 
     Example:
         >>> open_url("https://example.com")
-        {"output": "✓ Opened https://example.com\\n[lane: 1]"}
+        {"output": "✓ Opened\\nURL: https://example.com\\nTitle: Example Domain\\n[lane: 1]",
+         "url": "https://example.com",
+         "title": "Example Domain"}
     """
     result = asyncio.run(
         _call_execute(f"open {_q(url)}", use_daemon, session=session)
@@ -896,15 +952,13 @@ def back(use_daemon: bool = False, *, session: Any = None) -> dict:
         session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
-        Dict shaped ``{"output": str}`` on success, or
-        ``{"error": str, "output": str}`` on failure.
-
-        Note no ``"url"`` key. ``page.go_back`` guards its
-        ``session.set_url`` update on ``"url" in result`` and that
-        guard now always evaluates False — ``session.current_url`` is
-        not updated from a back navigation. (Same end behavior as
-        against the pre-parse ``CallToolResult`` shape, but worth
-        knowing for future parser refinement.)
+        Dict shaped ``{"output": str, "url": str, "title": str}`` on
+        success, or ``{"error": str, "output": str}`` on failure. ``url``
+        and ``title`` are extracted from the response text via regex
+        (lines starting ``URL:`` / ``Title:``) and may be omitted if
+        the response shape changes upstream — ``page.go_back`` guards
+        its ``session.set_url`` update on ``"url" in result``, so a
+        missing URL silently skips the update.
     """
     result = asyncio.run(_call_execute("back", use_daemon, session=session))
     return _parse_execute_result(result, "back")
@@ -918,15 +972,13 @@ def forward(use_daemon: bool = False, *, session: Any = None) -> dict:
         session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
-        Dict shaped ``{"output": str}`` on success, or
-        ``{"error": str, "output": str}`` on failure.
-
-        Note no ``"url"`` key. ``page.go_forward`` guards its
-        ``session.set_url`` update on ``"url" in result`` and that
-        guard now always evaluates False — ``session.current_url`` is
-        not updated from a forward navigation. (Same end behavior as
-        against the pre-parse ``CallToolResult`` shape, but worth
-        knowing for future parser refinement.)
+        Dict shaped ``{"output": str, "url": str, "title": str}`` on
+        success, or ``{"error": str, "output": str}`` on failure. ``url``
+        and ``title`` are extracted from the response text via regex
+        (lines starting ``URL:`` / ``Title:``) and may be omitted if
+        the response shape changes upstream — ``page.go_forward`` guards
+        its ``session.set_url`` update on ``"url" in result``, so a
+        missing URL silently skips the update.
     """
     result = asyncio.run(_call_execute("forward", use_daemon, session=session))
     return _parse_execute_result(result, "forward")

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -297,32 +297,55 @@ _ANSI_CSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
 
 def _is_error(result: Any) -> bool:
-    """Best-effort check that a ``domshell_execute`` result represents an error.
+    """Detect whether a ``domshell_execute`` result represents an error.
 
-    Inspects ``isError`` if the MCP SDK populated it, then ``isError`` /
-    ``error`` keys on dict-shaped test fixtures, and finally scans the
-    concatenated text content for a leading "error" — with ANSI escape
-    sequences stripped first, since DOMShell colours error lines red
-    (``\\x1b[31mError: ...\\x1b[0m``). Robust to the raw
-    ``CallToolResult`` and to ``SimpleNamespace(content=[...])`` test
-    fixtures.
+    DOMShell's actual error shape (verified upstream) is ANSI-red-wrapped
+    AND command-prefixed, e.g.:
+
+    * ``\\x1b[31mcd: foo: No such directory\\x1b[0m``
+    * ``\\x1b[31mfocus: No such element\\x1b[0m``
+    * ``\\x1b[31mls: main: No such directory\\x1b[0m``
+
+    Note none of these start with the literal "error" — the earlier
+    detection that ANSI-stripped first then checked ``startswith("error")``
+    silently failed every command-prefixed case, which silently regressed
+    the safety chain across ``ls`` / ``cat`` / ``click`` / ``grep`` /
+    ``type_text`` (Codex PR #308 round 7+). The fix: detect the
+    ``\\x1b[31m`` red color marker BEFORE ANSI stripping — DOMShell wraps
+    every error in red and uses different codes (e.g. ``\\x1b[32m``
+    green) for success.
+
+    Inspects ``isError`` and dict ``error``/``isError`` keys first
+    (covers the MCP SDK's explicit error flag and dict test fixtures),
+    then the ANSI-red marker, with a final fallback to a stripped
+    ``Error:`` prefix for any input that has been pre-stripped (e.g. by
+    a transport layer) or that arrives without DOMShell's coloring.
     """
     if hasattr(result, "isError") and result.isError:
         return True
     if isinstance(result, dict):
-        if result.get("isError"):
+        if result.get("isError") or result.get("error"):
             return True
-        if "error" in result:
-            return True
-    text = ""
-    content = getattr(result, "content", None)
-    if content:
-        for c in content:
-            piece = getattr(c, "text", None)
-            if piece:
-                text += piece
-    text = _ANSI_CSI_RE.sub("", text)
-    return text.strip().lower().startswith("error")
+
+    text = _extract_text(result)
+    if not text:
+        return False
+
+    # DOMShell wraps errors in ANSI red. Detect BEFORE stripping; the
+    # color code IS the signal, and the message that follows is
+    # typically command-prefixed (cd: …, focus: …, ls: …) rather than
+    # "Error:"-prefixed.
+    if "\x1b[31m" in text:
+        return True
+
+    # Fallback: ANSI-stripped text with explicit "Error:" prefix.
+    # Catches rarer non-colored errors and any input that arrives
+    # pre-stripped.
+    cleaned = _ANSI_CSI_RE.sub("", text).strip().lower()
+    if cleaned.startswith("error:"):
+        return True
+
+    return False
 
 
 def _extract_text(result: Any) -> str:
@@ -558,11 +581,22 @@ def ls(path: str = "/", use_daemon: bool = False, *, session: Any = None) -> dic
         session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
-        Dict with 'entries' key containing list of accessible elements
+        Dict shaped ``{"entries": [{"name": str, "role": "", "path": str}, ...],
+        "raw": str}`` (or ``{"error": str, "output": str}`` on failure —
+        wrappers reuse ``_parse_execute_result``'s contract).
+
+        ``name`` and ``path`` carry the raw line text from DOMShell's
+        ``ls`` output; directory entries currently include a trailing
+        ``/`` (cosmetic, see follow-up). ``role`` is always empty in
+        this round — structured role extraction will land alongside a
+        finer column parser in the follow-up.
 
     Example:
-        >>> ls("/")
-        {"path": "/", "entries": [{"name": "main", "role": "landmark", ...}]}
+        >>> ls("/main")
+        {"entries": [{"name": "heading_1", "role": "", "path": "heading_1"},
+                     {"name": "div/",      "role": "", "path": "div/"},
+                     ...],
+         "raw": "heading_1\\ndiv/\\n..."}
     """
     translated, is_absolute = _translate_path(path)
     if is_absolute:
@@ -601,11 +635,21 @@ def cd(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
-        Dict with 'path' key confirming current location
+        Dict shaped ``{"output": str}`` on success, or
+        ``{"error": str, "output": str}`` on failure.
+
+        Note no ``"path"`` key — ``fs.change_directory`` falls back to
+        the input ``path`` arg via ``result.get("path", path)``, so the
+        harness's ``working_dir`` ends up at the requested target. The
+        ``output`` field carries DOMShell's raw confirmation text for
+        display.
 
     Example:
         >>> cd("/main/div[0]")
-        {"path": "/main/div[0]", "element": {...}}
+        {"output": "✓ Entered /main/div[0]"}
+        >>> cd("/missing")
+        {"error": "cd: /missing: No such directory",
+         "output": "cd: /missing: No such directory"}
     """
     translated, is_absolute = _translate_path(path)
     # cd is the one wrapper where the operation IS the new state — no
@@ -718,7 +762,13 @@ def grep(
         ))
         return _parse_execute_result(op, "grep")
 
-    _assert_single_line("path", path)
+    # `path` was already newline-guarded by `_translate_path` above
+    # (round 6's translation-boundary check) so the field-named
+    # `_assert_single_line("path", path)` we used to call here would be
+    # dead. `prev`, however, is only translated in the relative branch
+    # below — the absolute branch doesn't touch it. Keep the explicit
+    # field-named guard for `prev` so a newlined-prev kwarg raises a
+    # useful error regardless of which branch consumes it.
     _assert_single_line("prev", prev)
 
     # Split-and-check. Anchor success is load-bearing: if the cd
@@ -801,11 +851,22 @@ def open_url(url: str, use_daemon: bool = False, *, session: Any = None) -> dict
         session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
-        Dict with navigation result
+        Dict shaped ``{"output": str}`` on success, or
+        ``{"error": str, "output": str}`` on failure.
+
+        Note no ``"url"`` key. ``page.open_page`` already calls
+        ``session.set_url(url)`` from the input arg unconditionally, so
+        this isn't a regression for ``open_url`` callers. But the same
+        absence applies to ``back()`` / ``forward()`` — ``page.go_back``
+        and ``page.go_forward`` guard their ``session.set_url`` updates
+        on ``"url" in result``, and that guard now always evaluates
+        False (it was already False against the pre-parse
+        ``CallToolResult`` shape, so no behavior change vs main, but
+        worth knowing for future parser refinement).
 
     Example:
         >>> open_url("https://example.com")
-        {"url": "https://example.com", "status": "loaded"}
+        {"output": "✓ Opened https://example.com\\n[lane: 1]"}
     """
     result = asyncio.run(
         _call_execute(f"open {_q(url)}", use_daemon, session=session)
@@ -835,7 +896,15 @@ def back(use_daemon: bool = False, *, session: Any = None) -> dict:
         session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
-        Dict with navigation result
+        Dict shaped ``{"output": str}`` on success, or
+        ``{"error": str, "output": str}`` on failure.
+
+        Note no ``"url"`` key. ``page.go_back`` guards its
+        ``session.set_url`` update on ``"url" in result`` and that
+        guard now always evaluates False — ``session.current_url`` is
+        not updated from a back navigation. (Same end behavior as
+        against the pre-parse ``CallToolResult`` shape, but worth
+        knowing for future parser refinement.)
     """
     result = asyncio.run(_call_execute("back", use_daemon, session=session))
     return _parse_execute_result(result, "back")
@@ -849,7 +918,15 @@ def forward(use_daemon: bool = False, *, session: Any = None) -> dict:
         session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
-        Dict with navigation result
+        Dict shaped ``{"output": str}`` on success, or
+        ``{"error": str, "output": str}`` on failure.
+
+        Note no ``"url"`` key. ``page.go_forward`` guards its
+        ``session.set_url`` update on ``"url" in result`` and that
+        guard now always evaluates False — ``session.current_url`` is
+        not updated from a forward navigation. (Same end behavior as
+        against the pre-parse ``CallToolResult`` shape, but worth
+        knowing for future parser refinement.)
     """
     result = asyncio.run(_call_execute("forward", use_daemon, session=session))
     return _parse_execute_result(result, "forward")

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -186,6 +186,55 @@ def _capture_lane(session: Any, result: Any) -> None:
         session.domshell_lane_id = lane
 
 
+def _translate_path(harness_path: str) -> str:
+    """Translate a harness DOM path to a DOMShell command path.
+
+    The harness models ``/`` as the focused tab's AX root. DOMShell models
+    ``~/`` (and bare ``/``) as the BROWSER root — windows and tabs.
+    Sending ``ls /`` verbatim would list tabs, not page elements. Strip
+    the leading ``/`` so harness ``/main`` becomes DOMShell ``main``
+    (relative to the lane's cwd, which IS the focused tab's AX root once
+    ``page open`` has put the lane inside the tab).
+
+    - ``""`` and ``"/"`` → ``""`` (signal: operate on lane cwd; the
+      wrappers turn this into a bare command, e.g. ``ls`` or ``cd %here%``).
+    - ``"/main"`` → ``"main"``
+    - ``"/main/article"`` → ``"main/article"``
+    - ``"main"``, ``".."``, ``"."`` → passed through unchanged.
+    """
+    if not harness_path or harness_path == "/":
+        return ""
+    if harness_path.startswith("/"):
+        return harness_path[1:]
+    return harness_path
+
+
+def _is_error(result: Any) -> bool:
+    """Best-effort check that a ``domshell_execute`` result represents an error.
+
+    Inspects ``isError`` if the MCP SDK populated it, then ``isError`` /
+    ``error`` keys on dict-shaped test fixtures, and finally scans the
+    concatenated text content for a leading "error". Robust to the raw
+    ``CallToolResult`` and to the ``SimpleNamespace(content=[...])``
+    fixtures used in tests.
+    """
+    if hasattr(result, "isError") and result.isError:
+        return True
+    if isinstance(result, dict):
+        if result.get("isError"):
+            return True
+        if "error" in result:
+            return True
+    text = ""
+    content = getattr(result, "content", None)
+    if content:
+        for c in content:
+            piece = getattr(c, "text", None)
+            if piece:
+                text += piece
+    return text.strip().lower().startswith("error")
+
+
 def _assert_single_line(field: str, value: str) -> None:
     """Reject newline characters in a user-supplied string.
 
@@ -358,7 +407,9 @@ def ls(path: str = "/", use_daemon: bool = False, *, session: Any = None) -> dic
         >>> ls("/")
         {"path": "/", "entries": [{"name": "main", "role": "landmark", ...}]}
     """
-    return asyncio.run(_call_execute(f"ls {_q(path)}", use_daemon, session=session))
+    translated = _translate_path(path)
+    command = f"ls {_q(translated)}" if translated else "ls"
+    return asyncio.run(_call_execute(command, use_daemon, session=session))
 
 
 def cd(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
@@ -376,7 +427,12 @@ def cd(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         >>> cd("/main/div[0]")
         {"path": "/main/div[0]", "element": {...}}
     """
-    return asyncio.run(_call_execute(f"cd {_q(path)}", use_daemon, session=session))
+    translated = _translate_path(path)
+    # Harness `cd /` means "back to focused-tab AX root" — DOMShell's
+    # equivalent is `cd %here%`, which jumps to the tab root regardless
+    # of where the lane wandered to.
+    command = "cd %here%" if not translated else f"cd {_q(translated)}"
+    return asyncio.run(_call_execute(command, use_daemon, session=session))
 
 
 def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
@@ -394,7 +450,13 @@ def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         >>> cat("/main/button[0]")
         {"name": "Submit", "role": "button", "text": "Submit", ...}
     """
-    return asyncio.run(_call_execute(f"cat {_q(path)}", use_daemon, session=session))
+    translated = _translate_path(path)
+    if not translated:
+        raise ValueError(
+            "cat: an element name is required — cannot cat the tab root. "
+            "Use `ls` to list the root's children, or pass a specific name."
+        )
+    return asyncio.run(_call_execute(f"cat {_q(translated)}", use_daemon, session=session))
 
 
 def grep(
@@ -440,10 +502,18 @@ def grep(
         {"matches": ["/main/button[0]"]}
     """
     _assert_single_line("pattern", pattern)
-    if path and path != "/":
+    translated_path = _translate_path(path)
+    translated_prev = _translate_path(prev)
+    if translated_path:
         _assert_single_line("path", path)
         _assert_single_line("prev", prev)
-        command = f"cd {_q(path)}\ngrep {_q(pattern)}\ncd {_q(prev)}"
+        # Harness `/` (the default for `prev`) means "back to focused-tab
+        # AX root", which is DOMShell's `cd %here%`. Any other restore
+        # path becomes `cd <translated>`.
+        restore = (
+            f"cd {_q(translated_prev)}" if translated_prev else "cd %here%"
+        )
+        command = f"cd {_q(translated_path)}\ngrep {_q(pattern)}\n{restore}"
         return asyncio.run(_call_execute(command, use_daemon, session=session))
     return asyncio.run(
         _call_execute(f"grep {_q(pattern)}", use_daemon, session=session)
@@ -465,8 +535,13 @@ def click(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         >>> click("/main/button[0]")
         {"action": "click", "path": "/main/button[0]", "status": "success"}
     """
+    translated = _translate_path(path)
+    if not translated:
+        raise ValueError(
+            "click: an element name is required — cannot click the tab root."
+        )
     return asyncio.run(
-        _call_execute(f"click {_q(path)}", use_daemon, session=session)
+        _call_execute(f"click {_q(translated)}", use_daemon, session=session)
     )
 
 
@@ -538,17 +613,28 @@ def type_text(
 ) -> dict:
     """Type text into an input element.
 
-    Focuses the element and types in a single ``domshell_execute`` call so
-    focus state is guaranteed to be in place when ``type`` runs (one MCP
-    round-trip, atomic).
+    Issued as two separate ``domshell_execute`` calls — ``focus``, check
+    for error, then ``type`` only if ``focus`` succeeded. Both share the
+    persisted lane id (via ``session``), so the focus state from the
+    first call carries into the second.
+
+    Why split: DOMShell's multi-line splitter continues past per-line
+    errors (apireno/DOMShell#46). That's the right semantic for cleanup
+    chains like ``cd / grep / cd back`` (the restore must always run)
+    but the WRONG semantic for safety chains like ``focus / type`` — a
+    failed ``focus`` followed by a successful ``type`` would dispatch
+    keys into whatever was previously focused (potentially a password
+    field). Halting between focus and type prevents that.
 
     Args:
         path: Path to input element
         text: Text to type
         use_daemon: Use persistent daemon connection if available
+        session: Harness session whose DOMShell lane id is reused / updated
 
     Returns:
-        Dict with action result
+        Dict with action result. If ``focus`` errors, returns the focus
+        result without calling ``type``.
 
     Raises:
         ValueError: If ``path`` or ``text`` contains a newline. DOMShell's
@@ -558,8 +644,24 @@ def type_text(
     """
     _assert_single_line("path", path)
     _assert_single_line("text", text)
-    command = f"focus {_q(path)}\ntype {_q(text)}"
-    return asyncio.run(_call_execute(command, use_daemon, session=session))
+    translated_path = _translate_path(path)
+    if not translated_path:
+        raise ValueError(
+            "type_text: an element name is required — cannot focus the tab root."
+        )
+    # Relies on DOMShell serializing commands within a lane: the `type`
+    # call below cannot be preempted by another agent's `focus` on the
+    # same lane between these two _call_execute boundaries. If that
+    # contract ever changes upstream, this needs to revert to a single
+    # multi-line call with an alternative safety story.
+    focus_result = asyncio.run(_call_execute(
+        f"focus {_q(translated_path)}", use_daemon, session=session,
+    ))
+    if _is_error(focus_result):
+        return focus_result  # don't type — focus didn't land
+    return asyncio.run(_call_execute(
+        f"type {_q(text)}", use_daemon, session=session,
+    ))
 
 
 # ── Daemon control functions ───────────────────────────────────────────

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -806,8 +806,12 @@ def grep(
     translated_path, path_abs = _translate_path(path)
     if not translated_path:
         # Unrooted grep — operate on lane cwd, no cd, no restore.
+        # `-r` preserves the pre-migration semantic: the old
+        # `domshell_grep` tool defaulted to recursive=True (walk all
+        # descendants). Plain `grep <pat>` in DOMShell shell only
+        # searches the cwd's immediate children, missing nested matches.
         op = asyncio.run(_call_execute(
-            f"grep {_q(pattern)}", use_daemon, session=session,
+            f"grep -r {_q(pattern)}", use_daemon, session=session,
         ))
         return _parse_execute_result(op, "grep")
 
@@ -847,8 +851,10 @@ def grep(
     anchor = asyncio.run(_call_execute(anchor_cmd, use_daemon, session=session))
     if _is_error(anchor):
         return _parse_execute_result(anchor, "grep")
+    # `-r` preserves the pre-migration recursive default (see unrooted
+    # branch above for the full rationale).
     op = asyncio.run(_call_execute(
-        f"grep {_q(pattern)}", use_daemon, session=session,
+        f"grep -r {_q(pattern)}", use_daemon, session=session,
     ))
     asyncio.run(_call_execute(restore_cmd, use_daemon, session=session))
     return _parse_execute_result(op, "grep")

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -499,21 +499,26 @@ async def _call_execute(
     global _daemon_session, _daemon_read, _daemon_write
 
     arguments: dict[str, Any] = {"command": command}
-    # Lane handling for non-daemon mode: every fresh stdio ClientSession
-    # would otherwise be assigned a brand-new lane, scattering `page open`
-    # / `fs ls` / etc. across disjoint browser state. So we name the lane
-    # explicitly on every call:
-    #   • subsequent calls   → group_id=<previously captured lane id>
-    #   • very first call    → group_id="new" — DOMShell creates a fresh
-    #     isolated lane and returns its id in the [lane: ...] marker,
-    #     which `_capture_lane` stores on the session for next time.
-    # DOMShell 2.0.2 deprecated omitting `group_id` entirely (emits a
-    # [DEPRECATION] warning in the reply; hard error in 3.0.0). Passing
-    # "new" on the first call matches our actual intent — we want our own
-    # private lane, not the shared one — and silences the deprecation
-    # warning across every REPL session.
+    # Lane handling. DOMShell 2.0.2 deprecated omitting `group_id`
+    # (emits a [DEPRECATION] warning in the reply; hard error in 3.0.0),
+    # so we name the lane explicitly on every call. Three cases:
+    #   • subsequent calls (session has captured lane) → reuse that lane.
+    #   • non-daemon first call → group_id="new" — DOMShell creates a
+    #     fresh isolated lane and returns its id in the [lane: ...]
+    #     marker, which `_capture_lane` stores on the session for next
+    #     time.
+    #   • daemon-mode first call without a Session → group_id="shared"
+    #     — the daemon's persistent connection has its own default lane
+    #     that stays sticky across calls, so direct (sessionless) daemon
+    #     workflows like `open_url(use_daemon=True)` followed by
+    #     `ls(use_daemon=True)` share browser state naturally. Using
+    #     "new" here would mint a fresh isolated lane per call and lose
+    #     the page just opened (Codex P2 regression caught on the
+    #     initial 2.0.2 migration commit be62f843b5).
     if session is not None and getattr(session, "domshell_lane_id", None):
         arguments["group_id"] = session.domshell_lane_id
+    elif use_daemon:
+        arguments["group_id"] = "shared"
     else:
         arguments["group_id"] = "new"
 

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -278,32 +278,16 @@ def _restore_cwd_cmd(session: Any) -> str:
     return f"cd {_q(stripped)}" if stripped else f"cd {_here_path('')}"
 
 
-def _wrap_absolute(operation: str, session: Any, *, deeper: str = "") -> str:
-    """Build a ``cd %here%[/deeper]\\n<operation>\\n<restore>`` triplet for
-    absolute harness paths, so the operation runs against the tab root
-    regardless of lane cwd drift.
+def _anchor_path_cmd(deeper: str = "") -> str:
+    """Build a single ``cd %here%[/<deeper>]`` command line, shell-quoted.
 
-    USE FOR cleanup-line idioms ONLY — operations whose error doesn't gate
-    further wrapper-side action (``ls``, ``cat``, ``click``, ``grep``).
-    DOMShell's multi-line semantics continue past per-line errors, which
-    is the correct property for "always run the restore" but the WRONG
-    property for **safety chains** where the second step depends on the
-    first step's success. For safety chains (e.g. ``type_text``'s
-    ``focus → type``), issue anchor / operation / restore as SEPARATE
-    ``_call_execute`` calls and ``_is_error``-check between them. See
-    ``type_text``'s absolute-path branch for the pattern.
-
-    ``deeper`` is the optional tab-root-relative subdir to ``cd`` into
-    BEFORE the operation. Used for ``ls /main`` where the operation is
-    bare ``ls`` (and the ``/main`` needs to become the anchored cwd) as
-    opposed to ``cat /main/btn`` where the operation already carries the
-    relative path and we just anchor at the tab root.
-
-    The ``%here%/<deeper>`` token is shell-quoted as a single unit via
-    ``_here_path``, so paths containing whitespace or other shell
-    metacharacters survive the wrap correctly.
+    The reusable anchor primitive for split-and-check wrapper patterns.
+    Every absolute-path wrapper (ls/cat/click/grep) issues this as its
+    first ``_call_execute``, then ``_is_error``-checks the result before
+    running the operation. Used for the anchor and restore positions in
+    the split-and-check pattern.
     """
-    return f"cd {_here_path(deeper)}\n{operation}\n{_restore_cwd_cmd(session)}"
+    return f"cd {_here_path(deeper)}"
 
 
 # CSI (ANSI) escape sequences DOMShell wraps error text in (typically red).
@@ -339,6 +323,68 @@ def _is_error(result: Any) -> bool:
                 text += piece
     text = _ANSI_CSI_RE.sub("", text)
     return text.strip().lower().startswith("error")
+
+
+def _extract_text(result: Any) -> str:
+    """Concatenate ``content[*].text`` from a CallToolResult-like object."""
+    text = ""
+    content = getattr(result, "content", None)
+    if content:
+        for c in content:
+            piece = getattr(c, "text", None)
+            if piece:
+                text += piece
+    return text
+
+
+def _parse_execute_result(result: Any, command: str) -> dict:
+    """Translate a ``domshell_execute`` text response into the dict shape
+    ``browser_cli.py`` and friends consume.
+
+    DOMShell 2.x returns text content over MCP (plus a trailing
+    ``[lane: <id>]`` marker). The CLI was written for the pre-2.0
+    per-command tools, which returned structured dicts — so without
+    this translator the harness throws ``AttributeError`` on
+    ``result.get("entries")`` / ``result.get("matches")`` etc.
+
+    The shape contract per command (read off the CLI callers):
+
+    * ``ls``  → ``{"entries": [{"name", "role", "path"}, ...], "raw"}``
+    * ``grep``→ ``{"matches": [...], "raw"}``
+    * error  → ``{"error": text, "output": text}`` (caller checks
+      ``"error" in result`` before normal handling)
+    * other  → ``{"output": text}`` (CLI's ``output()`` / ``_print_dict``
+      handles arbitrary dicts; ``page.go_back/forward`` skip the
+      ``set_url`` step if ``"url"`` is absent, matching today's behavior)
+
+    This is a minimum-viable parser that satisfies the dict-key
+    contract. Finer-grained parsing of element name / role / path
+    columns can land as a follow-up once DOMShell's exact text format
+    stabilizes — for now every line is plumbed through as the ``name``
+    field (and the ``path`` field) so the CLI's table view still
+    renders rather than crashing.
+    """
+    text = _LANE_LINE.sub("", _extract_text(result)).strip()
+
+    if _is_error(result):
+        return {"error": text, "output": text}
+
+    if command == "ls":
+        lines = [ln for ln in text.splitlines() if ln.strip()]
+        entries = [
+            {"name": ln.strip(), "role": "", "path": ln.strip()}
+            for ln in lines
+        ]
+        return {"entries": entries, "raw": text}
+
+    if command == "grep":
+        matches = [ln for ln in text.splitlines() if ln.strip()]
+        return {"matches": matches, "raw": text}
+
+    # cd / cat / click / focus / type / open / refresh / back / forward
+    # all funnel through the CLI's generic dict pretty-printer; an
+    # ``{"output": text}`` shape is enough.
+    return {"output": text}
 
 
 def _assert_single_line(field: str, value: str) -> None:
@@ -520,14 +566,30 @@ def ls(path: str = "/", use_daemon: bool = False, *, session: Any = None) -> dic
     """
     translated, is_absolute = _translate_path(path)
     if is_absolute:
-        # `ls /main`: cd to %here%/main, run bare ls, restore.
-        # `ls /`:     cd to %here%,      run bare ls, restore.
-        command = _wrap_absolute("ls", session, deeper=translated)
-    elif translated:
-        command = f"ls {_q(translated)}"
+        # Split-and-check: the anchor's success is load-bearing — if
+        # cd fails, ls would run in the wrong cwd and produce
+        # wrong-target results. Three separate _call_execute calls so
+        # we can _is_error-gate after the anchor and skip the operation
+        # cleanly. All share the persisted lane via session.
+        anchor = asyncio.run(_call_execute(
+            _anchor_path_cmd(translated), use_daemon, session=session,
+        ))
+        if _is_error(anchor):
+            return _parse_execute_result(anchor, "ls")
+        op = asyncio.run(_call_execute("ls", use_daemon, session=session))
+        # Best-effort restore — ls already ran; restore failure is
+        # cosmetic (next harness cd corrects any drift).
+        asyncio.run(_call_execute(
+            _restore_cwd_cmd(session), use_daemon, session=session,
+        ))
+        return _parse_execute_result(op, "ls")
+    if translated:
+        op = asyncio.run(_call_execute(
+            f"ls {_q(translated)}", use_daemon, session=session,
+        ))
     else:
-        command = "ls"
-    return asyncio.run(_call_execute(command, use_daemon, session=session))
+        op = asyncio.run(_call_execute("ls", use_daemon, session=session))
+    return _parse_execute_result(op, "ls")
 
 
 def cd(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
@@ -546,17 +608,19 @@ def cd(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         {"path": "/main/div[0]", "element": {...}}
     """
     translated, is_absolute = _translate_path(path)
-    # cd is the rare case where the operation IS the new state — no
-    # restore needed. Absolute targets anchor via `cd %here%/<rest>` so
+    # cd is the one wrapper where the operation IS the new state — no
+    # following operation needs the anchored cwd, so no split-and-check
+    # and no restore. Absolute targets anchor via `cd %here%/<rest>` so
     # the result is independent of the lane's current cwd.
     if is_absolute:
-        command = f"cd {_here_path(translated)}"
+        command = _anchor_path_cmd(translated)
     elif translated:
         command = f"cd {_q(translated)}"
     else:
         # Bare/empty `cd` → back to tab root.
-        command = f"cd {_here_path('')}"
-    return asyncio.run(_call_execute(command, use_daemon, session=session))
+        command = _anchor_path_cmd("")
+    result = asyncio.run(_call_execute(command, use_daemon, session=session))
+    return _parse_execute_result(result, "cd")
 
 
 def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
@@ -581,12 +645,26 @@ def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
             "Use `ls` to list the root's children, or pass a specific name."
         )
     if is_absolute:
-        # `cat /main/btn`: anchor at tab root, run `cat main/btn` relative,
-        # restore the harness's tracked cwd.
-        command = _wrap_absolute(f"cat {_q(translated)}", session)
-    else:
-        command = f"cat {_q(translated)}"
-    return asyncio.run(_call_execute(command, use_daemon, session=session))
+        # Split-and-check: anchor at tab root, halt if anchor fails,
+        # otherwise run relative cat, restore. Anchor success is
+        # load-bearing — without it cat resolves the relative path
+        # against the wrong cwd.
+        anchor = asyncio.run(_call_execute(
+            _anchor_path_cmd(""), use_daemon, session=session,
+        ))
+        if _is_error(anchor):
+            return _parse_execute_result(anchor, "cat")
+        op = asyncio.run(_call_execute(
+            f"cat {_q(translated)}", use_daemon, session=session,
+        ))
+        asyncio.run(_call_execute(
+            _restore_cwd_cmd(session), use_daemon, session=session,
+        ))
+        return _parse_execute_result(op, "cat")
+    op = asyncio.run(_call_execute(
+        f"cat {_q(translated)}", use_daemon, session=session,
+    ))
+    return _parse_execute_result(op, "cat")
 
 
 def grep(
@@ -635,36 +713,40 @@ def grep(
     translated_path, path_abs = _translate_path(path)
     if not translated_path:
         # Unrooted grep — operate on lane cwd, no cd, no restore.
-        return asyncio.run(
-            _call_execute(f"grep {_q(pattern)}", use_daemon, session=session)
-        )
+        op = asyncio.run(_call_execute(
+            f"grep {_q(pattern)}", use_daemon, session=session,
+        ))
+        return _parse_execute_result(op, "grep")
 
     _assert_single_line("path", path)
     _assert_single_line("prev", prev)
 
+    # Split-and-check. Anchor success is load-bearing: if the cd
+    # to the rooting path fails, grep would search against the wrong
+    # cwd and produce wrong-scope matches.
     if path_abs:
-        # Absolute path: anchor at `%here%/<target>`, grep, restore to the
-        # harness's tracked working_dir (so the lane cwd doesn't drift).
-        # The `%here%/<target>` token is quoted as a single unit by
-        # `_here_path` — survives whitespace / shell metachars cleanly.
-        cd_line = f"cd {_here_path(translated_path)}"
-        restore = _restore_cwd_cmd(session)
+        anchor_cmd = _anchor_path_cmd(translated_path)
+        restore_cmd = _restore_cwd_cmd(session)
     else:
-        # Relative path: lane cwd is the right reference. `prev` defaults
-        # to "/" — for relative grep we just go back to whatever caller
-        # asked, shell-quoted (or `%here%/...` for absolute prev).
         translated_prev, prev_abs = _translate_path(prev)
-        cd_line = f"cd {_q(translated_path)}"
+        anchor_cmd = f"cd {_q(translated_path)}"
         if prev_abs:
-            restore = f"cd {_here_path(translated_prev)}"
+            restore_cmd = _anchor_path_cmd(translated_prev)
         else:
-            restore = (
+            restore_cmd = (
                 f"cd {_q(translated_prev)}"
                 if translated_prev
-                else f"cd {_here_path('')}"
+                else _anchor_path_cmd("")
             )
-    command = f"{cd_line}\ngrep {_q(pattern)}\n{restore}"
-    return asyncio.run(_call_execute(command, use_daemon, session=session))
+
+    anchor = asyncio.run(_call_execute(anchor_cmd, use_daemon, session=session))
+    if _is_error(anchor):
+        return _parse_execute_result(anchor, "grep")
+    op = asyncio.run(_call_execute(
+        f"grep {_q(pattern)}", use_daemon, session=session,
+    ))
+    asyncio.run(_call_execute(restore_cmd, use_daemon, session=session))
+    return _parse_execute_result(op, "grep")
 
 
 def click(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
@@ -688,10 +770,26 @@ def click(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
             "click: an element name is required — cannot click the tab root."
         )
     if is_absolute:
-        command = _wrap_absolute(f"click {_q(translated)}", session)
-    else:
-        command = f"click {_q(translated)}"
-    return asyncio.run(_call_execute(command, use_daemon, session=session))
+        # Split-and-check: anchor at tab root, halt if anchor fails,
+        # otherwise click the relative path, restore. Anchor success is
+        # load-bearing — clicking the wrong element if cwd has drifted
+        # could trigger an unintended action.
+        anchor = asyncio.run(_call_execute(
+            _anchor_path_cmd(""), use_daemon, session=session,
+        ))
+        if _is_error(anchor):
+            return _parse_execute_result(anchor, "click")
+        op = asyncio.run(_call_execute(
+            f"click {_q(translated)}", use_daemon, session=session,
+        ))
+        asyncio.run(_call_execute(
+            _restore_cwd_cmd(session), use_daemon, session=session,
+        ))
+        return _parse_execute_result(op, "click")
+    op = asyncio.run(_call_execute(
+        f"click {_q(translated)}", use_daemon, session=session,
+    ))
+    return _parse_execute_result(op, "click")
 
 
 def open_url(url: str, use_daemon: bool = False, *, session: Any = None) -> dict:
@@ -709,9 +807,10 @@ def open_url(url: str, use_daemon: bool = False, *, session: Any = None) -> dict
         >>> open_url("https://example.com")
         {"url": "https://example.com", "status": "loaded"}
     """
-    return asyncio.run(
+    result = asyncio.run(
         _call_execute(f"open {_q(url)}", use_daemon, session=session)
     )
+    return _parse_execute_result(result, "open")
 
 
 def reload(use_daemon: bool = False, *, session: Any = None) -> dict:
@@ -724,7 +823,8 @@ def reload(use_daemon: bool = False, *, session: Any = None) -> dict:
     Returns:
         Dict with reload result
     """
-    return asyncio.run(_call_execute("refresh", use_daemon, session=session))
+    result = asyncio.run(_call_execute("refresh", use_daemon, session=session))
+    return _parse_execute_result(result, "refresh")
 
 
 def back(use_daemon: bool = False, *, session: Any = None) -> dict:
@@ -737,7 +837,8 @@ def back(use_daemon: bool = False, *, session: Any = None) -> dict:
     Returns:
         Dict with navigation result
     """
-    return asyncio.run(_call_execute("back", use_daemon, session=session))
+    result = asyncio.run(_call_execute("back", use_daemon, session=session))
+    return _parse_execute_result(result, "back")
 
 
 def forward(use_daemon: bool = False, *, session: Any = None) -> dict:
@@ -750,7 +851,8 @@ def forward(use_daemon: bool = False, *, session: Any = None) -> dict:
     Returns:
         Dict with navigation result
     """
-    return asyncio.run(_call_execute("forward", use_daemon, session=session))
+    result = asyncio.run(_call_execute("forward", use_daemon, session=session))
+    return _parse_execute_result(result, "forward")
 
 
 def type_text(
@@ -839,11 +941,11 @@ def type_text(
     # best-effort call. All four share the persisted lane via session.
     if is_absolute:
         anchor_result = asyncio.run(_call_execute(
-            f"cd {_here_path('')}", use_daemon, session=session,
+            _anchor_path_cmd(""), use_daemon, session=session,
         ))
         if _is_error(anchor_result):
             # Anchor failed — we never moved, so no restore is needed.
-            return anchor_result
+            return _parse_execute_result(anchor_result, "focus")
 
     focus_result = asyncio.run(_call_execute(
         f"focus {_q(translated_path)}", use_daemon, session=session,
@@ -856,7 +958,7 @@ def type_text(
             asyncio.run(_call_execute(
                 _restore_cwd_cmd(session), use_daemon, session=session,
             ))
-        return focus_result
+        return _parse_execute_result(focus_result, "focus")
 
     type_result = asyncio.run(_call_execute(
         f"type {_q(text)}", use_daemon, session=session,
@@ -870,7 +972,7 @@ def type_text(
             _restore_cwd_cmd(session), use_daemon, session=session,
         ))
 
-    return type_result
+    return _parse_execute_result(type_result, "type")
 
 
 # ── Daemon control functions ───────────────────────────────────────────

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -639,7 +639,7 @@ def ls(path: str = "/", use_daemon: bool = False, *, session: Any = None) -> dic
         finer column parser in the follow-up.
 
     Example:
-        >>> ls("/main")
+        >>> ls("/main", session=session)   # session required for absolute paths
         {"entries": [{"name": "heading_1", "role": "", "path": "heading_1"},
                      {"name": "div/",      "role": "", "path": "div/"},
                      ...],
@@ -727,8 +727,8 @@ def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         Dict with element details including text, role, attributes
 
     Example:
-        >>> cat("/main/button[0]")
-        {"name": "Submit", "role": "button", "text": "Submit", ...}
+        >>> cat("/main/button[0]", session=session)   # required for absolute paths
+        {"output": "button: Submit\\n..."}
     """
     translated, is_absolute = _translate_path(path)
     if not translated:
@@ -797,10 +797,10 @@ def grep(
         Dict with 'matches' key containing list of matching elements
 
     Example:
-        >>> grep("Login")
-        {"matches": ["/main/button[0]", "/main/link[1]"]}
-        >>> grep("Login", path="/main")
-        {"matches": ["/main/button[0]"]}
+        >>> grep("Login")                                # unrooted — session optional
+        {"matches": ["/main/button[0]", "/main/link[1]"], "raw": "..."}
+        >>> grep("Login", path="/main", session=session)   # rooted → session required
+        {"matches": ["/main/button[0]"], "raw": "..."}
     """
     _assert_single_line("pattern", pattern)
     translated_path, path_abs = _translate_path(path)
@@ -866,8 +866,8 @@ def click(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         Dict with action result
 
     Example:
-        >>> click("/main/button[0]")
-        {"action": "click", "path": "/main/button[0]", "status": "success"}
+        >>> click("/main/button[0]", session=session)   # required for absolute paths
+        {"output": "✓ Clicked\\n[lane: 1]"}
     """
     translated, is_absolute = _translate_path(path)
     if not translated:

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -10,10 +10,16 @@ Installation:
 
 DOMShell GitHub: https://github.com/apireno/DOMShell
 Chrome Web Store: https://chromewebstore.google.com/detail/domshell-%E2%80%94-browser-filesy/okcliheamhmijccjknkkplploacoidnp
+
+DOMShell 2.0.0 (May 2026) changed the default MCP tool surface from 38
+per-command tools to a single `domshell_execute` tool that accepts a
+shell-style command string (multi-line supported). This wrapper targets
+that single tool.
 """
 
 import asyncio
 import os
+import shlex
 import subprocess
 import shutil
 from typing import Any, Optional
@@ -78,7 +84,7 @@ def is_available() -> tuple[bool, str]:
 
     Examples:
         >>> is_available()
-        (True, "DOMShell v1.0.0 is available")
+        (True, "DOMShell v2.0.0 is available")
         >>> is_available()
         (False, "npx not found. Install Node.js from https://nodejs.org/")
     """
@@ -110,16 +116,17 @@ def is_available() -> tuple[bool, str]:
         return False, f"DOMShell check failed: {e}"
 
 
-async def _call_tool(
-    tool_name: str,
-    arguments: dict,
-    use_daemon: bool = False
-) -> Any:
-    """Call a DOMShell MCP tool.
+def _q(arg: str) -> str:
+    """Quote an argument for the DOMShell command parser (shell-style)."""
+    return shlex.quote(arg)
+
+
+async def _call_execute(command: str, use_daemon: bool = False) -> Any:
+    """Run a DOMShell command via the single `domshell_execute` MCP tool.
 
     Args:
-        tool_name: Name of the MCP tool (e.g., "domshell_ls", "domshell_cd")
-        arguments: Arguments to pass to the tool
+        command: DOMShell command string. May contain newlines for multi-command
+            execution — each line runs in order in the same shell state.
         use_daemon: If True, use persistent daemon connection (if available)
 
     Returns:
@@ -133,9 +140,11 @@ async def _call_tool(
     if use_daemon and _daemon_session is not None:
         # Use persistent daemon connection
         try:
-            result = await _daemon_session.call_tool(tool_name, arguments)
+            result = await _daemon_session.call_tool(
+                "domshell_execute", {"command": command}
+            )
             return result
-        except Exception as e:
+        except Exception:
             # Daemon died, fall back to spawning new server
             await _stop_daemon()
 
@@ -149,7 +158,9 @@ async def _call_tool(
         async with stdio_client(server_params) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
-                result = await session.call_tool(tool_name, arguments)
+                result = await session.call_tool(
+                    "domshell_execute", {"command": command}
+                )
                 return result
     except Exception as e:
         raise RuntimeError(
@@ -223,7 +234,11 @@ def daemon_started() -> bool:
     return _daemon_session is not None
 
 
-# ── Sync wrappers for each DOMShell tool ─────────────────────────────
+# ── Sync wrappers for each DOMShell command ──────────────────────────
+#
+# Each wrapper builds a shell-style command string and dispatches to
+# `domshell_execute`. The public Python API is unchanged from the
+# pre-2.0.0 per-tool wrappers.
 
 def ls(path: str = "/", use_daemon: bool = False) -> dict:
     """List directory contents in the accessibility tree.
@@ -239,8 +254,8 @@ def ls(path: str = "/", use_daemon: bool = False) -> dict:
         >>> ls("/")
         {"path": "/", "entries": [{"name": "main", "role": "landmark", ...}]}
     """
-    result = asyncio.run(_call_tool("domshell_ls", {"options": path}, use_daemon))
-    return result
+    command = f"ls {_q(path)}" if path else "ls"
+    return asyncio.run(_call_execute(command, use_daemon))
 
 
 def cd(path: str, use_daemon: bool = False) -> dict:
@@ -257,8 +272,7 @@ def cd(path: str, use_daemon: bool = False) -> dict:
         >>> cd("/main/div[0]")
         {"path": "/main/div[0]", "element": {...}}
     """
-    result = asyncio.run(_call_tool("domshell_cd", {"path": path}, use_daemon))
-    return result
+    return asyncio.run(_call_execute(f"cd {_q(path)}", use_daemon))
 
 
 def cat(path: str, use_daemon: bool = False) -> dict:
@@ -275,17 +289,28 @@ def cat(path: str, use_daemon: bool = False) -> dict:
         >>> cat("/main/button[0]")
         {"name": "Submit", "role": "button", "text": "Submit", ...}
     """
-    result = asyncio.run(_call_tool("domshell_cat", {"name": path}, use_daemon))
-    return result
+    return asyncio.run(_call_execute(f"cat {_q(path)}", use_daemon))
 
 
-def grep(pattern: str, use_daemon: bool = False) -> dict:
-    """Search for pattern in accessibility tree.
+def grep(
+    pattern: str,
+    path: str = "",
+    prev: str = "/",
+    use_daemon: bool = False,
+) -> dict:
+    """Search for pattern in the accessibility tree.
 
-    Searches from the current working directory.
+    When ``path`` is provided and is not ``/``, the search is rooted at that
+    path: ``cd`` into it, ``grep``, then ``cd`` back to ``prev`` — sent as one
+    multi-line ``domshell_execute`` call so all three steps share shell state
+    and complete in a single MCP round-trip.
 
     Args:
         pattern: Text pattern to search for
+        path: Optional path to root the search at. If empty or "/", searches
+            from the server-side current working directory.
+        prev: Path to restore as cwd after the search. Used only when
+            ``path`` is provided. Defaults to "/".
         use_daemon: Use persistent daemon connection if available
 
     Returns:
@@ -294,13 +319,14 @@ def grep(pattern: str, use_daemon: bool = False) -> dict:
     Example:
         >>> grep("Login")
         {"matches": ["/main/button[0]", "/main/link[1]"]}
+        >>> grep("Login", path="/main")
+        {"matches": ["/main/button[0]"]}
     """
-    result = asyncio.run(_call_tool(
-        "domshell_grep",
-        {"pattern": pattern},
-        use_daemon
-    ))
-    return result
+    if path and path != "/":
+        command = f"cd {_q(path)}\ngrep {_q(pattern)}\ncd {_q(prev)}"
+    else:
+        command = f"grep {_q(pattern)}"
+    return asyncio.run(_call_execute(command, use_daemon))
 
 
 def click(path: str, use_daemon: bool = False) -> dict:
@@ -317,8 +343,7 @@ def click(path: str, use_daemon: bool = False) -> dict:
         >>> click("/main/button[0]")
         {"action": "click", "path": "/main/button[0]", "status": "success"}
     """
-    result = asyncio.run(_call_tool("domshell_click", {"name": path}, use_daemon))
-    return result
+    return asyncio.run(_call_execute(f"click {_q(path)}", use_daemon))
 
 
 def open_url(url: str, use_daemon: bool = False) -> dict:
@@ -335,8 +360,7 @@ def open_url(url: str, use_daemon: bool = False) -> dict:
         >>> open_url("https://example.com")
         {"url": "https://example.com", "status": "loaded"}
     """
-    result = asyncio.run(_call_tool("domshell_open", {"url": url}, use_daemon))
-    return result
+    return asyncio.run(_call_execute(f"open {_q(url)}", use_daemon))
 
 
 def reload(use_daemon: bool = False) -> dict:
@@ -348,8 +372,7 @@ def reload(use_daemon: bool = False) -> dict:
     Returns:
         Dict with reload result
     """
-    result = asyncio.run(_call_tool("domshell_reload", {}, use_daemon))
-    return result
+    return asyncio.run(_call_execute("refresh", use_daemon))
 
 
 def back(use_daemon: bool = False) -> dict:
@@ -361,8 +384,7 @@ def back(use_daemon: bool = False) -> dict:
     Returns:
         Dict with navigation result
     """
-    result = asyncio.run(_call_tool("domshell_back", {}, use_daemon))
-    return result
+    return asyncio.run(_call_execute("back", use_daemon))
 
 
 def forward(use_daemon: bool = False) -> dict:
@@ -374,15 +396,15 @@ def forward(use_daemon: bool = False) -> dict:
     Returns:
         Dict with navigation result
     """
-    result = asyncio.run(_call_tool("domshell_forward", {}, use_daemon))
-    return result
+    return asyncio.run(_call_execute("forward", use_daemon))
 
 
 def type_text(path: str, text: str, use_daemon: bool = False) -> dict:
     """Type text into an input element.
 
-    Focuses the element first (via domshell_focus), then types. Both operations
-    run in a single MCP session so that focus state is preserved.
+    Focuses the element and types in a single ``domshell_execute`` call so
+    focus state is guaranteed to be in place when ``type`` runs (one MCP
+    round-trip, atomic).
 
     Args:
         path: Path to input element
@@ -392,23 +414,8 @@ def type_text(path: str, text: str, use_daemon: bool = False) -> dict:
     Returns:
         Dict with action result
     """
-    async def _focus_and_type():
-        global _daemon_session
-        if use_daemon and _daemon_session is not None:
-            await _daemon_session.call_tool("domshell_focus", {"name": path})
-            return await _daemon_session.call_tool("domshell_type", {"text": text})
-
-        server_params = StdioServerParameters(
-            command=DEFAULT_SERVER_CMD,
-            args=_build_server_args()
-        )
-        async with stdio_client(server_params) as (read, write):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                await session.call_tool("domshell_focus", {"name": path})
-                return await session.call_tool("domshell_type", {"text": text})
-
-    return asyncio.run(_focus_and_type())
+    command = f"focus {_q(path)}\ntype {_q(text)}"
+    return asyncio.run(_call_execute(command, use_daemon))
 
 
 # ── Daemon control functions ───────────────────────────────────────────

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -507,14 +507,25 @@ async def _call_execute(
     #     fresh isolated lane and returns its id in the [lane: ...]
     #     marker, which `_capture_lane` stores on the session for next
     #     time.
-    #   • daemon-mode first call without a Session → group_id="shared"
-    #     — the daemon's persistent connection has its own default lane
-    #     that stays sticky across calls, so direct (sessionless) daemon
-    #     workflows like `open_url(use_daemon=True)` followed by
-    #     `ls(use_daemon=True)` share browser state naturally. Using
-    #     "new" here would mint a fresh isolated lane per call and lose
-    #     the page just opened (Codex P2 regression caught on the
-    #     initial 2.0.2 migration commit be62f843b5).
+    #   • daemon-mode first call without a Session → group_id="shared".
+    #     When the persistent daemon connection is live, the default
+    #     per-connection lane stays sticky across calls — so direct
+    #     (sessionless) daemon workflows like `open_url(use_daemon=True)`
+    #     followed by `ls(use_daemon=True)` share browser state without
+    #     needing a Session to carry a lane id.
+    #
+    #     In the fall-back path (daemon dead / not started — i.e.
+    #     `_daemon_session is None` below), each call spawns its own
+    #     ClientSession, which triggers its own SESSION_START on
+    #     DOMShell and gets its own per-connection default lane.
+    #     "shared" is per-MCP-session, so it still routes correctly
+    #     there — to *that spawn's* default lane — giving per-call
+    #     isolation. Same outcome as omitting `group_id` would have
+    #     pre-2.0.2, minus the [DEPRECATION] warning, and crucially one
+    #     orphan tab-group per spawn instead of two (`group_id="new"`
+    #     would create an explicit second lane on top of the
+    #     SESSION_START default — the orphan flood reverted in commit
+    #     99d1182504).
     if session is not None and getattr(session, "domshell_lane_id", None):
         arguments["group_id"] = session.domshell_lane_id
     elif use_daemon:


### PR DESCRIPTION
## Why this matters now

The harness invokes the DOMShell MCP server via `npx @apireno/domshell` and `npx -p @apireno/domshell domshell-proxy` **without a pinned version**. `npx` resolves to the latest published version by default. DOMShell **2.0.0** shipped on 2026-05-22 and is **not backwards compatible** with the harness as written: the default MCP tool surface was consolidated from 38 per-command tools (`domshell_ls`, `domshell_cd`, `domshell_cat`, `domshell_grep`, `domshell_click`, `domshell_open`, `domshell_reload`, `domshell_back`, `domshell_forward`, `domshell_focus`, `domshell_type`) down to a single `domshell_execute` tool.

That means the next time a user runs the harness against a freshly-resolved `@apireno/domshell` from npm, every per-command MCP call returns "tool not found" and the harness fails. The legacy 38 tools still exist behind an opt-in `--granular` server flag, but users would have to know to pass it — there is no error path today that surfaces this. This PR removes the dependency on the per-command tools so the harness Just Works against the default 2.0.0+ server.

Follow-up to #135, which fixed the per-command parameter shapes against the (then-current) 1.x API.

## What changed upstream

- `@apireno/domshell` default MCP tool surface: **38 per-command tools → 1 (`domshell_execute`)**. The 38 granular tools remain available behind an opt-in `--granular` server flag, but the harness no longer needs them.
- Concurrent multi-agent: multiple MCP clients can connect simultaneously, each isolated in its own Chrome tab-group "lane."
- Optional `group_id` parameter on `domshell_execute` for explicit lane control.

Full notes: [DOMShell 2.0.0 CHANGELOG](https://github.com/apireno/DOMShell/blob/main/CHANGELOG.md).

## What this PR does

Migrates `cli_anything/browser/utils/domshell_backend.py` from 11 per-command tool calls to a single `domshell_execute` shim. Each public Python wrapper now builds a shell-style command string (with `shlex.quote` for path/text arguments) and dispatches through one `_call_execute` helper.

Side wins from the consolidation:
- Works against DOMShell 2.0.0's default config — no user-side `--granular` requirement.
- The `cd + grep + cd back` path-rooting pattern from #135 becomes a single multi-line `domshell_execute` call (one MCP round-trip instead of three).
- The `focus + type` pattern from #135 likewise collapses to one call — atomic, focus state is guaranteed in place when \`type\` runs.

Unchanged (intentionally — keeps the PR tight):
- `domshell-proxy` spawn command (port/token args).
- Env var contract (`DOMSHELL_TOKEN`, `DOMSHELL_PORT`).
- Public Python API of `domshell_backend.py` (function names, return shapes; `grep` gained two backward-compatible optional kwargs).
- `page` / `fs` / `act` / `session` CLI command groups in `browser_cli.py`.

## Optional follow-up (not in this PR)

DOMShell 2.0.0's `group_id` parameter could be a clean fit for the `session` command group — opt-in isolated lanes when the harness runs alongside other DOMShell consumers (e.g. a developer driving the same browser in Claude Desktop). Happy to draft a separate PR if of interest.

## Testing

- Unit: `pytest cli_anything/browser/tests/ -v` → **80 passed, 11 skipped** (e2e, gated on \`DOMSHELL_E2E=1\`), 0.36s.
- Manual smoke against `@apireno/domshell@2.0.0` in default mode (no `--granular`): page open / fs ls / act click / fs grep all green.

cc @yuh-yang @zhangxilong-43 @omerarslan0 — same areas you reviewed in #135.