### PR TITLE
feat: add cli-anything-everything — agent-native CLI for Everything file search

### DIFF
--- a/public_registry.json
+++ b/public_registry.json
@@ -362,6 +362,27 @@
           "url": "https://github.com/MartaKar"
         }
       ]
+    },
+    {
+      "name": "everything",
+      "display_name": "Everything",
+      "version": "1.0.0",
+      "description": "Instant file search on Windows via Everything's es.exe — JSON output, GBK→UTF-8 encoding, REPL mode, WSL/Linux dual-environment support",
+      "category": "search",
+      "requires": "Everything 1.4+ installed and running with es.exe",
+      "homepage": "https://www.voidtools.com",
+      "source_url": "https://github.com/jueduilunhui/cli-anything-everything",
+      "package_manager": "pip",
+      "install_cmd": "pip install git+https://github.com/jueduilunhui/cli-anything-everything.git",
+      "entry_point": "cli-anything-everything",
+      "skill_md": "https://raw.githubusercontent.com/jueduilunhui/cli-anything-everything/main/SKILL.md",
+      "contributors": [
+        {
+          "name": "jueduilunhui",
+          "url": "https://github.com/jueduilunhui"
+        }
+      ]
     }
+
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -1227,25 +1227,6 @@
           "url": "https://github.com/octo-patch"
         }
       ]
-    },
-    {
-      "name": "everything",
-      "display_name": "Everything",
-      "version": "1.0.0",
-      "description": "Instant file search on Windows via Everything's es.exe — JSON output, GBK→UTF-8 encoding, REPL mode, WSL/Linux dual-environment support",
-      "requires": "Everything 1.4+ installed and running with es.exe",
-      "homepage": "https://www.voidtools.com",
-      "source_url": "https://github.com/jueduilunhui/cli-anything-everything",
-      "install_cmd": "pip install git+https://github.com/jueduilunhui/cli-anything-everything.git",
-      "entry_point": "cli-anything-everything",
-      "skill_md": "https://raw.githubusercontent.com/jueduilunhui/cli-anything-everything/main/SKILL.md",
-      "category": "search",
-      "contributors": [
-        {
-          "name": "jueduilunhui",
-          "url": "https://github.com/jueduilunhui"
-        }
-      ]
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -1227,6 +1227,25 @@
           "url": "https://github.com/octo-patch"
         }
       ]
+    },
+    {
+      "name": "everything",
+      "display_name": "Everything",
+      "version": "1.0.0",
+      "description": "Instant file search on Windows via Everything's es.exe — JSON output, GBK→UTF-8 encoding, REPL mode, WSL/Linux dual-environment support",
+      "requires": "Everything 1.4+ installed and running with es.exe",
+      "homepage": "https://www.voidtools.com",
+      "source_url": "https://github.com/jueduilunhui/cli-anything-everything",
+      "install_cmd": "pip install git+https://github.com/jueduilunhui/cli-anything-everything.git",
+      "entry_point": "cli-anything-everything",
+      "skill_md": "https://raw.githubusercontent.com/jueduilunhui/cli-anything-everything/main/SKILL.md",
+      "category": "search",
+      "contributors": [
+        {
+          "name": "jueduilunhui",
+          "url": "https://github.com/jueduilunhui"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Type
- [x] New Software CLI (standalone repo) — registry-only PR

## Description

Adds `cli-anything-everything` to the CLI-Hub registry — an agent-native CLI for [Everything](https://www.voidtools.com) file search on Windows.

### Features
- ✅ **JSON output** — structured, machine-readable results for AI agents
- ✅ **GBK→UTF-8** — auto-converts Chinese Windows encoding
- ✅ **REPL mode** — interactive search with prompt-toolkit
- ✅ **WSL-ready** — detects and uses WSL paths for cross-environment execution
- ✅ **Full Everything syntax** — regex, case, whole-word, path matching, date filters

### Checklist
- [x] CLI is installable via `pip install git+https://github.com/jueduilunhui/cli-anything-everything.git`
- [x] SKILL.md exists at `https://raw.githubusercontent.com/jueduilunhui/cli-anything-everything/main/SKILL.md`
- [x] External repo has its own test suite (21 tests passing)
- [x] registry.json entry includes `source_url` pointing to external repo
- [x] `install_cmd` tested locally
- [x] `--json` flag supported on all commands

### Repo
https://github.com/jueduilunhui/cli-anything-everything

### Test output
```
21 passed in 0.04s
```

### Category
`search`