### PR TITLE
feat(registry): add Magnific (cli-anything-magnific)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1494,6 +1494,25 @@
           "url": "https://github.com/workcr"
         }
       ]
+    },
+    {
+      "name": "magnific",
+      "display_name": "Magnific",
+      "version": "0.1.0",
+      "description": "Agent-native CLI harness for Magnific's remote MCP media-generation server — generate and upscale images and video via mcpc OAuth without loading the full MCP schema each turn",
+      "requires": "Node.js + npm (for the mcpc transport), Python 3.10+, Magnific account (OAuth)",
+      "homepage": "https://magnific.com",
+      "source_url": "https://github.com/workcr/magnific-cli-anything",
+      "install_cmd": "pip install git+https://github.com/workcr/magnific-cli-anything.git",
+      "entry_point": "cli-anything-magnific",
+      "skill_md": "https://github.com/workcr/magnific-cli-anything/blob/main/skills/cli-anything-magnific/SKILL.md",
+      "category": "ai",
+      "contributors": [
+        {
+          "name": "workcr",
+          "url": "https://github.com/workcr"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What is added

A registry entry for **Magnific**, a standalone CLI-Anything harness.

- **Name:** `magnific`
- **Display name:** Magnific
- **Category:** `ai`
- **Source:** https://github.com/workcr/magnific-cli-anything (standalone repo)

## What the CLI does

Magnific hosts a remote MCP media-generation server at `https://mcp.magnific.com`
(OAuth). The harness exposes it through a small Click command tree
(`image generate`, `video generate`, `wait`, `show`, `call`, …) so agents can
generate and upscale images/video without loading the full MCP schema/catalog
each turn. Transport uses `mcpc` (Node) for the OAuth session — same backend
and credits as the MCP server, just fewer prompt/context tokens.

## Standalone-repo requirements checklist (per CONTRIBUTING.md)

- [x] Installable via `pip install git+https://github.com/workcr/magnific-cli-anything.git`
      (runtime also needs `npm install` for the `mcpc` transport, captured in `requires`)
- [x] `SKILL.md` — https://github.com/workcr/magnific-cli-anything/blob/main/skills/cli-anything-magnific/SKILL.md
- [x] Tests — offline pytest suite: https://github.com/workcr/magnific-cli-anything/tree/main/tests
- [x] `registry.json` entry added (this PR)

## Verification

```bash
git clone https://github.com/workcr/magnific-cli-anything.git
cd magnific-cli-anything
npm install                       # installs the mcpc transport
python3 -m pip install -e .
cli-anything-magnific auth        # one-time OAuth (browser)
cli-anything-magnific test-auth --json
cli-anything-magnific balance --json
pytest -q                         # offline tests pass
```

The entry is appended to `clis` and `meta.updated` is bumped. No other files changed.