### PR TITLE
feat: add CloakBrowser CLI to public registry

### DIFF
--- a/public_registry.json
+++ b/public_registry.json
@@ -2,7 +2,7 @@
   "meta": {
     "repo": "https://github.com/HKUDS/CLI-Anything",
     "description": "Public CLI Registry — Third-party and official CLIs managed by CLI-Hub across npm, bundled, brew, and other install methods",
-    "updated": "2026-04-18"
+    "updated": "2026-06-02"
   },
   "clis": [
     {
@@ -400,6 +400,28 @@
         {
           "name": "Jasper0122",
           "url": "https://github.com/Jasper0122"
+        }
+      ]
+    },
+    {
+      "name": "cloakbrowser-cli",
+      "display_name": "CloakBrowser CLI",
+      "version": "latest",
+      "description": "Agent-friendly CLI for CloakBrowser — stealth Chromium that passes every bot detection test. Covers fingerprint spoofing, humanize behaviors, page operations, content extraction, cookies, storage, and multi-page sessions.",
+      "category": "web",
+      "requires": "Node.js >= 20, cloakbrowser >= 0.3.0, playwright-core >= 1.40.0",
+      "homepage": "https://github.com/dreamor/cloakbrowser-cli",
+      "source_url": "https://github.com/dreamor/cloakbrowser-cli",
+      "package_manager": "npm",
+      "npm_package": "@dreamor/cloakbrowser-cli",
+      "install_cmd": "npm install -g @dreamor/cloakbrowser-cli cloakbrowser playwright-core",
+      "npx_cmd": "npx @dreamor/cloakbrowser-cli",
+      "skill_md": "https://github.com/dreamor/cloakbrowser-cli/blob/main/SKILL.md",
+      "entry_point": "cloak",
+      "contributors": [
+        {
+          "name": "dreamor",
+          "url": "https://github.com/dreamor"
         }
       ]
     }


### PR DESCRIPTION
## Description

Add **CloakBrowser CLI** (`@dreamor/cloakbrowser-cli`) to the public CLI registry.

CloakBrowser CLI is an agent-friendly command-line interface for [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) — a stealth Chromium browser that passes every bot detection test. It provides structured JSON output designed for AI agent consumption, covering all CloakBrowser features:

- **Browser automation**: navigation, clicks, form filling, screenshots, PDFs
- **Fingerprint spoofing**: deterministic fingerprints, platform/UA/GPU emulation
- **Humanize behaviors**: realistic mouse movements, typing patterns, timing
- **Content extraction**: HTML, text, markdown (Readability + Turndown), selectors
- **Session management**: daemon mode with persistent sessions, cookie/storage state
- **Network**: proxy support, GeoIP, request interception, CDP gateway
- **Anti-detection**: passes FingerprintJS, BrowserScan, BotD, Sannysoft

### Key details

| Field | Value |
|-------|-------|
| `name` | `cloakbrowser-cli` |
| `display_name` | CloakBrowser CLI |
| `category` | `web` |
| `package_manager` | `npm` |
| `npm_package` | `@dreamor/cloakbrowser-cli` |
| `entry_point` | `cloak` |
| `install_cmd` | `npm install -g @dreamor/cloakbrowser-cli cloakbrowser playwright-core` |
| `source_url` | https://github.com/dreamor/cloakbrowser-cli |
| `skill_md` | https://github.com/dreamor/cloakbrowser-cli/blob/main/SKILL.md |

## Type of Change

- [x] **New Software CLI (standalone repo)** — registry-only PR pointing to an external repo

### For New Software CLIs (standalone repo)

- [x] CLI is installable via `npm install -g @dreamor/cloakbrowser-cli cloakbrowser playwright-core`
- [x] `SKILL.md` exists in the external repo — [view SKILL.md](https://github.com/dreamor/cloakbrowser-cli/blob/main/SKILL.md)
- [x] External repo has its own test suite (vitest unit + e2e tests)
- [x] `public_registry.json` entry includes `source_url` pointing to the external repo
- [x] `public_registry.json` entry includes `skill_md` with full URL to the external SKILL.md
- [x] `install_cmd` in `public_registry.json` works (tested locally)

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] Commit messages follow the conventional format (`feat:`)
- [x] I have tested my changes locally

## Test Results

```bash
# Verified install works
npm install -g @dreamor/cloakbrowser-cli cloakbrowser playwright-core
cloak doctor  # confirms installation
cloak version # 0.1.0
```