### PR TITLE
feat: add OpenWebUI CLI registry entry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -451,6 +451,25 @@
       ]
     },
     {
+      "name": "openwebui",
+      "display_name": "OpenWebUI",
+      "version": "1.0.0",
+      "description": "Operate a running OpenWebUI backend through an agent-friendly CLI",
+      "requires": "OpenWebUI instance running",
+      "homepage": "https://openwebui.com",
+      "source_url": "https://github.com/ashaiful/cli-anything-openwebui",
+      "install_cmd": "pip install git+https://github.com/ashaiful/cli-anything-openwebui.git",
+      "entry_point": "cli-anything-openwebui",
+      "skill_md": "https://github.com/ashaiful/cli-anything-openwebui/blob/main/cli_anything/openwebui/skills/SKILL.md",
+      "category": "ai",
+      "contributors": [
+        {
+          "name": "ashaiful",
+          "url": "https://github.com/ashaiful"
+        }
+      ]
+    },
+    {
       "name": "obs-studio",
       "display_name": "OBS Studio",
       "version": "1.0.0",


### PR DESCRIPTION
## Description

Adds OpenWebUI to CLI-AnythingHub as a standalone repository CLI via `registry.json`.

Fixes: N/A

## Type of Change

- [ ] **New Software CLI (in-repo)** — adds a CLI harness inside this monorepo
- [x] **New Software CLI (standalone repo)** — registry-only PR pointing to an external repo
- [ ] **New Feature** — adds new functionality to an existing harness or the plugin
- [ ] **Bug Fix** — fixes incorrect behavior
- [ ] **Documentation** — updates docs only
- [ ] **Other** — please describe:

---

### For New Software CLIs (in-repo)

- [ ] `<SOFTWARE>.md` SOP document exists at `<software>/agent-harness/<SOFTWARE>.md`
- [ ] Canonical `SKILL.md` exists at `skills/cli-anything-<software>/SKILL.md`
- [ ] Packaged compatibility `SKILL.md` exists at `cli_anything/<software>/skills/SKILL.md`
- [ ] Unit tests at `cli_anything/<software>/tests/test_core.py` are present and pass without backend
- [ ] E2E tests at `cli_anything/<software>/tests/test_full_e2e.py` are present
- [ ] `README.md` includes the new software (with link to harness directory)
- [ ] `registry.json` includes an entry with `source_url: null` (see [Contributing guide](CONTRIBUTING.md#registry-fields))
- [ ] `repl_skin.py` in `utils/` is an unmodified copy from the plugin

### For New Software CLIs (standalone repo)

- [x] CLI is installable via `pip install <package-name>` or a `pip install git+https://...` URL
- [x] `SKILL.md` exists in the external repo
- [x] External repo has its own test suite
- [x] `registry.json` entry includes `source_url` pointing to the external repo
- [x] `registry.json` entry includes `skill_md` with full URL to the external SKILL.md
- [x] `install_cmd` in `registry.json` works (tested locally)

### For Existing CLI Modifications

- [ ] All unit tests pass: `python3 -m pytest cli_anything/<software>/tests/test_core.py -v`
- [ ] All E2E tests pass: `python3 -m pytest cli_anything/<software>/tests/test_full_e2e.py -v`
- [ ] No test regressions — no previously passing tests were removed or weakened
- [ ] `registry.json` entry is updated if version, description, or requirements changed

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands
- [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
- [x] I have tested my changes locally

## Test Results

Registry validation:

```text
registry ok
openwebui entry parsed successfully from registry.json
no duplicate registry names
```

External CLI test suite:

```text
python -m pytest cli_anything\openwebui\tests -q
...............................                                          [100%]
31 passed in 37.80s
```

Install command validation in a fresh virtual environment:

```text
pip install git+https://github.com/ashaiful/cli-anything-openwebui.git
Resolved https://github.com/ashaiful/cli-anything-openwebui.git to commit 5570c15849b43ceb20f1336b4afd5c04c8f6c924
Successfully installed cli-anything-openwebui-1.0.0
cli-anything-openwebui --help
install_cmd ok
```

External repo CI:

```text
ashaiful/cli-anything-openwebui CI completed successfully on main
```
