### PR TITLE
registry: update meerk40t entry (v1.2.0, 3d category)

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,7 +773,7 @@ The meta-skill points agents to the live CLI-Hub catalog, where they can choose 
 | **🌐 Network & Infrastructure** | Manage network services, DNS, ad-blocking, and infrastructure through structured CLI commands | AdGuardHome |
 | **🧪 Testing & Mocking** | Control HTTP mock servers, manage test stubs, record and replay API traffic for integration testing | **[WireMock](https://wiremock.org)** |
 | **🔬 Graphics & GPU Debugging** | Analyze GPU frame captures, inspect pipeline state, export shaders, and diff rendering state | RenderDoc |
-| **⚙️ Fabrication & Machine Control** | Drive real hardware from design file to physical output — device connection, motion control, and machine-ready exports over the software's real backend | MeerK40t (laser), Ink/Stitch (embroidery) |
+| **⚙️ Fabrication & Machine Control** | Drive real hardware from design file to physical output — safety-gated detect, preflight, jog, and framing commands with machine profiles over the software's real backend | MeerK40t (laser), Ink/Stitch (embroidery) |
 | **🎬 Video & Subtitles** | Transcribe speech, translate subtitles, burn styled captions into video — full captioning pipeline | VideoCaptioner |
 | **🔍 AI-Native Search** | Neural and deep web search with structured content retrieval through embedding-based APIs | [Exa](https://exa.ai) |
 | **✨ AI Content Generation** | Generate professional deliverables (slides, docs, diagrams, websites, research reports) through AI-powered cloud APIs | [AnyGen](https://www.anygen.io), Gamma, Beautiful.ai, Tome |

--- a/README.md
+++ b/README.md
@@ -773,6 +773,7 @@ The meta-skill points agents to the live CLI-Hub catalog, where they can choose 
 | **🌐 Network & Infrastructure** | Manage network services, DNS, ad-blocking, and infrastructure through structured CLI commands | AdGuardHome |
 | **🧪 Testing & Mocking** | Control HTTP mock servers, manage test stubs, record and replay API traffic for integration testing | **[WireMock](https://wiremock.org)** |
 | **🔬 Graphics & GPU Debugging** | Analyze GPU frame captures, inspect pipeline state, export shaders, and diff rendering state | RenderDoc |
+| **⚙️ Fabrication & Machine Control** | Drive real hardware from design file to physical output — safety-gated connect, preflight, jog, and framing commands with live position feedback | MeerK40t (laser), Ink/Stitch (embroidery) |
 | **🎬 Video & Subtitles** | Transcribe speech, translate subtitles, burn styled captions into video — full captioning pipeline | VideoCaptioner |
 | **🔍 AI-Native Search** | Neural and deep web search with structured content retrieval through embedding-based APIs | [Exa](https://exa.ai) |
 | **✨ AI Content Generation** | Generate professional deliverables (slides, docs, diagrams, websites, research reports) through AI-powered cloud APIs | [AnyGen](https://www.anygen.io), Gamma, Beautiful.ai, Tome |

--- a/README.md
+++ b/README.md
@@ -773,7 +773,7 @@ The meta-skill points agents to the live CLI-Hub catalog, where they can choose 
 | **🌐 Network & Infrastructure** | Manage network services, DNS, ad-blocking, and infrastructure through structured CLI commands | AdGuardHome |
 | **🧪 Testing & Mocking** | Control HTTP mock servers, manage test stubs, record and replay API traffic for integration testing | **[WireMock](https://wiremock.org)** |
 | **🔬 Graphics & GPU Debugging** | Analyze GPU frame captures, inspect pipeline state, export shaders, and diff rendering state | RenderDoc |
-| **⚙️ Fabrication & Machine Control** | Drive real hardware from design file to physical output — safety-gated connect, preflight, jog, and framing commands with live position feedback | MeerK40t (laser), Ink/Stitch (embroidery) |
+| **⚙️ Fabrication & Machine Control** | Drive real hardware from design file to physical output — device connection, motion control, and machine-ready exports over the software's real backend | MeerK40t (laser), Ink/Stitch (embroidery) |
 | **🎬 Video & Subtitles** | Transcribe speech, translate subtitles, burn styled captions into video — full captioning pipeline | VideoCaptioner |
 | **🔍 AI-Native Search** | Neural and deep web search with structured content retrieval through embedding-based APIs | [Exa](https://exa.ai) |
 | **✨ AI Content Generation** | Generate professional deliverables (slides, docs, diagrams, websites, research reports) through AI-powered cloud APIs | [AnyGen](https://www.anygen.io), Gamma, Beautiful.ai, Tome |

--- a/registry.json
+++ b/registry.json
@@ -1461,7 +1461,7 @@
       "name": "meerk40t",
       "display_name": "MeerK40t",
       "version": "1.2.0",
-      "description": "Laser cutting/engraving via the real MeerK40t kernel — elements, operations, SVG/G-code export, and real GRBL hardware control (detect, preflight, jog, frame) with --json output",
+      "description": "Laser cutting/engraving via the real MeerK40t kernel — elements, operations, SVG/G-code export, and real GRBL device connection and motion control with --json output",
       "requires": "MeerK40t (installed automatically)",
       "homepage": "https://github.com/meerk40t/meerk40t",
       "source_url": "https://github.com/George-RD/cli-anything-meerk40t",

--- a/registry.json
+++ b/registry.json
@@ -1460,15 +1460,15 @@
     {
       "name": "meerk40t",
       "display_name": "MeerK40t",
-      "version": "1.0.0",
-      "description": "Laser cutting/engraving job preparation via the real MeerK40t kernel — elements, operations, SVG/G-code export with --json output",
+      "version": "1.2.0",
+      "description": "Laser cutting/engraving via the real MeerK40t kernel — elements, operations, SVG/G-code export, and real GRBL hardware control (detect, preflight, jog, frame) with --json output",
       "requires": "MeerK40t (installed automatically)",
       "homepage": "https://github.com/meerk40t/meerk40t",
       "source_url": "https://github.com/George-RD/cli-anything-meerk40t",
       "install_cmd": "pip install cli-anything-meerk40t",
       "entry_point": "cli-anything-meerk40t",
       "skill_md": "https://github.com/George-RD/cli-anything-meerk40t/blob/main/skills/cli-anything-meerk40t/SKILL.md",
-      "category": "graphics",
+      "category": "design",
       "contributors": [
         {
           "name": "George-RD",

--- a/registry.json
+++ b/registry.json
@@ -1460,8 +1460,8 @@
     {
       "name": "meerk40t",
       "display_name": "MeerK40t",
-      "version": "1.2.0",
-      "description": "Laser cutting/engraving via the real MeerK40t kernel — elements, operations, SVG/G-code export, and real GRBL device connection and motion control with --json output",
+      "version": "1.3.0",
+      "description": "Laser cutting/engraving via the real MeerK40t kernel — elements, operations, SVG/G-code export with placement guard, and real GRBL hardware control (detect, preflight check, jog, frame) with machine profiles and --json output",
       "requires": "MeerK40t (installed automatically)",
       "homepage": "https://github.com/meerk40t/meerk40t",
       "source_url": "https://github.com/George-RD/cli-anything-meerk40t",

--- a/registry.json
+++ b/registry.json
@@ -1468,7 +1468,7 @@
       "install_cmd": "pip install cli-anything-meerk40t",
       "entry_point": "cli-anything-meerk40t",
       "skill_md": "https://github.com/George-RD/cli-anything-meerk40t/blob/main/skills/cli-anything-meerk40t/SKILL.md",
-      "category": "design",
+      "category": "3d",
       "contributors": [
         {
           "name": "George-RD",


### PR DESCRIPTION
Updates the existing meerk40t entry (added in #374):

- version 1.0.0 -> 1.3.0 (live on PyPI)
- category graphics -> 3d, alongside FreeCAD (CAM/G-code): laser engraving is machine-control/G-code territory and 3D & CAD is where fabrication tools live in the hub
- description updated for the released hardware-control commands (device detect/check/jog/frame, machine profiles, export placement guard) - all shipped and live-verified against a Sculpfun S9
- README: new 'Fabrication & Machine Control' row in the When to Use table (MeerK40t + Ink/Stitch)

install_cmd and skill_md unchanged and verified live.