### PR TITLE
feat: add cli-anything-meerk40t (MeerK40t laser software)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1456,6 +1456,25 @@
           "url": "https://github.com/webdevtodayjason"
         }
       ]
+    },
+    {
+      "name": "meerk40t",
+      "display_name": "MeerK40t",
+      "version": "1.0.0",
+      "description": "Laser cutting/engraving job preparation via the real MeerK40t kernel — elements, operations, SVG/G-code export with --json output",
+      "requires": "MeerK40t (installed automatically)",
+      "homepage": "https://github.com/meerk40t/meerk40t",
+      "source_url": "https://github.com/George-RD/cli-anything-meerk40t",
+      "install_cmd": "pip install cli-anything-meerk40t",
+      "entry_point": "cli-anything-meerk40t",
+      "skill_md": "https://github.com/George-RD/cli-anything-meerk40t/blob/main/skills/cli-anything-meerk40t/SKILL.md",
+      "category": "graphics",
+      "contributors": [
+        {
+          "name": "George-RD",
+          "url": "https://github.com/George-RD"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## New CLI: cli-anything-meerk40t

Standalone repository: https://github.com/George-RD/cli-anything-meerk40t

### What it does
Agent CLI harness for **MeerK40t** laser cutting/engraving software. Wraps the real MeerK40t kernel headless for agent-driven laser job preparation — project, elements, operations, device, export, console-passthrough, and session commands with `--json` output.

### Install
```bash
pip install cli-anything-meerk40t
cli-anything-meerk40t --help
```

### Registry entry
- **Name**: `meerk40t`
- **Category**: `graphics` (laser/CAM — closest existing fit; 3MF and CloudCompare are here)
- **Source**: https://github.com/George-RD/cli-anything-meerk40t
- **PyPI**: https://pypi.org/project/cli-anything-meerk40t/ (v1.0.0 live)
- **Entry point**: `cli-anything-meerk40t`
- **Skill**: https://github.com/George-RD/cli-anything-meerk40t/blob/main/skills/cli-anything-meerk40t/SKILL.md

### Verification
- 38 tests (27 unit + 11 E2E), 100% pass rate
- Fresh-venv install from PyPI verified: `pip install cli-anything-meerk40t` + CLI smoke test
- Backend wraps real MeerK40t kernel (SVGWriter, GRBL save_job) — not a reimplementation
- Export formats: SVG (headless, truthful), G-code (GRBL save_job pipeline), PNG (GUI-dependent, errors clearly)

### CONTRIBUTING.md compliance
- [x] Standalone repo (Option 2)
- [x] Published to PyPI (`pip install cli-anything-meerk40t`)
- [x] SKILL.md exists (canonical + packaged copy)
- [x] Tests present and passing
- [x] registry.json entry with `source_url` pointing to standalone repo