### PR TITLE
feat: add TinyFish Web Agent CLI (standalone repo)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1422,8 +1422,8 @@
     {
       "name": "tinyfish",
       "display_name": "TinyFish Web Agent",
-      "version": "0.1.0",
-      "description": "Web search, clean page extraction, and natural-language browser automation via the TinyFish REST APIs.",
+      "version": "0.1.1",
+      "description": "All four TinyFish products from the terminal: web search, clean page extraction, natural-language browser automation, and remote CDP browser sessions — via the REST APIs.",
       "requires": "TinyFish API key (free at agent.tinyfish.ai/api-keys)",
       "homepage": "https://tinyfish.ai",
       "source_url": "https://github.com/webdevtodayjason/cli-anything-tinyfish",

--- a/registry.json
+++ b/registry.json
@@ -1418,6 +1418,25 @@
           "url": "https://github.com/davidmyriel"
         }
       ]
+    },
+    {
+      "name": "tinyfish",
+      "display_name": "TinyFish Web Agent",
+      "version": "0.1.0",
+      "description": "Web search, clean page extraction, and natural-language browser automation via the TinyFish REST APIs.",
+      "requires": "TinyFish API key (free at agent.tinyfish.ai/api-keys)",
+      "homepage": "https://tinyfish.ai",
+      "source_url": "https://github.com/webdevtodayjason/cli-anything-tinyfish",
+      "install_cmd": "pip install cli-anything-tinyfish",
+      "entry_point": "cli-anything-tinyfish",
+      "skill_md": "https://github.com/webdevtodayjason/cli-anything-tinyfish/blob/main/cli_anything/tinyfish/skills/SKILL.md",
+      "category": "web",
+      "contributors": [
+        {
+          "name": "webdevtodayjason",
+          "url": "https://github.com/webdevtodayjason"
+        }
+      ]
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -1424,7 +1424,7 @@
       "display_name": "TinyFish Web Agent",
       "version": "0.1.1",
       "description": "All four TinyFish products from the terminal: web search, clean page extraction, natural-language browser automation, and remote CDP browser sessions — via the REST APIs.",
-      "requires": "TinyFish API key (free at agent.tinyfish.ai/api-keys)",
+      "requires": "TinyFish API key (free at https://agent.tinyfish.ai/api-keys)",
       "homepage": "https://tinyfish.ai",
       "source_url": "https://github.com/webdevtodayjason/cli-anything-tinyfish",
       "install_cmd": "pip install cli-anything-tinyfish",


### PR DESCRIPTION
## Description

Adds **TinyFish Web Agent** to the hub as a standalone-repo CLI covering all
four TinyFish products: **Search** (ranked web results), **Fetch** (clean page
extraction, JS-rendered, up to 10 URLs in parallel), **Agent**
(natural-language browser automation with sync/async run management), and
**Browser** (remote CDP sessions for direct Playwright/Puppeteer control) —
via TinyFish's REST APIs.

Why a community CLI: TinyFish's official MCP server requires an interactive
OAuth 2.1 browser flow, which headless agents and kiosk machines cannot
complete. This CLI uses the REST APIs with `X-API-Key` auth (free tier;
search and fetch are credit-free), making TinyFish usable from any agent
with shell access.

- Repo: https://github.com/webdevtodayjason/cli-anything-tinyfish
- PyPI: https://pypi.org/project/cli-anything-tinyfish/ (v0.1.1 published, install verified from a clean venv)
- Tests: 14 unit tests (no network) + 3 credit-free E2E tests — 17/17 passing

## Type of Change

- [x] **New Software CLI (standalone repo)** — registry-only PR pointing to an external repo

### For New Software CLIs (standalone repo)

- [x] CLI is installable via `pip install cli-anything-tinyfish` (PyPI)
- [x] `SKILL.md` exists in the external repo (`cli_anything/tinyfish/skills/SKILL.md`)
- [x] External repo has its own test suite (14 unit tests, no network; credit-free E2E suite)
- [x] `registry.json` entry includes `source_url` pointing to the external repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)