### PR TITLE
fix: prevent session ID path traversal

### DIFF
--- a/macrocli/agent-harness/cli_anything/macrocli/core/session.py
+++ b/macrocli/agent-harness/cli_anything/macrocli/core/session.py
@@ -8,12 +8,42 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import time
 from pathlib import Path
 from typing import Optional
 
 SESSION_DIR = Path.home() / ".macrocli" / "sessions"
 MAX_HISTORY = 200
+_SESSION_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,128}\Z")
+_WINDOWS_RESERVED_SESSION_IDS = {
+    "CON", "PRN", "AUX", "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+
+
+def validate_session_id(session_id: str) -> str:
+    """Validate a portable session identifier used as a file name."""
+    if (
+        not isinstance(session_id, str)
+        or not _SESSION_ID_RE.fullmatch(session_id)
+        or session_id.upper() in _WINDOWS_RESERVED_SESSION_IDS
+    ):
+        raise ValueError(
+            "session_id must be 1-128 ASCII letters, digits, underscores, or hyphens"
+        )
+    return session_id
+
+
+def _session_path(session_id: str) -> Path:
+    """Return the resolved path for a validated session inside SESSION_DIR."""
+    session_id = validate_session_id(session_id)
+    session_root = SESSION_DIR.resolve()
+    path = (session_root / f"{session_id}.json").resolve()
+    if path.parent != session_root:
+        raise ValueError("session_id resolves outside the session directory")
+    return path
 
 
 def _locked_save_json(path: str, data, **dump_kwargs) -> None:
@@ -99,7 +129,9 @@ class ExecutionSession:
     """Tracks macro run history for the current session."""
 
     def __init__(self, session_id: Optional[str] = None):
-        self.session_id = session_id or f"session_{int(time.time())}"
+        if session_id is None:
+            session_id = f"session_{int(time.time())}"
+        self.session_id = validate_session_id(session_id)
         self._history: list[RunRecord] = []
 
     # ── Record management ─────────────────────────────────────────────
@@ -145,24 +177,26 @@ class ExecutionSession:
     def save(self) -> str:
         """Persist session to disk. Returns the file path."""
         SESSION_DIR.mkdir(parents=True, exist_ok=True)
-        path = str(SESSION_DIR / f"{self.session_id}.json")
+        path = _session_path(self.session_id)
         data = {
             "session_id": self.session_id,
             "timestamp": time.time(),
             "history": [r.to_dict() for r in self._history],
         }
-        _locked_save_json(path, data, indent=2, sort_keys=True)
-        return path
+        _locked_save_json(str(path), data, indent=2, sort_keys=True)
+        return str(path)
 
     @classmethod
     def load(cls, session_id: str) -> Optional["ExecutionSession"]:
         """Load a session from disk."""
-        path = SESSION_DIR / f"{session_id}.json"
+        path = _session_path(session_id)
         if not path.is_file():
             return None
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
-        session = cls(session_id=data.get("session_id", session_id))
+        # The file name is the canonical identifier. Do not allow persisted
+        # data to redirect a later save to a different path.
+        session = cls(session_id=session_id)
         session._history = [RunRecord.from_dict(r) for r in data.get("history", [])]
         return session
 

--- a/macrocli/agent-harness/cli_anything/macrocli/macrocli_cli.py
+++ b/macrocli/agent-harness/cli_anything/macrocli/macrocli_cli.py
@@ -24,7 +24,7 @@ from typing import Optional
 
 from cli_anything.macrocli.core.registry import MacroRegistry
 from cli_anything.macrocli.core.runtime import MacroRuntime
-from cli_anything.macrocli.core.session import ExecutionSession
+from cli_anything.macrocli.core.session import ExecutionSession, validate_session_id
 
 # ── Global state ─────────────────────────────────────────────────────────────
 
@@ -131,13 +131,24 @@ def _parse_params(param_tuples: tuple) -> dict:
     return result
 
 
+def _validate_session_id_option(ctx, param, value):
+    """Convert core session ID validation errors into Click usage errors."""
+    if value is None:
+        return None
+    try:
+        return validate_session_id(value)
+    except ValueError as exc:
+        raise click.BadParameter(str(exc), ctx=ctx, param=param) from exc
+
+
 # ── Main CLI group ────────────────────────────────────────────────────────────
 
 @click.group(invoke_without_command=True)
 @click.option("--json", "json_flag", is_flag=True, help="Machine-readable JSON output.")
 @click.option("--dry-run", "dry_run_flag", is_flag=True,
               help="Simulate execution without side effects.")
-@click.option("--session-id", default=None, help="Resume or create a named session.")
+@click.option("--session-id", default=None, callback=_validate_session_id_option,
+              help="Resume or create a named session (letters, digits, '_' and '-').")
 @click.pass_context
 def cli(ctx, json_flag, dry_run_flag, session_id):
     """MacroCLI — run GUI workflows as CLI commands.

--- a/macrocli/agent-harness/cli_anything/macrocli/skills/SKILL.md
+++ b/macrocli/agent-harness/cli_anything/macrocli/skills/SKILL.md
@@ -55,7 +55,7 @@ cli-anything-macrocli backends --json
 |------|-------------|
 | `--json` | Machine-readable JSON output on stdout |
 | `--dry-run` | Simulate all steps, skip side effects |
-| `--session-id <id>` | Resume or create a named session |
+| `--session-id <id>` | Resume or create a named session; use 1-128 ASCII letters, digits, `_`, or `-` |
 
 ### `macro` group
 

--- a/macrocli/agent-harness/cli_anything/macrocli/tests/test_core.py
+++ b/macrocli/agent-harness/cli_anything/macrocli/tests/test_core.py
@@ -593,3 +593,93 @@ class TestExecutionSession:
         assert loaded is not None
         assert loaded.session_id == "save_test"
         assert loaded.last().macro_name == "m1"
+
+    @pytest.mark.parametrize("session_id", [
+        "../escape",
+        r"..\escape",
+        "/tmp/escape",
+        r"C:\temp\escape",
+        "C:relative",
+        "nested/session",
+        "",
+        "x" * 129,
+        "CON",
+        "nul",
+        "COM1",
+        "LPT9",
+    ])
+    def test_rejects_unsafe_session_ids(self, session_id):
+        from cli_anything.macrocli.core.session import ExecutionSession
+
+        with pytest.raises(ValueError, match="session_id"):
+            ExecutionSession(session_id=session_id)
+
+    def test_save_revalidates_mutated_session_id(self, tmp_path, monkeypatch):
+        import cli_anything.macrocli.core.session as sess_module
+        from cli_anything.macrocli.core.session import ExecutionSession
+
+        session_dir = tmp_path / "sessions"
+        monkeypatch.setattr(sess_module, "SESSION_DIR", session_dir)
+        sess = ExecutionSession(session_id="safe_session")
+        sess.session_id = "../escape"
+
+        with pytest.raises(ValueError, match="session_id"):
+            sess.save()
+
+        assert not (tmp_path / "escape.json").exists()
+
+    def test_load_rejects_path_traversal(self, tmp_path, monkeypatch):
+        import cli_anything.macrocli.core.session as sess_module
+        from cli_anything.macrocli.core.session import ExecutionSession
+
+        monkeypatch.setattr(sess_module, "SESSION_DIR", tmp_path / "sessions")
+        (tmp_path / "outside.json").write_text(
+            json.dumps({"session_id": "outside", "history": []}),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="session_id"):
+            ExecutionSession.load("../outside")
+
+    def test_load_uses_filename_as_canonical_session_id(self, tmp_path, monkeypatch):
+        import cli_anything.macrocli.core.session as sess_module
+        from cli_anything.macrocli.core.session import ExecutionSession
+
+        session_dir = tmp_path / "sessions"
+        session_dir.mkdir()
+        monkeypatch.setattr(sess_module, "SESSION_DIR", session_dir)
+        (session_dir / "safe_session.json").write_text(
+            json.dumps({"session_id": "../escape", "history": []}),
+            encoding="utf-8",
+        )
+
+        loaded = ExecutionSession.load("safe_session")
+        assert loaded is not None
+        assert loaded.session_id == "safe_session"
+        loaded.save()
+        assert not (tmp_path / "escape.json").exists()
+
+    def test_load_rejects_session_file_symlink_outside_session_dir(self, tmp_path, monkeypatch):
+        import cli_anything.macrocli.core.session as sess_module
+        from cli_anything.macrocli.core.session import ExecutionSession
+
+        session_dir = tmp_path / "sessions"
+        session_dir.mkdir()
+        outside = tmp_path / "outside.json"
+        outside.write_text(
+            json.dumps({"session_id": "outside", "history": []}),
+            encoding="utf-8",
+        )
+        session_file = session_dir / "safe_session.json"
+        try:
+            session_file.symlink_to(outside)
+        except OSError:
+            pytest.skip("symlink creation is unavailable in this environment")
+        monkeypatch.setattr(sess_module, "SESSION_DIR", session_dir)
+
+        sentinel = outside.read_text(encoding="utf-8")
+        with pytest.raises(ValueError, match="outside the session directory"):
+            ExecutionSession.load("safe_session")
+        with pytest.raises(ValueError, match="outside the session directory"):
+            ExecutionSession(session_id="safe_session").save()
+        assert outside.read_text(encoding="utf-8") == sentinel

--- a/macrocli/agent-harness/cli_anything/macrocli/tests/test_full_e2e.py
+++ b/macrocli/agent-harness/cli_anything/macrocli/tests/test_full_e2e.py
@@ -267,12 +267,14 @@ class TestPostconditionE2E:
 class TestCLISubprocess:
     CLI_BASE = _resolve_cli("cli-anything-macrocli")
 
-    def _run(self, args: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    def _run(self, args: list[str], check: bool = True,
+             env: dict | None = None) -> subprocess.CompletedProcess:
         return subprocess.run(
             self.CLI_BASE + args,
             capture_output=True,
             text=True,
             check=check,
+            env=env,
         )
 
     def test_help(self):
@@ -331,6 +333,41 @@ class TestCLISubprocess:
         data = json.loads(result.stdout)
         assert "session_id" in data
         print(f"\n  Session: {data['session_id']}")
+
+    def test_named_session_save_json(self, tmp_path):
+        env = os.environ.copy()
+        env["HOME"] = str(tmp_path)
+
+        result = self._run(
+            ["--json", "--session-id", "release_2026", "session", "save"],
+            env=env,
+        )
+
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["session_id"] == "release_2026"
+        assert (tmp_path / ".macrocli" / "sessions" / "release_2026.json").is_file()
+
+        resumed = self._run(
+            ["--json", "--session-id", "release_2026", "session", "status"],
+            env=env,
+        )
+        assert resumed.returncode == 0, f"stderr: {resumed.stderr}"
+        assert json.loads(resumed.stdout)["session_id"] == "release_2026"
+
+    def test_session_id_path_traversal_is_rejected(self, tmp_path):
+        env = os.environ.copy()
+        env["HOME"] = str(tmp_path)
+
+        result = self._run(
+            ["--session-id", "../escape", "session", "save"],
+            check=False,
+            env=env,
+        )
+
+        assert result.returncode == 2
+        assert "Invalid value for '--session-id'" in result.stderr
+        assert not (tmp_path / "escape.json").exists()
 
     def test_macro_run_json_transform_workflow(self, tmp_path):
         """Full E2E: create a JSON file, run transform_json macro, verify output."""


### PR DESCRIPTION
## Summary

- Validate MacroCLI session IDs at the core API and CLI boundaries.
- Resolve session paths and require them to remain inside `SESSION_DIR`.
- Prevent persisted session JSON from redirecting a later save.
- Add regression coverage for traversal, Windows-specific path forms and device names, and escaping symlinks.

Fixes #382
Fixes #383

## Root cause

`ExecutionSession.load()` and `ExecutionSession.save()` interpolated an untrusted `session_id` directly into a filesystem path. Values such as `../escape` could escape `~/.macrocli/sessions/`; a loaded JSON document could also supply a different session ID that redirected a later save.

## User impact

Named session IDs are now intentionally limited to 1-128 ASCII letters, digits, underscores, and hyphens. Generated IDs and existing in-tree named-session usage remain valid. The CLI rejects invalid values as a usage error before any filesystem access.

## Validation

- Added core API and CLI subprocess regression tests.
- `python -m compileall -q cli_anything/macrocli` passed in Docker (Python 3.12).
- `python -m pytest -q` passed in Docker: 82 passed on Python 3.12 and 82 passed on Python 3.10.
- Direct CLI verification confirmed that `--session-id ../escape session save` is rejected without creating an outside file, while a valid named session can be saved and resumed.
