### PR TITLE
feat(registry): add Palmier Pro (cli-anything-palmier)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -2,7 +2,7 @@
   "meta": {
     "repo": "https://github.com/HKUDS/CLI-Anything",
     "description": "CLI-Hub — Agent-native stateful CLI interfaces for softwares, codebases, and Web Services",
-    "updated": "2026-06-10"
+    "updated": "2026-06-19"
   },
   "clis": [
     {
@@ -1473,6 +1473,25 @@
         {
           "name": "George-RD",
           "url": "https://github.com/George-RD"
+        }
+      ]
+    },
+    {
+      "name": "palmier",
+      "display_name": "Palmier Pro",
+      "version": "0.1.0",
+      "description": "Agent-native CLI harness for the Palmier Pro local MCP video editor — drive timeline editing, media, captions, and AI generation from the command line",
+      "requires": "Palmier Pro desktop app running its local MCP server at 127.0.0.1:19789, Python 3.10+",
+      "homepage": "https://palmier.com",
+      "source_url": "https://github.com/workcr/palmier-cli-anything",
+      "install_cmd": "pip install git+https://github.com/workcr/palmier-cli-anything.git",
+      "entry_point": "cli-anything-palmier",
+      "skill_md": "https://github.com/workcr/palmier-cli-anything/blob/main/skills/cli-anything-palmier/SKILL.md",
+      "category": "video",
+      "contributors": [
+        {
+          "name": "workcr",
+          "url": "https://github.com/workcr"
         }
       ]
     }


### PR DESCRIPTION
## What is added

A registry entry for **Palmier Pro**, a standalone CLI-Anything harness.

- **Name:** `palmier`
- **Display name:** Palmier Pro
- **Category:** `video`
- **Source:** https://github.com/workcr/palmier-cli-anything (standalone repo)

## What the CLI does

Palmier Pro is an AI-native video editor whose desktop app runs a local,
no-auth MCP server at `http://127.0.0.1:19789/mcp` (29 tools: timeline, media
library, clips/tracks, text/captions, AI generation, folders). The harness
exposes that server through a small Click command tree so agents can drive the
editor without loading the full MCP schema each turn. The transport is the
Python standard library only (streamable-HTTP JSON-RPC) — no Node/mcpc
dependency, since the server is local and auth-free.

## Standalone-repo requirements checklist (per CONTRIBUTING.md)

- [x] Installable via `pip install git+https://github.com/workcr/palmier-cli-anything.git`
- [x] `SKILL.md` — https://github.com/workcr/palmier-cli-anything/blob/main/skills/cli-anything-palmier/SKILL.md
- [x] Tests — offline pytest suite (monkeypatches `urllib`, no live server needed): https://github.com/workcr/palmier-cli-anything/tree/main/tests
- [x] `registry.json` entry added (this PR)

## Verification

```bash
pip install git+https://github.com/workcr/palmier-cli-anything.git
cli-anything-palmier ping --json        # server info (requires Palmier Pro running)
cli-anything-palmier tools --json       # 29 tools
cli-anything-palmier timeline get --json
pytest -q                               # 15 offline tests pass
```

The entry is appended to `clis` and `meta.updated` is bumped. No other files changed.