### PR TITLE
fix(audacity): write 8-bit WAV as unsigned PCM

### DIFF
--- a/audacity/agent-harness/cli_anything/audacity/tests/test_full_e2e.py
+++ b/audacity/agent-harness/cli_anything/audacity/tests/test_full_e2e.py
@@ -132,6 +132,19 @@ class TestWavIO:
         corr = np.corrcoef(original[:min_len], loaded[:min_len])[0, 1]
         assert corr > 0.99
 
+    def test_write_read_roundtrip_8bit(self, tmp_dir):
+        # 8-bit WAV PCM is unsigned (0..255, silence == 128). A signed encoder
+        # makes silence (0.0) read back as full-scale (-1.0). Assert every value
+        # round-trips within the 8-bit quantization step (1/128 ~= 0.0078).
+        path = os.path.join(tmp_dir, "rt8.wav")
+        original = [0.0, 0.5, 1.0, -0.5, -1.0, 0.25]
+        write_wav(path, original, 44100, 1, 8)
+        loaded, sr, ch, bd = read_wav(path)
+        assert bd == 8
+        assert len(loaded) == len(original)
+        for o, l in zip(original, loaded):
+            assert abs(o - l) < 0.02, f"{o} -> {l}"
+
     def test_wav_file_properties(self, sine_wav):
         with wave.open(sine_wav, "r") as wf:
             assert wf.getframerate() == 44100

--- a/audacity/agent-harness/cli_anything/audacity/utils/audio_utils.py
+++ b/audacity/agent-harness/cli_anything/audacity/utils/audio_utils.py
@@ -325,7 +325,7 @@ def samples_to_wav_bytes(
         sample_width = 2
     elif bit_depth == 8:
         max_val = 127
-        fmt = "<b"
+        fmt = None  # 8-bit WAV samples are unsigned; handled specially below
         sample_width = 1
     elif bit_depth == 24:
         max_val = 8388607
@@ -345,6 +345,9 @@ def samples_to_wav_bytes(
         if bit_depth == 24:
             # Pack 24-bit as 3 bytes little-endian
             raw.extend(struct.pack("<i", int_val)[:3])
+        elif bit_depth == 8:
+            # 8-bit WAV samples are unsigned (0..255), centered at 128
+            raw.extend(struct.pack("<B", int_val + 128))
         else:
             raw.extend(struct.pack(fmt, int_val))
 
@@ -374,7 +377,7 @@ def write_wav(
         sample_width = 2
     elif bit_depth == 8:
         max_val = 127
-        fmt = "<b"
+        fmt = None  # 8-bit WAV samples are unsigned; handled specially below
         sample_width = 1
     elif bit_depth == 24:
         max_val = 8388607
@@ -393,6 +396,9 @@ def write_wav(
         int_val = max(-max_val - 1, min(max_val, int_val))
         if bit_depth == 24:
             raw.extend(struct.pack("<i", int_val)[:3])
+        elif bit_depth == 8:
+            # 8-bit WAV samples are unsigned (0..255), centered at 128
+            raw.extend(struct.pack("<B", int_val + 128))
         else:
             raw.extend(struct.pack(fmt, int_val))
 


### PR DESCRIPTION
## Problem

In `audacity/agent-harness/cli_anything/audacity/utils/audio_utils.py`, 8-bit WAV export writes **signed** bytes, but the WAV/RIFF format stores 8-bit PCM as **unsigned** (0–255, silence = 128). 16/24/32-bit are signed; only 8-bit is unsigned.

Both writers packed 8-bit with a signed format:

```python
elif bit_depth == 8:
    max_val = 127
    fmt = "<b"          # signed byte -- wrong for 8-bit WAV
    sample_width = 1
...
    raw.extend(struct.pack(fmt, int_val))
```

This is inconsistent with the module's **own** reader, which decodes 8-bit as unsigned:

```python
# read_wav()
if bit_depth == 8:
    val = raw[offset]
    samples.append((val - 128) / max_val)   # max_val = 128.0
```

So 8-bit output is misdecoded by every standard player *and* by this module's own `read_wav`. `bit_depth=8` is a real export path — the `wav-8` preset in `core/export.py` and `create_project(bit_depth=8)` both select it.

## Reproduction

Write `[0.0, 0.5, 1.0, -0.5]` at `bit_depth=8`, then read back via the module's own `read_wav`:

| | result |
|---|---|
| **Before** | `[-1.0, -0.508, -0.008, 0.508]` — max round-trip error **1.008** (silence `0.0` → full-scale `-1.0`); raw bytes `[0, 63, 127, 193]` (signed) |
| **After** | `[0.0, 0.492, 0.992, -0.492]` — max error **0.008** (normal 8-bit quantization); raw bytes `[128, 191, 255, 65]` (unsigned) |

16-bit round-trips are unchanged (verified).

## Fix

Pack 8-bit as unsigned, centered at 128 (`int_val` is already clamped to `[-128, 127]`, so `int_val + 128 ∈ [0, 255]`), in both `samples_to_wav_bytes` and `write_wav`:

```python
elif bit_depth == 8:
    max_val = 127
    fmt = None  # 8-bit WAV samples are unsigned; handled specially below
    sample_width = 1
...
    elif bit_depth == 8:
        # 8-bit WAV samples are unsigned (0..255), centered at 128
        raw.extend(struct.pack("<B", int_val + 128))
```

## Test

Added `test_write_read_roundtrip_8bit` to `TestWavIO` (which previously covered only 16/24-bit).

- **Before the fix:** fails — `AssertionError: 0.0 -> -1.0`.
- **After the fix:** passes.

Verified with the WAV round-trip + audio-util unit tests (all green). The `TestSoXAudioE2E` cases require the external `sox` binary, which isn't installed in my environment, so those were not run — they are unrelated to this change.
