### PR TITLE
Fix: Python 3.11 compatibility issue with f-string backslash in cli_hub/preview.py

### DIFF
--- a/cli-hub/cli_hub/__init__.py
+++ b/cli-hub/cli_hub/__init__.py
@@ -1,3 +1,3 @@
 """cli-hub — Download, manage, and browse CLI-Anything harnesses."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/cli-hub/cli_hub/preview.py
+++ b/cli-hub/cli_hub/preview.py
@@ -720,7 +720,7 @@ def _render_trajectory_html_section(trajectory: Optional[Dict[str, Any]]) -> str
         '<section class="section">'
         "<h2>Trajectory</h2>"
         f'<div class="facts">{cards_html}</div>'
-        f'<div class="trajectory-list">{items_html or "<div class=\"artifact-file\">No step timeline entries yet.</div>"}</div>'
+        f'<div class="trajectory-list">{items_html or "<div class=\'artifact-file\'>No step timeline entries yet.</div>"}</div>'
         "</section>"
     )
 

--- a/cli-hub/cli_hub/preview.py
+++ b/cli-hub/cli_hub/preview.py
@@ -716,11 +716,12 @@ def _render_trajectory_html_section(trajectory: Optional[Dict[str, Any]]) -> str
         for item in items
     )
 
+    empty_message = '<div class="artifact-file">No step timeline entries yet.</div>'
     return (
         '<section class="section">'
         "<h2>Trajectory</h2>"
         f'<div class="facts">{cards_html}</div>'
-        f'<div class="trajectory-list">{items_html or "<div class=\'artifact-file\'>No step timeline entries yet.</div>"}</div>'
+        f'<div class="trajectory-list">{items_html or empty_message}</div>'
         "</section>"
     )
 

--- a/cli-hub/setup.py
+++ b/cli-hub/setup.py
@@ -50,7 +50,7 @@ class sdist(_sdist):
 
 setup(
     name="cli-anything-hub",
-    version="0.4.0",
+    version="0.4.1",
     description="Package manager for CLI-Anything — browse, install, and manage 40+ agent-native CLI interfaces for GUI applications",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes issue #367 (and duplicate #372). The backslash inside the f-string expression part caused a SyntaxError in Python 3.11. This PR resolves it by using single quotes for the HTML attribute instead of escaping double quotes.