### PR TITLE
fix(cli-hub): harden registry command execution

### DIFF
--- a/cli-hub/README.md
+++ b/cli-hub/README.md
@@ -31,7 +31,7 @@ cli-hub info gimp
 cli-hub install gimp
 
 # Explicitly approve registry-provided command/script installs (for automation)
-cli-hub install jimeng --yes
+cli-hub install 1password-cli --yes
 
 # Update a CLI to the latest version
 cli-hub update gimp
@@ -43,9 +43,10 @@ cli-hub uninstall gimp
 Entries that use the `command` install strategy can run arbitrary commands,
 including remote scripts. Before executing one, `cli-hub` safely displays the
 complete registry-provided command and, in an interactive terminal, asks for
-confirmation with a default of **No**. Non-interactive installs fail closed;
+confirmation with a default of **No**. Non-interactive commands fail closed;
 use `--yes` only after reviewing the command. The same guard applies to
-`cli-hub matrix install` (including `--json` invocations).
+install, update, uninstall, and `cli-hub matrix install` (including `--json`
+invocations).
 
 Remote-script entries that do not provide verifiable integrity metadata for
 every downloaded executable are marked as `manual`, and CLI-Hub will not run

--- a/cli-hub/README.md
+++ b/cli-hub/README.md
@@ -30,12 +30,22 @@ cli-hub info gimp
 # Install a CLI harness
 cli-hub install gimp
 
+# Explicitly approve registry-provided command/script installs (for automation)
+cli-hub install jimeng --yes
+
 # Update a CLI to the latest version
 cli-hub update gimp
 
 # Uninstall a CLI
 cli-hub uninstall gimp
 ```
+
+Entries that use the `command` install strategy can run arbitrary commands,
+including remote scripts. Before executing one, `cli-hub` safely displays the
+complete registry-provided command and, in an interactive terminal, asks for
+confirmation with a default of **No**. Non-interactive installs fail closed;
+use `--yes` only after reviewing the command. The same guard applies to
+`cli-hub matrix install` (including `--json` invocations).
 
 ## Preview Viewer
 

--- a/cli-hub/README.md
+++ b/cli-hub/README.md
@@ -47,6 +47,12 @@ confirmation with a default of **No**. Non-interactive installs fail closed;
 use `--yes` only after reviewing the command. The same guard applies to
 `cli-hub matrix install` (including `--json` invocations).
 
+Remote-script entries that do not provide verifiable integrity metadata for
+every downloaded executable are marked as `manual`, and CLI-Hub will not run
+them. `cli-hub info <name>` shows the official
+instructions and any audited bootstrap-script digest, but installation remains
+an explicit manual decision.
+
 ## Preview Viewer
 
 `cli-hub` also includes the generic preview consumer for preview-capable

--- a/cli-hub/cli_hub/__init__.py
+++ b/cli-hub/cli_hub/__init__.py
@@ -1,3 +1,3 @@
 """cli-hub — Download, manage, and browse CLI-Anything harnesses."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/cli-hub/cli_hub/__init__.py
+++ b/cli-hub/cli_hub/__init__.py
@@ -1,3 +1,3 @@
 """cli-hub — Download, manage, and browse CLI-Anything harnesses."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/cli-hub/cli_hub/cli.py
+++ b/cli-hub/cli_hub/cli.py
@@ -174,9 +174,21 @@ def install(name, assume_yes):
 
 @main.command()
 @click.argument("name")
-def uninstall(name):
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    help="Approve registry-provided commands without prompting.",
+)
+def uninstall(name, assume_yes):
     """Uninstall a CLI by name."""
-    success, msg = uninstall_cli(name)
+    success, msg = uninstall_cli(
+        name,
+        command_approver=lambda display_name, command: _approve_registry_command(
+            display_name, command, assume_yes
+        ),
+    )
     if success:
         track_uninstall(name)
         click.secho(f"✓ {msg}", fg="green")
@@ -187,10 +199,22 @@ def uninstall(name):
 
 @main.command()
 @click.argument("name")
-def update(name):
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    help="Approve registry-provided commands without prompting.",
+)
+def update(name, assume_yes):
     """Update a CLI to the latest version."""
     click.echo(f"Updating {name}...")
-    success, msg = update_cli(name)
+    success, msg = update_cli(
+        name,
+        command_approver=lambda display_name, command: _approve_registry_command(
+            display_name, command, assume_yes
+        ),
+    )
     if success:
         cli = get_cli(name)
         track_install(name, cli["version"] if cli else "unknown")

--- a/cli-hub/cli_hub/cli.py
+++ b/cli-hub/cli_hub/cli.py
@@ -307,6 +307,15 @@ def info(name):
             click.echo(f"  npx command: {cli['npx_cmd']}")
         if cli.get("install_cmd"):
             click.echo(f"  Install cmd: {cli['install_cmd']}")
+        if cli.get("install_instructions_url"):
+            click.echo(f"  Instructions: {cli['install_instructions_url']}")
+        if cli.get("remote_script"):
+            script = cli["remote_script"]
+            click.echo(f"  Remote script: {script.get('url', 'N/A')}")
+            if script.get("sha256"):
+                click.echo(f"  Script SHA-256: {script['sha256']}")
+            if script.get("integrity_scope"):
+                click.echo(f"  Integrity scope: {script['integrity_scope']}")
         if cli.get("install_notes"):
             click.echo(f"  Notes:       {cli['install_notes']}")
     click.echo(f"  Version:     {cli['version']}")
@@ -811,6 +820,7 @@ def _render_dry_run(payload):
     skips = [p for p in payload["plan"] if p["action"] == "skip"]
     installs = [p for p in payload["plan"] if p["action"] == "install"]
     errors = [p for p in payload["plan"] if p["action"] == "error"]
+    manual = [p for p in payload["plan"] if p["action"] == "manual"]
 
     if skips:
         names = ", ".join(p["name"] for p in skips)
@@ -823,6 +833,9 @@ def _render_dry_run(payload):
     if errors:
         names = ", ".join(p["name"] for p in errors)
         click.secho(f"  ! Not in CLI registry ({len(errors)}): {names}", fg="yellow")
+    if manual:
+        names = ", ".join(p["name"] for p in manual)
+        click.secho(f"  ! Manual install required ({len(manual)}): {names}", fg="yellow")
 
     not_managed = payload.get("not_managed", {})
     if not_managed:

--- a/cli-hub/cli_hub/cli.py
+++ b/cli-hub/cli_hub/cli.py
@@ -107,12 +107,57 @@ def _plural(count, singular, plural=None):
     return f"{count} {singular if count == 1 else (plural or singular + 's')}"
 
 
+def _approval_streams_are_interactive():
+    """Return whether the approval prompt can be both seen and answered."""
+    try:
+        return sys.stdin.isatty() and sys.stderr.isatty()
+    except (AttributeError, OSError, ValueError):
+        return False
+
+
+def _approve_registry_command(display_name, command, assume_yes=False, allow_prompt=True):
+    """Show a registry-provided install command and request approval."""
+    click.secho(
+        f"Warning: installing {json_mod.dumps(display_name)} will execute a command "
+        "provided by the CLI registry:",
+        fg="yellow",
+        bold=True,
+        err=True,
+    )
+    # JSON string escaping keeps control characters from spoofing the prompt
+    # while preserving a complete, reviewable representation of the command.
+    click.echo(f"  {json_mod.dumps(command)}", err=True)
+    if assume_yes:
+        return True
+    if not allow_prompt or not _approval_streams_are_interactive():
+        click.secho(
+            "Refusing to run a registry command non-interactively. "
+            "After reviewing it, re-run with --yes.",
+            fg="yellow",
+            err=True,
+        )
+        return False
+    return click.confirm("Execute this command?", default=False, err=True)
+
+
 @main.command()
 @click.argument("name")
-def install(name):
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    help="Approve registry-provided install commands without prompting.",
+)
+def install(name, assume_yes):
     """Install a CLI by name."""
     click.echo(f"Installing {name}...")
-    success, msg = install_cli(name)
+    success, msg = install_cli(
+        name,
+        command_approver=lambda display_name, command: _approve_registry_command(
+            display_name, command, assume_yes
+        ),
+    )
     if success:
         cli = get_cli(name)
         track_install(name, cli["version"] if cli else "unknown")
@@ -832,8 +877,15 @@ def _scope_args(scope):
     is_flag=True,
     help="Render the matrix skill (SKILL.md + references/ + scripts/) without installing member CLIs.",
 )
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    help="Approve registry-provided install commands without prompting.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Output the plan or result as JSON.")
-def matrix_install(name, capability, recipe, only, dry_run, resume, skill_only, as_json):
+def matrix_install(name, capability, recipe, only, dry_run, resume, skill_only, assume_yes, as_json):
     """Install the CLIs in a matrix (optionally scoped to a capability, recipe, or subset).
 
     Exit codes: 0 success · 3 partial failure · 1 total failure or not found ·
@@ -877,7 +929,14 @@ def matrix_install(name, capability, recipe, only, dry_run, resume, skill_only, 
         return
 
     success, payload = install_matrix(
-        name, capability=capability, recipe=recipe, only=only, resume=resume
+        name,
+        capability=capability,
+        recipe=recipe,
+        only=only,
+        resume=resume,
+        command_approver=lambda display_name, command: _approve_registry_command(
+            display_name, command, assume_yes, allow_prompt=not as_json
+        ),
     )
     if payload.get("error"):
         track_matrix_install(

--- a/cli-hub/cli_hub/installer.py
+++ b/cli-hub/cli_hub/installer.py
@@ -120,13 +120,17 @@ def _install_strategy(cli):
     return "command"
 
 
-def _requires_command_approval(cli):
-    """Return whether installing this entry uses the free-form command handler."""
-    if not cli.get("install_cmd"):
+def _requires_command_approval(cli, action):
+    """Return whether an action is dispatched through the free-form command handler."""
+    if not cli.get(f"{action}_cmd"):
         return False
     strategy = _install_strategy(cli)
     handlers = _STRATEGY_ACTIONS.get(strategy, _STRATEGY_ACTIONS["command"])
-    return handlers["install"] is _generic_install
+    return handlers[action] is {
+        "install": _generic_install,
+        "uninstall": _generic_uninstall,
+        "update": _generic_update,
+    }[action]
 
 
 def _generic_install(cli):
@@ -414,23 +418,29 @@ def _installed_entry(cli, source, strategy):
 # ── Unified interface ──
 
 
-def _approve_command_install(cli, command_approver):
-    """Obtain approval for a free-form command install."""
-    if _requires_command_approval(cli):
+def _approve_command_action(cli, action, command_approver):
+    """Obtain approval before dispatching a free-form registry command."""
+    command = cli.get(f"{action}_cmd")
+    if _requires_command_approval(cli, action):
         if command_approver is None:
             return False, (
-                "Explicit approval is required before running this registry install command:\n"
-                f"  {json.dumps(cli['install_cmd'])}"
+                f"Explicit approval is required before running this registry {action} command:\n"
+                f"  {json.dumps(command)}"
             )
-        if not command_approver(cli["display_name"], cli["install_cmd"]):
-            return False, "Installation cancelled; the registry command was not executed."
+        if not command_approver(cli["display_name"], command):
+            action_label = {
+                "install": "Installation",
+                "uninstall": "Uninstallation",
+                "update": "Update",
+            }[action]
+            return False, f"{action_label} cancelled; the registry command was not executed."
     return True, ""
 
 
 def _install_cli_entry(cli, command_approver=None, command_approved=False):
     """Install one already-resolved registry entry."""
     if not command_approved:
-        approved, message = _approve_command_install(cli, command_approver)
+        approved, message = _approve_command_action(cli, "install", command_approver)
         if not approved:
             return False, message
 
@@ -460,11 +470,15 @@ def install_cli(name, command_approver=None):
     return _install_cli_entry(cli, command_approver=command_approver)
 
 
-def uninstall_cli(name):
-    """Uninstall a CLI by name. Returns (success, message)."""
+def uninstall_cli(name, command_approver=None):
+    """Uninstall a CLI by name, approving free-form registry commands first."""
     cli = get_cli(name)
     if cli is None:
         return False, f"CLI '{name}' not found in registry."
+
+    approved, message = _approve_command_action(cli, "uninstall", command_approver)
+    if not approved:
+        return False, message
 
     _, (success, msg) = _perform_action(cli, "uninstall")
 
@@ -476,11 +490,15 @@ def uninstall_cli(name):
     return success, msg
 
 
-def update_cli(name):
-    """Update a CLI by reinstalling. Returns (success, message)."""
+def update_cli(name, command_approver=None):
+    """Update a CLI by name, approving free-form registry commands first."""
     cli = get_cli(name, force_refresh=True)
     if cli is None:
         return False, f"CLI '{name}' not found in registry."
+
+    approved, message = _approve_command_action(cli, "update", command_approver)
+    if not approved:
+        return False, message
 
     source = cli.get("_source", "harness")
     strategy, (success, msg) = _perform_action(cli, "update")
@@ -636,7 +654,7 @@ def install_matrix(
     for item in install_items:
         if item["action"] != "install":
             continue
-        approved, message = _approve_command_install(item["cli"], command_approver)
+        approved, message = _approve_command_action(item["cli"], "install", command_approver)
         if not approved:
             return False, {
                 "error": message,

--- a/cli-hub/cli_hub/installer.py
+++ b/cli-hub/cli_hub/installer.py
@@ -72,7 +72,8 @@ def _run_command(cmd):
 
     Uses shell=True when the command contains shell operators (pipes, &&, etc.)
     so that script-type installs like ``curl … | bash`` work correctly.
-    Commands come from the trusted registry, not from user input.
+    Callers must obtain approval before passing a free-form registry install
+    command here.
     """
     use_shell = any(c in cmd for c in _SHELL_METACHARACTERS)
     try:
@@ -117,6 +118,15 @@ def _install_strategy(cli):
     if cli.get("package_manager") == "bundled":
         return "bundled"
     return "command"
+
+
+def _requires_command_approval(cli):
+    """Return whether installing this entry uses the free-form command handler."""
+    if not cli.get("install_cmd"):
+        return False
+    strategy = _install_strategy(cli)
+    handlers = _STRATEGY_ACTIONS.get(strategy, _STRATEGY_ACTIONS["command"])
+    return handlers["install"] is _generic_install
 
 
 def _generic_install(cli):
@@ -218,34 +228,64 @@ def _pip_update(cli):
 # ── uv operations (public CLIs) ──
 
 
+def _run_uv_command(cmd, expected_action):
+    """Run a registry uv command as validated argv, never through a shell."""
+    uv = _find_uv()
+    if uv is None:
+        return None
+    try:
+        args = shlex.split(cmd)
+    except ValueError as exc:
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=2, stdout="", stderr=f"Invalid uv command: {exc}"
+        )
+    valid_prefix = (
+        len(args) >= 3
+        and Path(args[0]).name.lower() in {"uv", "uv.exe"}
+        and args[1:3] == ["tool", expected_action]
+    )
+    if not valid_prefix:
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=2,
+            stdout="",
+            stderr=(
+                "Invalid uv command: expected the command to start with "
+                f"'uv tool {expected_action}'."
+            ),
+        )
+    args[0] = uv
+    return subprocess.run(args, capture_output=True, text=True, shell=False)
+
+
 def _uv_install(cli):
-    if _find_uv() is None:
+    result = _run_uv_command(cli["install_cmd"], "install")
+    if result is None:
         return False, _UV_INSTALL_HINT
-    result = _run_command(cli["install_cmd"])
     if result.returncode == 0:
         return True, f"Installed {cli['display_name']} ({cli['entry_point']})"
     return False, f"uv install failed:\n{result.stderr or result.stdout}"
 
 
 def _uv_uninstall(cli):
-    if _find_uv() is None:
-        return False, _UV_INSTALL_HINT
     uninstall_cmd = cli.get("uninstall_cmd")
     if not uninstall_cmd:
         return False, f"No uninstall command is defined for {cli['display_name']}."
-    result = _run_command(uninstall_cmd)
+    result = _run_uv_command(uninstall_cmd, "uninstall")
+    if result is None:
+        return False, _UV_INSTALL_HINT
     if result.returncode == 0:
         return True, f"Uninstalled {cli['display_name']}"
     return False, f"uv uninstall failed:\n{result.stderr or result.stdout}"
 
 
 def _uv_update(cli):
-    if _find_uv() is None:
-        return False, _UV_INSTALL_HINT
     update_cmd = cli.get("update_cmd")
     if not update_cmd:
         return False, f"No update command is defined for {cli['display_name']}."
-    result = _run_command(update_cmd)
+    result = _run_uv_command(update_cmd, "upgrade")
+    if result is None:
+        return False, _UV_INSTALL_HINT
     if result.returncode == 0:
         return True, f"Updated {cli['display_name']}"
     return False, f"uv update failed:\n{result.stderr or result.stdout}"
@@ -298,17 +338,28 @@ def _npm_update(cli):
     return False, f"Update failed:\n{result.stderr}"
 
 
+_STRATEGY_ACTIONS = {
+    "pip": {"install": _pip_install, "uninstall": _pip_uninstall, "update": _pip_update},
+    "npm": {"install": _npm_install, "uninstall": _npm_uninstall, "update": _npm_update},
+    "uv": {"install": _uv_install, "uninstall": _uv_uninstall, "update": _uv_update},
+    "command": {
+        "install": _generic_install,
+        "uninstall": _generic_uninstall,
+        "update": _generic_update,
+    },
+    "bundled": {
+        "install": _bundled_install,
+        "uninstall": _bundled_uninstall,
+        "update": _bundled_update,
+    },
+}
+
+
 def _perform_action(cli, action):
     """Dispatch install/uninstall/update based on CLI strategy."""
     strategy = _install_strategy(cli)
-    actions = {
-        "pip": {"install": _pip_install, "uninstall": _pip_uninstall, "update": _pip_update},
-        "npm": {"install": _npm_install, "uninstall": _npm_uninstall, "update": _npm_update},
-        "uv": {"install": _uv_install, "uninstall": _uv_uninstall, "update": _uv_update},
-        "command": {"install": _generic_install, "uninstall": _generic_uninstall, "update": _generic_update},
-        "bundled": {"install": _bundled_install, "uninstall": _bundled_uninstall, "update": _bundled_update},
-    }
-    handler = actions.get(strategy, actions["command"]).get(action)
+    handlers = _STRATEGY_ACTIONS.get(strategy, _STRATEGY_ACTIONS["command"])
+    handler = handlers.get(action)
     return strategy, handler(cli)
 
 
@@ -336,11 +387,25 @@ def _installed_entry(cli, source, strategy):
 # ── Unified interface ──
 
 
-def install_cli(name):
-    """Install a CLI by name. Dispatches to pip or npm based on source. Returns (success, message)."""
-    cli = get_cli(name)
-    if cli is None:
-        return False, f"CLI '{name}' not found in registry. Use 'cli-hub list' to see available CLIs."
+def _approve_command_install(cli, command_approver):
+    """Obtain approval for a free-form command install."""
+    if _requires_command_approval(cli):
+        if command_approver is None:
+            return False, (
+                "Explicit approval is required before running this registry install command:\n"
+                f"  {json.dumps(cli['install_cmd'])}"
+            )
+        if not command_approver(cli["display_name"], cli["install_cmd"]):
+            return False, "Installation cancelled; the registry command was not executed."
+    return True, ""
+
+
+def _install_cli_entry(cli, command_approver=None, command_approved=False):
+    """Install one already-resolved registry entry."""
+    if not command_approved:
+        approved, message = _approve_command_install(cli, command_approver)
+        if not approved:
+            return False, message
 
     source = cli.get("_source", "harness")
     strategy, (success, msg) = _perform_action(cli, "install")
@@ -351,6 +416,21 @@ def install_cli(name):
         _save_installed(installed)
 
     return success, msg
+
+
+def install_cli(name, command_approver=None):
+    """Install a CLI by name.
+
+    Registry entries using the ``command`` strategy may execute arbitrary
+    commands, including remote scripts.  They therefore require an explicit
+    approval callback before the command is dispatched. The callback receives
+    ``(display_name, install_cmd)``. Keeping this check at the installer
+    boundary also protects non-CLI callers and matrix installs.
+    """
+    cli = get_cli(name)
+    if cli is None:
+        return False, f"CLI '{name}' not found in registry. Use 'cli-hub list' to see available CLIs."
+    return _install_cli_entry(cli, command_approver=command_approver)
 
 
 def uninstall_cli(name):
@@ -460,12 +540,15 @@ def plan_matrix_install(name, capability=None, recipe=None, only=None):
     return True, payload
 
 
-def install_matrix(name, capability=None, recipe=None, only=None, resume=False):
+def install_matrix(
+    name, capability=None, recipe=None, only=None, resume=False, command_approver=None
+):
     """Install the CLIs in a named matrix, optionally scoped (F2.2) or resumed (F2.3).
 
     Returns ``(success, payload)``. ``payload['arg_error']`` marks usage errors.
     Records per-CLI outcomes to ``matrix_state.json`` so ``--resume`` and
-    ``matrix doctor`` can act on them.
+    ``matrix doctor`` can act on them. Free-form commands are all approved via
+    ``command_approver(display_name, install_cmd)`` before any member runs.
     """
     matrix_item = get_matrix(name)
     if matrix_item is None:
@@ -497,28 +580,58 @@ def install_matrix(name, capability=None, recipe=None, only=None, resume=False):
         scope = scope_info["scope"]
 
     installed = set(get_installed())
-    results = []
-
+    install_items = []
     for cli_name in target_names:
         cli = get_cli(cli_name)
         display_name = cli["display_name"] if cli else cli_name
         via = _install_strategy(cli) if cli else None
 
         if cli_name in installed:
-            results.append({"name": cli_name, "display_name": display_name,
-                            "status": "skipped", "via": via, "message": "Already installed"})
-            continue
+            action = "skip"
+        elif cli is None:
+            action = "error"
+        else:
+            action = "install"
+        install_items.append({
+            "name": cli_name,
+            "display_name": display_name,
+            "via": via,
+            "cli": cli,
+            "action": action,
+        })
 
-        if cli is None:
-            results.append({"name": cli_name, "display_name": display_name,
-                            "status": "failed", "via": via, "message": "CLI not found in registry"})
+    # Authorize every free-form command before installing any matrix member, so
+    # declining a later command cannot leave an unexpectedly partial install.
+    for item in install_items:
+        if item["action"] != "install":
             continue
+        approved, message = _approve_command_install(item["cli"], command_approver)
+        if not approved:
+            return False, {
+                "error": message,
+                "matrix": matrix_item,
+                "scope": scope,
+                "cancelled": True,
+            }
 
-        success, msg = install_cli(cli_name)
-        results.append({"name": cli_name, "display_name": display_name,
-                        "status": "installed" if success else "failed", "via": via, "message": msg})
-        if success:
-            installed.add(cli_name)
+    results = []
+    for item in install_items:
+        if item["action"] == "skip":
+            status, message = "skipped", "Already installed"
+        elif item["action"] == "error":
+            status, message = "failed", "CLI not found in registry"
+        else:
+            success, message = _install_cli_entry(item["cli"], command_approved=True)
+            status = "installed" if success else "failed"
+            if success:
+                installed.add(item["name"])
+        results.append({
+            "name": item["name"],
+            "display_name": item["display_name"],
+            "status": status,
+            "via": item["via"],
+            "message": message,
+        })
 
     summary = {
         "total": len(results),

--- a/cli-hub/cli_hub/installer.py
+++ b/cli-hub/cli_hub/installer.py
@@ -188,6 +188,28 @@ def _bundled_update(cli):
     return False, note
 
 
+def _manual_install(cli):
+    """Return instructions for entries intentionally not installed by cli-hub."""
+    note = cli.get("install_notes") or (
+        f"{cli['display_name']} must be installed manually from its upstream instructions."
+    )
+    return False, note
+
+
+def _manual_uninstall(cli):
+    note = cli.get("uninstall_notes") or (
+        f"{cli['display_name']} was installed manually and must be removed manually."
+    )
+    return False, note
+
+
+def _manual_update(cli):
+    note = cli.get("update_notes") or (
+        f"{cli['display_name']} was installed manually and must be updated manually."
+    )
+    return False, note
+
+
 # ── pip operations (harness CLIs) ──
 
 
@@ -352,6 +374,11 @@ _STRATEGY_ACTIONS = {
         "uninstall": _bundled_uninstall,
         "update": _bundled_update,
     },
+    "manual": {
+        "install": _manual_install,
+        "uninstall": _manual_uninstall,
+        "update": _manual_update,
+    },
 }
 
 
@@ -505,6 +532,8 @@ def plan_matrix_install(name, capability=None, recipe=None, only=None):
             action, via = "skip", (_install_strategy(cli) if cli else None)
         elif cli is None:
             action, via = "error", None
+        elif _install_strategy(cli) == "manual":
+            action, via = "manual", "manual"
         else:
             action, via = "install", _install_strategy(cli)
         plan.append({
@@ -527,7 +556,7 @@ def plan_matrix_install(name, capability=None, recipe=None, only=None):
         "total": len(plan),
         "to_install": sum(1 for p in plan if p["action"] == "install"),
         "to_skip": sum(1 for p in plan if p["action"] == "skip"),
-        "unresolved": sum(1 for p in plan if p["action"] == "error"),
+        "unresolved": sum(1 for p in plan if p["action"] in {"error", "manual"}),
     }
     payload = {
         "matrix": matrix_item,
@@ -590,6 +619,8 @@ def install_matrix(
             action = "skip"
         elif cli is None:
             action = "error"
+        elif _install_strategy(cli) == "manual":
+            action = "manual"
         else:
             action = "install"
         install_items.append({
@@ -620,6 +651,8 @@ def install_matrix(
             status, message = "skipped", "Already installed"
         elif item["action"] == "error":
             status, message = "failed", "CLI not found in registry"
+        elif item["action"] == "manual":
+            status, message = "failed", _manual_install(item["cli"])[1]
         else:
             success, message = _install_cli_entry(item["cli"], command_approved=True)
             status = "installed" if success else "failed"

--- a/cli-hub/setup.py
+++ b/cli-hub/setup.py
@@ -50,7 +50,7 @@ class sdist(_sdist):
 
 setup(
     name="cli-anything-hub",
-    version="0.4.1",
+    version="0.4.2",
     description="Package manager for CLI-Anything — browse, install, and manage 40+ agent-native CLI interfaces for GUI applications",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/cli-hub/setup.py
+++ b/cli-hub/setup.py
@@ -50,7 +50,7 @@ class sdist(_sdist):
 
 setup(
     name="cli-anything-hub",
-    version="0.4.2",
+    version="0.4.3",
     description="Package manager for CLI-Anything — browse, install, and manage 40+ agent-native CLI interfaces for GUI applications",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/cli-hub/tests/test_cli_hub.py
+++ b/cli-hub/tests/test_cli_hub.py
@@ -973,9 +973,51 @@ class TestInstaller:
         }
         mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
 
-        success, msg = install_cli("onepassword-cli")
+        success, msg = install_cli(
+            "onepassword-cli", command_approver=lambda display_name, command: True
+        )
         assert success
         assert "1Password CLI" in msg
+
+    @patch("cli_hub.installer.subprocess.run")
+    @patch("cli_hub.installer.get_cli")
+    def test_install_command_strategy_requires_approval(self, mock_get_cli, mock_run):
+        install_cmd = "brew install --cask 1password-cli"
+        mock_get_cli.return_value = {
+            "name": "onepassword-cli",
+            "display_name": "1Password CLI",
+            "version": "latest",
+            "entry_point": "op",
+            "_source": "public",
+            "install_strategy": "command",
+            "install_cmd": install_cmd,
+        }
+
+        success, msg = install_cli("onepassword-cli")
+
+        assert not success
+        assert "approval is required" in msg
+        assert install_cmd in msg
+        mock_run.assert_not_called()
+
+    @patch("cli_hub.installer.subprocess.run")
+    @patch("cli_hub.installer.get_cli")
+    def test_unknown_install_strategy_fails_closed(self, mock_get_cli, mock_run):
+        mock_get_cli.return_value = {
+            "name": "future-tool",
+            "display_name": "Future Tool",
+            "version": "latest",
+            "entry_point": "future-tool",
+            "_source": "public",
+            "install_strategy": "future-strategy",
+            "install_cmd": "future-installer --install",
+        }
+
+        success, msg = install_cli("future-tool")
+
+        assert not success
+        assert "approval is required" in msg
+        mock_run.assert_not_called()
 
     @patch("cli_hub.installer.subprocess.run", side_effect=FileNotFoundError(2, "No such file or directory", "brew"))
     @patch("cli_hub.installer.get_cli")
@@ -993,7 +1035,9 @@ class TestInstaller:
             "install_cmd": "brew install --cask 1password-cli",
         }
 
-        success, msg = install_cli("onepassword-cli")
+        success, msg = install_cli(
+            "onepassword-cli", command_approver=lambda display_name, command: True
+        )
         assert not success
         assert "Command not found: brew" in msg
 
@@ -1053,6 +1097,9 @@ class TestUvStrategy:
         success, msg = install_cli("generate-veo-video")
         assert success
         assert "Generate Veo Video" in msg
+        args, kwargs = mock_run.call_args
+        assert args[0][0] == "/usr/bin/uv"
+        assert kwargs["shell"] is False
 
     @patch("cli_hub.installer.get_cli")
     @patch("cli_hub.installer._find_uv", return_value=None)
@@ -1063,6 +1110,40 @@ class TestUvStrategy:
         assert "uv is not installed" in msg
         assert "astral.sh/uv" in msg
         assert "brew install uv" in msg
+
+    @patch("cli_hub.installer.subprocess.run")
+    @patch("cli_hub.installer.get_cli")
+    @patch("cli_hub.installer._find_uv", return_value="/usr/bin/uv")
+    def test_uv_strategy_cannot_smuggle_a_shell_command(
+        self, mock_find_uv, mock_get_cli, mock_run
+    ):
+        mock_get_cli.return_value = {
+            **GENERATE_VEO_CLI,
+            "install_cmd": "curl -s https://example.com/install.sh | bash",
+        }
+
+        success, msg = install_cli("generate-veo-video")
+
+        assert not success
+        assert "expected the command to start with 'uv tool install'" in msg
+        mock_run.assert_not_called()
+
+    @patch("cli_hub.installer.subprocess.run")
+    @patch("cli_hub.installer.get_cli")
+    @patch("cli_hub.installer._find_uv", return_value="/usr/bin/uv")
+    def test_uv_strategy_rejects_non_install_subcommands(
+        self, mock_find_uv, mock_get_cli, mock_run
+    ):
+        mock_get_cli.return_value = {
+            **GENERATE_VEO_CLI,
+            "install_cmd": "uv run -- bash -c 'echo compromised'",
+        }
+
+        success, msg = install_cli("generate-veo-video")
+
+        assert not success
+        assert "expected the command to start with 'uv tool install'" in msg
+        mock_run.assert_not_called()
 
     @patch("cli_hub.installer.subprocess.run")
     @patch("cli_hub.installer.get_cli")
@@ -1178,7 +1259,9 @@ class TestScriptStrategy:
         mock_get_cli.return_value = JIMENG_CLI
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-        success, msg = install_cli("jimeng")
+        success, msg = install_cli(
+            "jimeng", command_approver=lambda display_name, command: True
+        )
 
         assert success, f"Expected success but got: {msg}"
         assert "Jimeng" in msg
@@ -1198,7 +1281,9 @@ class TestScriptStrategy:
             returncode=1, stdout="", stderr="curl: (6) Could not resolve host"
         )
 
-        success, msg = install_cli("jimeng")
+        success, msg = install_cli(
+            "jimeng", command_approver=lambda display_name, command: True
+        )
 
         assert not success
         assert "failed" in msg.lower()
@@ -1216,6 +1301,52 @@ class TestScriptStrategy:
 
     @patch("cli_hub.installer.subprocess.run")
     @patch("cli_hub.installer.get_cli")
+    def test_install_jimeng_rejected_without_execution(self, mock_get_cli, mock_run):
+        """A rejected registry command never reaches subprocess."""
+        mock_get_cli.return_value = JIMENG_CLI
+
+        success, msg = install_cli(
+            "jimeng", command_approver=lambda display_name, command: False
+        )
+
+        assert not success
+        assert "cancelled" in msg.lower()
+        mock_run.assert_not_called()
+
+    def test_matrix_authorizes_commands_before_any_install(self):
+        """Rejecting a later command entry leaves earlier safe members untouched."""
+        matrix_item = {"name": "demo", "display_name": "Demo", "clis": ["gimp", "jimeng"]}
+        safe_cli = {
+            "name": "gimp",
+            "display_name": "GIMP",
+            "version": "1.0.0",
+            "entry_point": "cli-anything-gimp",
+            "_source": "harness",
+            "install_cmd": "pip install cli-anything-gimp",
+        }
+        cli_entries = {"gimp": safe_cli, "jimeng": JIMENG_CLI}
+
+        with (
+            patch("cli_hub.installer.get_matrix", return_value=matrix_item),
+            patch("cli_hub.installer.get_cli", side_effect=cli_entries.get),
+            patch("cli_hub.installer.get_installed", return_value={}),
+            patch("cli_hub.installer._load_matrix_state", return_value={}),
+            patch("cli_hub.installer._save_matrix_state") as mock_save_state,
+            patch("cli_hub.installer.render_matrix_skill_file") as mock_render,
+            patch("cli_hub.installer.subprocess.run") as mock_run,
+        ):
+            success, payload = install_matrix(
+                "demo", command_approver=lambda display_name, command: False
+            )
+
+        assert not success
+        assert payload["cancelled"] is True
+        mock_run.assert_not_called()
+        mock_save_state.assert_not_called()
+        mock_render.assert_not_called()
+
+    @patch("cli_hub.installer.subprocess.run")
+    @patch("cli_hub.installer.get_cli")
     @patch("cli_hub.installer.INSTALLED_FILE", Path(tempfile.mktemp()))
     def test_install_jimeng_recorded_in_installed_json(self, mock_get_cli, mock_run):
         """After a successful install, jimeng appears in installed.json."""
@@ -1224,7 +1355,9 @@ class TestScriptStrategy:
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
         with patch("cli_hub.installer.INSTALLED_FILE", installed_file):
-            success, _ = install_cli("jimeng")
+            success, _ = install_cli(
+                "jimeng", command_approver=lambda display_name, command: True
+            )
             assert success
             data = json.loads(installed_file.read_text())
             assert "jimeng" in data
@@ -1697,6 +1830,85 @@ class TestCLI:
     @patch("cli_hub.cli.track_first_run")
     @patch("cli_hub.cli.track_visit")
     @patch("cli_hub.cli.detect_invocation_context")
+    @patch("cli_hub.cli.track_matrix_install")
+    @patch("cli_hub.cli.install_matrix")
+    def test_matrix_install_yes_approves_command_without_prompt(
+        self,
+        mock_install_matrix,
+        mock_track_matrix,
+        mock_detect,
+        mock_visit,
+        mock_first_run,
+    ):
+        mock_detect.return_value = self.agent_detection
+
+        def guarded_matrix_install(name, **kwargs):
+            assert kwargs["command_approver"](
+                JIMENG_CLI["display_name"], JIMENG_CLI["install_cmd"]
+            )
+            return True, {
+                "matrix": {"name": name},
+                "scope": {"type": "all"},
+                "results": [{
+                    "name": "jimeng",
+                    "status": "installed",
+                    "message": "Installed Jimeng / Dreamina CLI (dreamina)",
+                }],
+                "summary": {"installed": 1, "skipped": 0, "failed": 0},
+            }
+
+        mock_install_matrix.side_effect = guarded_matrix_install
+        result = self.runner.invoke(
+            main, ["matrix", "install", "video-creation", "--yes"]
+        )
+
+        assert result.exit_code == 0
+        assert "curl -s https://jimeng.jianying.com/cli | bash" in result.output
+        assert "Execute this command?" not in result.output
+        mock_track_matrix.assert_called_once()
+
+    @patch("cli_hub.cli.track_first_run")
+    @patch("cli_hub.cli.track_visit")
+    @patch("cli_hub.cli.detect_invocation_context")
+    @patch("cli_hub.cli.track_matrix_install")
+    @patch("cli_hub.cli.install_matrix")
+    def test_matrix_install_json_requires_yes_without_corrupting_stdout(
+        self,
+        mock_install_matrix,
+        mock_track_matrix,
+        mock_detect,
+        mock_visit,
+        mock_first_run,
+    ):
+        mock_detect.return_value = self.agent_detection
+
+        def guarded_matrix_install(name, **kwargs):
+            approved = kwargs["command_approver"](
+                JIMENG_CLI["display_name"], JIMENG_CLI["install_cmd"]
+            )
+            assert not approved
+            return False, {"error": "Installation cancelled; use --yes after review."}
+
+        mock_install_matrix.side_effect = guarded_matrix_install
+        try:
+            runner = click.testing.CliRunner(mix_stderr=False)
+        except TypeError:  # Click 8.2+ always captures the streams separately.
+            runner = click.testing.CliRunner()
+        result = runner.invoke(
+            main, ["matrix", "install", "video-creation", "--json"]
+        )
+
+        assert result.exit_code == 1
+        assert json.loads(result.stdout) == {
+            "error": "Installation cancelled; use --yes after review."
+        }
+        assert "curl -s https://jimeng.jianying.com/cli | bash" in result.stderr
+        assert "re-run with --yes" in result.stderr
+        mock_track_matrix.assert_called_once()
+
+    @patch("cli_hub.cli.track_first_run")
+    @patch("cli_hub.cli.track_visit")
+    @patch("cli_hub.cli.detect_invocation_context")
     @patch("cli_hub.cli.install_matrix", return_value=(False, {"error": "Matrix 'missing' not found."}))
     def test_matrix_install_command_not_found(self, mock_install_matrix, mock_detect, mock_visit, mock_first_run):
         mock_detect.return_value = self.human_detection
@@ -1774,6 +1986,145 @@ class TestCLI:
         assert result.exit_code == 0
         assert "Installed" in result.output
         mock_track.assert_called_once()
+
+    @patch("cli_hub.cli.track_first_run")
+    @patch("cli_hub.cli.track_visit")
+    @patch("cli_hub.cli.detect_invocation_context")
+    def test_install_help_documents_yes_option(
+        self, mock_detect, mock_visit, mock_first_run
+    ):
+        mock_detect.return_value = self.human_detection
+
+        install_help = self.runner.invoke(main, ["install", "--help"])
+        matrix_help = self.runner.invoke(main, ["matrix", "install", "--help"])
+
+        assert install_help.exit_code == 0
+        assert "-y, --yes" in install_help.output
+        assert matrix_help.exit_code == 0
+        assert "-y, --yes" in matrix_help.output
+
+    @patch("cli_hub.cli.track_first_run")
+    @patch("cli_hub.cli.track_visit")
+    @patch("cli_hub.cli.detect_invocation_context")
+    @patch("cli_hub.cli.track_install")
+    @patch("cli_hub.cli.get_cli", return_value=JIMENG_CLI)
+    @patch("cli_hub.cli.install_cli")
+    def test_command_install_defaults_to_no(
+        self, mock_install, mock_get, mock_track, mock_detect, mock_visit, mock_first_run
+    ):
+        mock_detect.return_value = self.human_detection
+
+        def guarded_install(name, command_approver):
+            if not command_approver(JIMENG_CLI["display_name"], JIMENG_CLI["install_cmd"]):
+                return False, "Installation cancelled; the registry command was not executed."
+            return True, "Installed Jimeng / Dreamina CLI (dreamina)"
+
+        mock_install.side_effect = guarded_install
+        with patch("cli_hub.cli._approval_streams_are_interactive", return_value=True):
+            result = self.runner.invoke(main, ["install", "jimeng"], input="\n")
+
+        assert result.exit_code == 1
+        assert "curl -s https://jimeng.jianying.com/cli | bash" in result.output
+        assert "Execute this command? [y/N]" in result.output
+        assert "cancelled" in result.output.lower()
+        mock_track.assert_not_called()
+
+    @patch("cli_hub.cli.track_first_run")
+    @patch("cli_hub.cli.track_visit")
+    @patch("cli_hub.cli.detect_invocation_context")
+    @patch("cli_hub.cli.track_install")
+    @patch("cli_hub.cli.get_cli", return_value=JIMENG_CLI)
+    @patch("cli_hub.cli.install_cli")
+    def test_command_install_accepts_interactive_confirmation(
+        self, mock_install, mock_get, mock_track, mock_detect, mock_visit, mock_first_run
+    ):
+        mock_detect.return_value = self.human_detection
+
+        def guarded_install(name, command_approver):
+            assert command_approver(JIMENG_CLI["display_name"], JIMENG_CLI["install_cmd"])
+            return True, "Installed Jimeng / Dreamina CLI (dreamina)"
+
+        mock_install.side_effect = guarded_install
+        with patch("cli_hub.cli._approval_streams_are_interactive", return_value=True):
+            result = self.runner.invoke(main, ["install", "jimeng"], input="y\n")
+
+        assert result.exit_code == 0
+        assert "curl -s https://jimeng.jianying.com/cli | bash" in result.output
+        assert "Execute this command? [y/N]" in result.output
+        mock_track.assert_called_once()
+
+    @patch("cli_hub.cli.track_first_run")
+    @patch("cli_hub.cli.track_visit")
+    @patch("cli_hub.cli.detect_invocation_context")
+    @patch("cli_hub.cli.track_install")
+    @patch("cli_hub.cli.get_cli", return_value=JIMENG_CLI)
+    @patch("cli_hub.cli.install_cli")
+    def test_command_install_yes_skips_prompt_but_shows_command(
+        self, mock_install, mock_get, mock_track, mock_detect, mock_visit, mock_first_run
+    ):
+        mock_detect.return_value = self.agent_detection
+
+        def guarded_install(name, command_approver):
+            assert command_approver(JIMENG_CLI["display_name"], JIMENG_CLI["install_cmd"])
+            return True, "Installed Jimeng / Dreamina CLI (dreamina)"
+
+        mock_install.side_effect = guarded_install
+        result = self.runner.invoke(main, ["install", "jimeng", "--yes"])
+
+        assert result.exit_code == 0
+        assert "curl -s https://jimeng.jianying.com/cli | bash" in result.output
+        assert "Execute this command?" not in result.output
+        mock_track.assert_called_once()
+
+    @patch("cli_hub.cli.track_first_run")
+    @patch("cli_hub.cli.track_visit")
+    @patch("cli_hub.cli.detect_invocation_context")
+    @patch("cli_hub.cli.track_install")
+    @patch("cli_hub.cli.get_cli", return_value=JIMENG_CLI)
+    @patch("cli_hub.cli.install_cli")
+    def test_command_warning_escapes_registry_control_characters(
+        self, mock_install, mock_get, mock_track, mock_detect, mock_visit, mock_first_run
+    ):
+        mock_detect.return_value = self.agent_detection
+        display_name = "Spoofed\n\x1b[2JName"
+        command = "echo safe\n\x1b[2Jfake prompt"
+
+        def guarded_install(name, command_approver):
+            assert command_approver(display_name, command)
+            return True, "Installed test command"
+
+        mock_install.side_effect = guarded_install
+        result = self.runner.invoke(main, ["install", "jimeng", "--yes"])
+
+        assert result.exit_code == 0
+        assert "\\n" in result.output
+        assert "\\u001b" in result.output
+        assert "\x1b" not in result.output
+        mock_track.assert_called_once()
+
+    @patch("cli_hub.cli.track_first_run")
+    @patch("cli_hub.cli.track_visit")
+    @patch("cli_hub.cli.detect_invocation_context")
+    @patch("cli_hub.cli.track_install")
+    @patch("cli_hub.cli.get_cli", return_value=JIMENG_CLI)
+    @patch("cli_hub.cli.install_cli")
+    def test_command_install_noninteractive_fails_closed(
+        self, mock_install, mock_get, mock_track, mock_detect, mock_visit, mock_first_run
+    ):
+        mock_detect.return_value = self.agent_detection
+
+        def guarded_install(name, command_approver):
+            if not command_approver(JIMENG_CLI["display_name"], JIMENG_CLI["install_cmd"]):
+                return False, "Installation cancelled; the registry command was not executed."
+            return True, "Installed Jimeng / Dreamina CLI (dreamina)"
+
+        mock_install.side_effect = guarded_install
+        result = self.runner.invoke(main, ["install", "jimeng"])
+
+        assert result.exit_code == 1
+        assert "re-run with --yes" in result.output
+        assert "Execute this command?" not in result.output
+        mock_track.assert_not_called()
 
     @patch("cli_hub.cli.track_first_run")
     @patch("cli_hub.cli.track_visit")

--- a/cli-hub/tests/test_cli_hub.py
+++ b/cli-hub/tests/test_cli_hub.py
@@ -48,6 +48,7 @@ from cli_hub.installer import (
     install_cli,
     install_matrix,
     uninstall_cli,
+    update_cli,
     get_installed,
     _load_installed,
     _save_installed,
@@ -1007,6 +1008,66 @@ class TestInstaller:
         assert "approval is required" in msg
         assert install_cmd in msg
         mock_run.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("action", "command_key"),
+        [("uninstall", "uninstall_cmd"), ("update", "update_cmd")],
+    )
+    @patch("cli_hub.installer.subprocess.run")
+    @patch("cli_hub.installer.get_cli")
+    def test_command_management_actions_require_approval(
+        self, mock_get_cli, mock_run, action, command_key
+    ):
+        command = f"tool {action} --from-registry"
+        mock_get_cli.return_value = {
+            "name": "managed-tool",
+            "display_name": "Managed Tool",
+            "version": "latest",
+            "entry_point": "managed-tool",
+            "_source": "public",
+            "install_strategy": "command",
+            command_key: command,
+        }
+
+        operation = uninstall_cli if action == "uninstall" else update_cli
+        success, msg = operation("managed-tool")
+
+        assert not success
+        assert f"registry {action} command" in msg
+        assert command in msg
+        mock_run.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("action", "command_key"),
+        [("uninstall", "uninstall_cmd"), ("update", "update_cmd")],
+    )
+    def test_command_management_actions_execute_after_approval(
+        self, action, command_key
+    ):
+        command = f"tool {action} --from-registry"
+        with (
+            patch("cli_hub.installer.subprocess.run") as mock_run,
+            patch("cli_hub.installer.get_cli") as mock_get_cli,
+            patch("cli_hub.installer.INSTALLED_FILE", Path(tempfile.mktemp())),
+        ):
+            mock_get_cli.return_value = {
+                "name": "managed-tool",
+                "display_name": "Managed Tool",
+                "version": "latest",
+                "entry_point": "managed-tool",
+                "_source": "public",
+                "install_strategy": "command",
+                command_key: command,
+            }
+            mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+            operation = uninstall_cli if action == "uninstall" else update_cli
+            success, _ = operation(
+                "managed-tool", command_approver=lambda display_name, approved_command: approved_command == command
+            )
+
+            assert success
+            mock_run.assert_called_once()
 
     @patch("cli_hub.installer.subprocess.run")
     @patch("cli_hub.installer.get_cli")
@@ -2075,16 +2136,22 @@ class TestCLI:
     @patch("cli_hub.cli.track_first_run")
     @patch("cli_hub.cli.track_visit")
     @patch("cli_hub.cli.detect_invocation_context")
-    def test_install_help_documents_yes_option(
+    def test_command_help_documents_yes_option(
         self, mock_detect, mock_visit, mock_first_run
     ):
         mock_detect.return_value = self.human_detection
 
         install_help = self.runner.invoke(main, ["install", "--help"])
+        update_help = self.runner.invoke(main, ["update", "--help"])
+        uninstall_help = self.runner.invoke(main, ["uninstall", "--help"])
         matrix_help = self.runner.invoke(main, ["matrix", "install", "--help"])
 
         assert install_help.exit_code == 0
         assert "-y, --yes" in install_help.output
+        assert update_help.exit_code == 0
+        assert "-y, --yes" in update_help.output
+        assert uninstall_help.exit_code == 0
+        assert "-y, --yes" in uninstall_help.output
         assert matrix_help.exit_code == 0
         assert "-y, --yes" in matrix_help.output
 
@@ -2221,6 +2288,28 @@ class TestCLI:
         result = self.runner.invoke(main, ["uninstall", "gimp"])
         assert result.exit_code == 0
         mock_track.assert_called_once()
+
+    @patch("cli_hub.cli.track_first_run")
+    @patch("cli_hub.cli.track_visit")
+    @patch("cli_hub.cli.detect_invocation_context")
+    @patch("cli_hub.cli.track_install")
+    @patch("cli_hub.cli.get_cli", return_value={"version": "latest"})
+    @patch("cli_hub.cli.update_cli")
+    def test_update_command_yes_passes_explicit_approval(
+        self, mock_update, mock_get_cli, mock_track, mock_detect, mock_visit, mock_first_run
+    ):
+        mock_detect.return_value = self.agent_detection
+
+        def guarded_update(name, command_approver):
+            assert command_approver("Managed Tool", "tool update --from-registry")
+            return True, "Updated Managed Tool"
+
+        mock_update.side_effect = guarded_update
+        result = self.runner.invoke(main, ["update", "managed-tool", "--yes"])
+
+        assert result.exit_code == 0
+        assert "tool update --from-registry" in result.output
+        mock_update.assert_called_once()
 
     @patch("cli_hub.cli.track_first_run")
     @patch("cli_hub.cli.track_visit")

--- a/cli-hub/tests/test_cli_hub.py
+++ b/cli-hub/tests/test_cli_hub.py
@@ -378,6 +378,14 @@ def _make_preview_session(tmp_path: Path, *, with_trajectory: bool = False) -> P
 class TestRegistry:
     """Tests for registry.py — fetch, cache, search, and lookup."""
 
+    def test_openapi_documents_remote_script_integrity_metadata(self):
+        schema_path = Path(__file__).resolve().parents[2] / "docs" / "hub" / "openapi.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        remote_script = schema["components"]["schemas"]["RemoteScript"]
+
+        assert remote_script["required"] == ["url", "sha256", "interpreter"]
+        assert remote_script["properties"]["sha256"]["pattern"] == "^[A-Fa-f0-9]{64}$"
+
     @patch("cli_hub.registry.requests.get")
     @patch("cli_hub.registry.CACHE_FILE", Path(tempfile.mktemp()))
     def test_fetch_registry_from_remote(self, mock_get):
@@ -1203,6 +1211,27 @@ JIMENG_CLI = {
 }
 
 
+MANUAL_JIMENG_CLI = {
+    "name": "jimeng",
+    "display_name": "Jimeng / Dreamina CLI",
+    "version": "1.4.10",
+    "description": "Official ByteDance AI image and video generation CLI",
+    "category": "ai",
+    "entry_point": "dreamina",
+    "_source": "public",
+    "package_manager": "manual",
+    "install_strategy": "manual",
+    "install_instructions_url": "https://jimeng.jianying.com/ai-tool/install",
+    "remote_script": {
+        "url": "https://jimeng.jianying.com/cli",
+        "sha256": "3d9a5cade9c94420b13c46f1a425d657e22225c926b06a4608eae32065d7e158",
+        "interpreter": "bash",
+        "integrity_scope": "bootstrap-only; upstream does not publish checksums for the downloaded CLI binaries",
+    },
+    "install_notes": "Automatic installation is disabled: upstream artifacts are not fully verifiable.",
+}
+
+
 class TestScriptStrategy:
     """Tests for script/pipe-command installs (e.g. jimeng curl | bash)."""
 
@@ -1217,6 +1246,45 @@ class TestScriptStrategy:
         cli = {**JIMENG_CLI}
         del cli["install_strategy"]
         assert _install_strategy(cli) == "command"
+
+    def test_public_jimeng_is_manual_with_audited_bootstrap_metadata(self):
+        registry_path = Path(__file__).resolve().parents[2] / "public_registry.json"
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+        jimeng = next(cli for cli in registry["clis"] if cli["name"] == "jimeng")
+
+        assert jimeng["install_strategy"] == "manual"
+        assert jimeng["package_manager"] == "manual"
+        assert "install_cmd" not in jimeng
+        assert jimeng["remote_script"]["url"] == "https://jimeng.jianying.com/cli"
+        assert len(jimeng["remote_script"]["sha256"]) == 64
+        assert "bootstrap-only" in jimeng["remote_script"]["integrity_scope"]
+
+    @patch("cli_hub.installer.subprocess.run")
+    @patch("cli_hub.installer.get_cli")
+    def test_manual_jimeng_install_never_executes(self, mock_get_cli, mock_run):
+        mock_get_cli.return_value = MANUAL_JIMENG_CLI
+
+        success, message = install_cli("jimeng")
+
+        assert not success
+        assert "Automatic installation is disabled" in message
+        mock_run.assert_not_called()
+
+    def test_matrix_plan_marks_manual_cli_unresolved(self):
+        from cli_hub.installer import plan_matrix_install
+
+        matrix_item = {"name": "demo", "display_name": "Demo", "clis": ["jimeng"]}
+        with (
+            patch("cli_hub.installer.get_matrix", return_value=matrix_item),
+            patch("cli_hub.installer.get_cli", return_value=MANUAL_JIMENG_CLI),
+            patch("cli_hub.installer.get_installed", return_value={}),
+        ):
+            success, payload = plan_matrix_install("demo")
+
+        assert success
+        assert payload["plan"][0]["action"] == "manual"
+        assert payload["summary"]["to_install"] == 0
+        assert payload["summary"]["unresolved"] == 1
 
     # ── _run_command shell detection ───────────────────────────────────
 
@@ -1973,6 +2041,23 @@ class TestCLI:
         mock_detect.return_value = self.human_detection
         result = self.runner.invoke(main, ["info", "nonexistent"])
         assert result.exit_code == 1
+
+    @patch("cli_hub.cli.track_first_run")
+    @patch("cli_hub.cli.track_visit")
+    @patch("cli_hub.cli.detect_invocation_context")
+    @patch("cli_hub.cli.get_installed", return_value={})
+    @patch("cli_hub.cli.get_cli", return_value=MANUAL_JIMENG_CLI)
+    def test_info_shows_manual_remote_script_metadata(
+        self, mock_get, mock_installed, mock_detect, mock_visit, mock_first_run
+    ):
+        mock_detect.return_value = self.human_detection
+        result = self.runner.invoke(main, ["info", "jimeng"])
+
+        assert result.exit_code == 0
+        assert "Install via: manual" in result.output
+        assert "Automatic installation is disabled" in result.output
+        assert "Remote script: https://jimeng.jianying.com/cli" in result.output
+        assert "Script SHA-256:" in result.output
 
     @patch("cli_hub.cli.track_first_run")
     @patch("cli_hub.cli.track_visit")

--- a/docs/hub/openapi.json
+++ b/docs/hub/openapi.json
@@ -177,8 +177,18 @@
           "install_cmd": {
             "type": "string"
           },
+          "install_strategy": {
+            "type": "string"
+          },
           "package_manager": {
             "type": "string"
+          },
+          "install_instructions_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "remote_script": {
+            "$ref": "#/components/schemas/RemoteScript"
           },
           "homepage": {
             "type": "string",
@@ -198,6 +208,32 @@
           "category"
         ],
         "additionalProperties": true
+      },
+      "RemoteScript": {
+        "type": "object",
+        "description": "Audited metadata for an upstream remote bootstrap script. A digest may cover only the bootstrap and not any artifacts it subsequently downloads.",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[A-Fa-f0-9]{64}$"
+          },
+          "interpreter": {
+            "type": "string"
+          },
+          "integrity_scope": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "sha256",
+          "interpreter"
+        ],
+        "additionalProperties": false
       }
     }
   }

--- a/public_registry.json
+++ b/public_registry.json
@@ -277,16 +277,23 @@
     {
       "name": "jimeng",
       "display_name": "Jimeng / Dreamina CLI",
-      "version": "latest",
+      "version": "1.4.10",
       "description": "Official ByteDance AI image and video generation CLI — text-to-image, text-to-video, image-to-video, digital human, and intelligent canvas; domestic brand is Jimeng (即梦), international brand is Dreamina",
       "category": "ai",
       "requires": "Jimeng / Dreamina account and API key",
       "homepage": "https://jimeng.jianying.com/",
       "docs_url": "https://bytedance.larkoffice.com/wiki/FVTwwm0bGiishxkKOoScdHR2nsg",
       "source_url": null,
-      "package_manager": "script",
-      "install_strategy": "command",
-      "install_cmd": "curl -s https://jimeng.jianying.com/cli | bash",
+      "package_manager": "manual",
+      "install_strategy": "manual",
+      "install_instructions_url": "https://jimeng.jianying.com/ai-tool/install",
+      "remote_script": {
+        "url": "https://jimeng.jianying.com/cli",
+        "sha256": "3d9a5cade9c94420b13c46f1a425d657e22225c926b06a4608eae32065d7e158",
+        "interpreter": "bash",
+        "integrity_scope": "bootstrap-only; upstream does not publish checksums for the downloaded CLI binaries"
+      },
+      "install_notes": "Automatic installation is disabled: the official bootstrap script downloads additional mutable binaries without published checksums. Review the official instructions and verify upstream artifacts before installing manually.",
       "skill_md": "https://bytedance.larkoffice.com/wiki/FVTwwm0bGiishxkKOoScdHR2nsg",
       "entry_point": "dreamina",
       "contributors": [


### PR DESCRIPTION
## Summary

Fixes #373.

CLI-Hub previously dispatched registry `command` entries through the shell when their command contained shell operators. The public Jimeng entry used an unpinned `curl | bash` bootstrap command.

This PR hardens the complete registry-command boundary:

- displays the exact escaped registry command and requires an interactive default-No confirmation;
- makes non-interactive and JSON command invocations fail closed unless the caller explicitly supplies `--yes`;
- applies the same approval boundary to free-form install, update, uninstall, and matrix-install commands;
- keeps npm, pip, uv, bundled, and manual strategies on their dedicated paths; uv commands are validated argv and never run through a shell;
- changes Jimeng to a fail-closed `manual` strategy. CLI-Hub exposes the official instructions, bootstrap URL, SHA-256, interpreter, and integrity scope, but never executes it;
- documents the policy and adds the remote-script metadata to the public registry/OpenAPI schema.

The manual Jimeng policy is intentional: its official bootstrap script downloads additional mutable CLI binaries for which the upstream does not publish checksums, so checking only the bootstrap file would not provide end-to-end integrity.

## Validation

- Focused security/install/matrix regression suite: `59 passed`
- Full related suite: `163 passed`; the remaining `24` failures are pre-existing Windows-only environment baselines (cache permission, symlink privilege, GBK decoding, and preview expectations).
- `py -m compileall -q cli_hub tests`
- `git diff --check`
- Static registry audit: zero public `install_cmd` values matching a remote-script pipe pattern.
- Re-fetched the official Jimeng bootstrap script and verified the recorded SHA-256: `3d9a5cade9c94420b13c46f1a425d657e22225c926b06a4608eae32065d7e158` (12,497 bytes).