### PR TITLE
feat: upgrade cli-anything-minimax default model to MiniMax-M3

### DIFF
--- a/minimax/agent-harness/cli_anything/minimax/README.md
+++ b/minimax/agent-harness/cli_anything/minimax/README.md
@@ -34,7 +34,7 @@ cli-anything-minimax tts --text "Hello world" --output hello.mp3
 ### Chat
 
 ```bash
-# Simple chat (default model: MiniMax-M2.7)
+# Simple chat (default model: MiniMax-M3)
 cli-anything-minimax chat --prompt "Explain quantum computing"
 
 # High-speed model
@@ -85,7 +85,8 @@ cli-anything-minimax models --tts
 
 | Model | Description |
 |-------|-------------|
-| `MiniMax-M2.7` | Peak Performance. Ultimate Value. (default) |
+| `MiniMax-M3` | Next-generation flagship model (default) |
+| `MiniMax-M2.7` | Peak Performance. Ultimate Value. |
 | `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |
 
 ### TTS

--- a/minimax/agent-harness/cli_anything/minimax/minimax_cli.py
+++ b/minimax/agent-harness/cli_anything/minimax/minimax_cli.py
@@ -3,7 +3,7 @@
 
 Usage:
     # One-shot commands
-    cli-anything-minimax chat --prompt "Hello" --model MiniMax-M2.7
+    cli-anything-minimax chat --prompt "Hello" --model MiniMax-M3
     cli-anything-minimax stream --prompt "Tell me a story"
     cli-anything-minimax tts --text "Hello world" --output hello.mp3
 
@@ -108,7 +108,7 @@ def handle_error(func):
     "model_opt",
     type=str,
     default=None,
-    help="Model ID (default: MiniMax-M2.7)",
+    help="Model ID (default: MiniMax-M3)",
 )
 @click.pass_context
 def cli(ctx, use_json, api_key_opt, model_opt):
@@ -130,7 +130,7 @@ def cli(ctx, use_json, api_key_opt, model_opt):
     "model_opt",
     type=str,
     default=None,
-    help="Model ID (default: MiniMax-M2.7)",
+    help="Model ID (default: MiniMax-M3)",
 )
 @click.option(
     "--temperature",
@@ -145,7 +145,7 @@ def chat(ctx, prompt, model_opt=None, temperature=None, max_tokens=None):
     """Chat with the MiniMax API."""
     parent_key = ctx.obj.get("api_key") if ctx.obj else None
     api_key = get_api_key(parent_key)
-    model = model_opt or (ctx.obj.get("model") if ctx.obj else None) or "MiniMax-M2.7"
+    model = model_opt or (ctx.obj.get("model") if ctx.obj else None) or "MiniMax-M3"
 
     session = get_session()
     messages = []
@@ -181,7 +181,7 @@ def chat(ctx, prompt, model_opt=None, temperature=None, max_tokens=None):
     "model_opt",
     type=str,
     default=None,
-    help="Model ID (default: MiniMax-M2.7)",
+    help="Model ID (default: MiniMax-M3)",
 )
 @click.option(
     "--temperature",
@@ -196,7 +196,7 @@ def stream(ctx, prompt, model_opt=None, temperature=None, max_tokens=None):
     """Stream chat completion from MiniMax."""
     parent_key = ctx.obj.get("api_key") if ctx.obj else None
     api_key = get_api_key(parent_key)
-    model = model_opt or (ctx.obj.get("model") if ctx.obj else None) or "MiniMax-M2.7"
+    model = model_opt or (ctx.obj.get("model") if ctx.obj else None) or "MiniMax-M3"
 
     session = get_session()
     messages = []
@@ -381,13 +381,13 @@ def config_path():
     "model_opt",
     type=str,
     default=None,
-    help="Chat model ID to test (default: MiniMax-M2.7)",
+    help="Chat model ID to test (default: MiniMax-M3)",
 )
 @handle_error
 def test(model_opt=None):
     """Test MiniMax API connectivity."""
     api_key = get_api_key()
-    model = model_opt or "MiniMax-M2.7"
+    model = model_opt or "MiniMax-M3"
 
     result = chat_completion(
         api_key=api_key,
@@ -449,7 +449,7 @@ def repl():
     pt_session = skin.create_prompt_session()
 
     commands = {
-        "chat --prompt <text>": "Chat with MiniMax (MiniMax-M2.7)",
+        "chat --prompt <text>": "Chat with MiniMax (MiniMax-M3)",
         "stream --prompt <text>": "Stream chat completion",
         "tts --text <text> --output out.mp3": "Text-to-speech synthesis",
         "models": "List chat models",

--- a/minimax/agent-harness/cli_anything/minimax/skills/SKILL.md
+++ b/minimax/agent-harness/cli_anything/minimax/skills/SKILL.md
@@ -2,7 +2,7 @@
 name: >-
   cli-anything-minimax
 description: >-
-  Command-line interface for MiniMax AI — chat (MiniMax-M2.7) and TTS (speech-2.8-hd) via the MiniMax API.
+  Command-line interface for MiniMax AI — chat (MiniMax-M3) and TTS (speech-2.8-hd) via the MiniMax API.
 ---
 
 # cli-anything-minimax
@@ -30,7 +30,7 @@ cli-anything-minimax --help
 # Start interactive REPL
 cli-anything-minimax
 
-# Chat with MiniMax-M2.7
+# Chat with MiniMax-M3
 cli-anything-minimax chat --prompt "What is AI?"
 
 # High-speed model
@@ -115,7 +115,8 @@ cli-anything-minimax tts --text "Fast" --model speech-2.8-turbo --voice English_
 
 | Model ID | Description |
 |----------|-------------|
-| `MiniMax-M2.7` | Peak Performance. Ultimate Value. (default) |
+| `MiniMax-M3` | Next-generation flagship model (default) |
+| `MiniMax-M2.7` | Peak Performance. Ultimate Value. |
 | `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |
 
 ## TTS Models

--- a/minimax/agent-harness/cli_anything/minimax/tests/test_core.py
+++ b/minimax/agent-harness/cli_anything/minimax/tests/test_core.py
@@ -53,10 +53,10 @@ def test_save_and_load_config(tmp_path):
         original_file = backend.CONFIG_FILE
         backend.CONFIG_FILE = config_file
         try:
-            save_config({"api_key": "test-key-123", "default_model": "MiniMax-M2.7"})
+            save_config({"api_key": "test-key-123", "default_model": "MiniMax-M3"})
             loaded = load_config()
             assert loaded["api_key"] == "test-key-123"
-            assert loaded["default_model"] == "MiniMax-M2.7"
+            assert loaded["default_model"] == "MiniMax-M3"
         finally:
             backend.CONFIG_FILE = original_file
 
@@ -64,11 +64,14 @@ def test_save_and_load_config(tmp_path):
 # ── Chat models ────────────────────────────────────────────────────────────────
 
 def test_chat_models_list():
-    """MiniMax-M2.7 and MiniMax-M2.7-highspeed must be in the model list."""
+    """MiniMax-M3, MiniMax-M2.7 and MiniMax-M2.7-highspeed must be in the model list."""
     model_ids = [m["id"] for m in CHAT_MODELS]
+    assert "MiniMax-M3" in model_ids
     assert "MiniMax-M2.7" in model_ids
     assert "MiniMax-M2.7-highspeed" in model_ids
-    assert len(CHAT_MODELS) == 2
+    assert len(CHAT_MODELS) == 3
+    # M3 must be the first (default) model
+    assert CHAT_MODELS[0]["id"] == "MiniMax-M3"
 
 
 def test_tts_models_list():
@@ -102,7 +105,7 @@ def test_chat_completion_success():
 
         result = chat_completion(
             api_key="fake-key",
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             messages=[{"role": "user", "content": "Hello"}],
         )
 
@@ -118,7 +121,7 @@ def test_chat_completion_uses_minimax_base_url():
         mock_resp.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
         mock_post.return_value = mock_resp
 
-        chat_completion(api_key="key", model="MiniMax-M2.7", messages=[])
+        chat_completion(api_key="key", model="MiniMax-M3", messages=[])
 
         call_url = mock_post.call_args[0][0]
         assert "minimax.io" in call_url
@@ -133,7 +136,7 @@ def test_chat_completion_default_temperature():
         mock_resp.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
         mock_post.return_value = mock_resp
 
-        chat_completion(api_key="key", model="MiniMax-M2.7", messages=[])
+        chat_completion(api_key="key", model="MiniMax-M3", messages=[])
 
         body = mock_post.call_args[1]["json"]
         assert body["temperature"] == 1.0
@@ -189,7 +192,7 @@ def test_chat_completion_stream_success():
 
         result = chat_completion_stream(
             api_key="fake-key",
-            model="MiniMax-M2.7",
+            model="MiniMax-M3",
             messages=[{"role": "user", "content": "Hi"}],
             on_chunk=on_chunk,
         )

--- a/minimax/agent-harness/cli_anything/minimax/tests/test_full_e2e.py
+++ b/minimax/agent-harness/cli_anything/minimax/tests/test_full_e2e.py
@@ -156,12 +156,13 @@ class TestCLISubprocessSmoke:
         assert status["history_count"] == 0
 
         models = self._run(["models"], tmp_path)
+        assert "MiniMax-M3" in models.stdout
         assert "MiniMax-M2.7" in models.stdout
 
         models_json = self._run(["--json", "models"], tmp_path)
         model_payload = json.loads(models_json.stdout)
         assert isinstance(model_payload, list)
-        assert model_payload[0]["id"] == "MiniMax-M2.7"
+        assert model_payload[0]["id"] == "MiniMax-M3"
 
         voices = self._run(["voices"], tmp_path)
         assert "English_Graceful_Lady" in voices.stdout
@@ -257,7 +258,7 @@ def test_chat_completion_e2e():
 
             result = chat_completion(
                 api_key="sk-mock",
-                model="MiniMax-M2.7",
+                model="MiniMax-M3",
                 messages=[{"role": "user", "content": "Say ok"}],
             )
             assert result["choices"][0]["message"]["content"] == "ok"
@@ -265,7 +266,7 @@ def test_chat_completion_e2e():
 
     result = chat_completion(
         api_key=API_KEY,
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         messages=[{"role": "user", "content": "Say 'ok'"}],
         max_tokens=10,
     )
@@ -328,7 +329,7 @@ def test_chat_stream_e2e():
 
             chat_completion_stream(
                 api_key="sk-mock",
-                model="MiniMax-M2.7",
+                model="MiniMax-M3",
                 messages=[{"role": "user", "content": "Hello"}],
                 on_chunk=on_chunk,
             )
@@ -339,7 +340,7 @@ def test_chat_stream_e2e():
     received = []
     chat_completion_stream(
         api_key=API_KEY,
-        model="MiniMax-M2.7",
+        model="MiniMax-M3",
         messages=[{"role": "user", "content": "Say 'ok' only"}],
         max_tokens=5,
         on_chunk=lambda c: received.append(c),

--- a/minimax/agent-harness/cli_anything/minimax/utils/minimax_backend.py
+++ b/minimax/agent-harness/cli_anything/minimax/utils/minimax_backend.py
@@ -20,6 +20,7 @@ CONFIG_FILE = CONFIG_DIR / "config.json"
 ENV_API_KEY = "MINIMAX_API_KEY"
 
 CHAT_MODELS = [
+    {"id": "MiniMax-M3", "description": "Next-generation flagship model (default)"},
     {"id": "MiniMax-M2.7", "description": "Peak Performance. Ultimate Value. Master the Complex"},
     {"id": "MiniMax-M2.7-highspeed", "description": "Same performance, faster and more agile"},
 ]
@@ -91,7 +92,7 @@ def _make_auth_headers(api_key: str) -> dict:
 
 def chat_completion(
     api_key: Optional[str] = None,
-    model: str = "MiniMax-M2.7",
+    model: str = "MiniMax-M3",
     messages: Optional[list] = None,
     temperature: Optional[float] = None,
     max_tokens: Optional[int] = None,
@@ -124,7 +125,7 @@ def chat_completion(
 
 def chat_completion_stream(
     api_key: Optional[str] = None,
-    model: str = "MiniMax-M2.7",
+    model: str = "MiniMax-M3",
     messages: Optional[list] = None,
     temperature: Optional[float] = None,
     max_tokens: Optional[int] = None,
@@ -251,7 +252,7 @@ def tts_synthesize(
 
 def run_full_workflow(
     api_key: Optional[str] = None,
-    model: str = "MiniMax-M2.7",
+    model: str = "MiniMax-M3",
     prompt: str = "",
     system_message: Optional[str] = None,
     temperature: Optional[float] = None,

--- a/minimax/agent-harness/setup.py
+++ b/minimax/agent-harness/setup.py
@@ -12,10 +12,10 @@ with open("cli_anything/minimax/README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="cli-anything-minimax",
-    version="1.0.0",
+    version="1.1.0",
     author="cli-anything contributors",
     author_email="",
-    description="CLI harness for MiniMax AI — chat (MiniMax-M2.7) and TTS via MiniMax API. Requires: MINIMAX_API_KEY",
+    description="CLI harness for MiniMax AI — chat (MiniMax-M3) and TTS via MiniMax API. Requires: MINIMAX_API_KEY",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/HKUDS/CLI-Anything",

--- a/registry.json
+++ b/registry.json
@@ -1231,8 +1231,8 @@
     {
       "name": "minimax",
       "display_name": "MiniMax",
-      "version": "1.0.0",
-      "description": "Chat and TTS via MiniMax AI API — MiniMax-M2.7 chat models and speech-2.8-hd TTS",
+      "version": "1.1.0",
+      "description": "Chat and TTS via MiniMax AI API — MiniMax-M3 chat models and speech-2.8-hd TTS",
       "requires": "MINIMAX_API_KEY",
       "homepage": "https://platform.minimax.io",
       "source_url": null,

--- a/skills/cli-anything-minimax/SKILL.md
+++ b/skills/cli-anything-minimax/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli-anything-minimax"
 description: >-
-  Command-line interface for MiniMax AI — chat (MiniMax-M2.7) and TTS (speech-2.8-hd) via the MiniMax API.
+  Command-line interface for MiniMax AI — chat (MiniMax-M3) and TTS (speech-2.8-hd) via the MiniMax API.
 ---
 
 # cli-anything-minimax
@@ -29,7 +29,7 @@ cli-anything-minimax --help
 # Start interactive REPL
 cli-anything-minimax
 
-# Chat with MiniMax-M2.7
+# Chat with MiniMax-M3
 cli-anything-minimax chat --prompt "What is AI?"
 
 # High-speed model
@@ -114,7 +114,8 @@ cli-anything-minimax tts --text "Fast" --model speech-2.8-turbo --voice English_
 
 | Model ID | Description |
 |----------|-------------|
-| `MiniMax-M2.7` | Peak Performance. Ultimate Value. (default) |
+| `MiniMax-M3` | Next-generation flagship model (default) |
+| `MiniMax-M2.7` | Peak Performance. Ultimate Value. |
 | `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |
 
 ## TTS Models


### PR DESCRIPTION
## Summary

Upgrade the `cli-anything-minimax` harness to use `MiniMax-M3` as the default chat model, while keeping `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` available for users who prefer the previous generation.

## Changes

- Add `MiniMax-M3` to the model selection list (first entry, new default)
- Switch default model in `chat` / `stream` / `test` / `run_full_workflow` to `MiniMax-M3`
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Sync model references in `README.md`, the package `skills/SKILL.md`, and the top-level `skills/cli-anything-minimax/SKILL.md`
- Update unit tests for the new model list and default
- Bump `cli-anything-minimax` to `1.1.0` in `setup.py` and `registry.json`

## Testing

- `python3 -m pytest cli_anything/minimax/tests/test_core.py cli_anything/minimax/tests/test_full_e2e.py -v` -> 25 passed
- `CLI_ANYTHING_FORCE_INSTALLED=1 python3 -m pytest cli_anything/minimax/tests/test_full_e2e.py::TestCLISubprocessSmoke -v` -> 5 passed
- `cli-anything-minimax --json models` now lists `MiniMax-M3` first, followed by `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`