### PR TITLE
feat: add NI LabVIEW CLI harness to public registry

### DIFF
--- a/public_registry.json
+++ b/public_registry.json
@@ -470,7 +470,10 @@
           "name": "99cz99",
           "url": "https://github.com/99cz99"
         }
-      ]
+      ],
+      "install_strategy": "command",
+      "uninstall_cmd": "pip uninstall -y cli-anything-labview",
+      "update_cmd": "pip install --upgrade --force-reinstall git+https://github.com/99cz99/cli-anything-labview.git@v1.0.0"
     }
   ]
 }

--- a/public_registry.json
+++ b/public_registry.json
@@ -450,6 +450,27 @@
           "url": "https://github.com/123dx-svg"
         }
       ]
+    },
+    {
+      "name": "labview",
+      "display_name": "NI LabVIEW",
+      "version": "1.0.0",
+      "description": "Agent-native CLI harness for NI LabVIEW: VI control, project management, front-panel access, build specs, and data acquisition from the command line via ActiveX/COM automation",
+      "category": "scientific",
+      "platform": "windows",
+      "requires": "Windows only — NI LabVIEW 2025 (or compatible) with ActiveX Server enabled; Python 3.10+ with pywin32>=300",
+      "homepage": "https://www.ni.com/en/support/downloads/software-products/download.labview.html",
+      "source_url": "https://github.com/99cz99/cli-anything-labview",
+      "package_manager": "pip",
+      "install_cmd": "pip install git+https://github.com/99cz99/cli-anything-labview.git@v1.0.0",
+      "entry_point": "cli-anything-labview",
+      "skill_md": "https://raw.githubusercontent.com/99cz99/cli-anything-labview/master/skills/cli-anything-labview/SKILL.md",
+      "contributors": [
+        {
+          "name": "99cz99",
+          "url": "https://github.com/99cz99"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add `cli-anything-labview` to the public registry.

## About the harness

- Software: NI LabVIEW 2025
- Backend: ActiveX/COM automation + subprocess fallback
- Commands: project, vi, control, run, build, session, status
- Tests: 56 tests passing (35 unit + 21 E2E)
- Platform: Windows only
- License: Apache 2.0
- Repo: https://github.com/99cz99/cli-anything-labview

## Checklist

- [x] Installable via `pip install git+https://github.com/99cz99/cli-anything-labview.git@v1.0.0`
- [x] SKILL.md available at raw GitHub URL
- [x] Test suite passes (56 tests)
- [x] JSON output mode (`--json` flag) supported
- [x] Entry follows PEP 420 namespace package convention
