### PR TITLE
fix(cli-hub): recover from corrupt registry caches

### DIFF
--- a/cli-hub/cli_hub/matrix.py
+++ b/cli-hub/cli_hub/matrix.py
@@ -43,9 +43,16 @@ def _load_cached_data():
     if not MATRIX_CACHE_FILE.exists():
         return None
     try:
-        cached = json.loads(MATRIX_CACHE_FILE.read_text())
+        cached = json.loads(MATRIX_CACHE_FILE.read_text(encoding="utf-8"))
         return cached["data"]
-    except (json.JSONDecodeError, KeyError):
+    except (
+        OSError,
+        UnicodeError,
+        json.JSONDecodeError,
+        AttributeError,
+        KeyError,
+        TypeError,
+    ):
         return None
 
 
@@ -68,10 +75,17 @@ def fetch_matrix_registry(force_refresh=False):
 
     if not force_refresh and MATRIX_CACHE_FILE.exists():
         try:
-            cached = json.loads(MATRIX_CACHE_FILE.read_text())
+            cached = json.loads(MATRIX_CACHE_FILE.read_text(encoding="utf-8"))
             if time.time() - cached.get("_cached_at", 0) < CACHE_TTL:
                 return cached["data"]
-        except (json.JSONDecodeError, KeyError):
+        except (
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+            AttributeError,
+            KeyError,
+            TypeError,
+        ):
             pass
 
     try:
@@ -87,7 +101,10 @@ def fetch_matrix_registry(force_refresh=False):
             return local_data
         raise
 
-    MATRIX_CACHE_FILE.write_text(json.dumps({"_cached_at": time.time(), "data": data}, indent=2))
+    MATRIX_CACHE_FILE.write_text(
+        json.dumps({"_cached_at": time.time(), "data": data}, indent=2),
+        encoding="utf-8",
+    )
     return data
 
 

--- a/cli-hub/cli_hub/registry.py
+++ b/cli-hub/cli_hub/registry.py
@@ -23,9 +23,16 @@ def _load_cached_data(cache_file):
     if not cache_file.exists():
         return None
     try:
-        cached = json.loads(cache_file.read_text())
+        cached = json.loads(cache_file.read_text(encoding="utf-8"))
         return cached["data"]
-    except (json.JSONDecodeError, KeyError):
+    except (
+        OSError,
+        UnicodeError,
+        json.JSONDecodeError,
+        AttributeError,
+        KeyError,
+        TypeError,
+    ):
         return None
 
 
@@ -35,10 +42,17 @@ def _fetch_json(url, cache_file, force_refresh=False):
 
     if not force_refresh and cache_file.exists():
         try:
-            cached = json.loads(cache_file.read_text())
+            cached = json.loads(cache_file.read_text(encoding="utf-8"))
             if time.time() - cached.get("_cached_at", 0) < CACHE_TTL:
                 return cached["data"]
-        except (json.JSONDecodeError, KeyError):
+        except (
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+            AttributeError,
+            KeyError,
+            TypeError,
+        ):
             pass
 
     try:
@@ -52,7 +66,7 @@ def _fetch_json(url, cache_file, force_refresh=False):
         raise
 
     cache_payload = {"_cached_at": time.time(), "data": data}
-    cache_file.write_text(json.dumps(cache_payload, indent=2))
+    cache_file.write_text(json.dumps(cache_payload, indent=2), encoding="utf-8")
 
     return data
 

--- a/cli-hub/tests/test_cli_hub.py
+++ b/cli-hub/tests/test_cli_hub.py
@@ -402,6 +402,24 @@ class TestRegistry:
         assert result["clis"][0]["name"] == "gimp"
         mock_get.assert_called_once()
 
+    @pytest.mark.parametrize("cache_contents", [b"\xff", b"[]"])
+    @patch("cli_hub.registry.requests.get")
+    def test_fetch_registry_recovers_from_invalid_cache(
+        self, mock_get, tmp_path, cache_contents
+    ):
+        cache_file = tmp_path / "registry_cache.json"
+        cache_file.write_bytes(cache_contents)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_REGISTRY
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        with patch("cli_hub.registry.CACHE_FILE", cache_file):
+            result = fetch_registry()
+
+        assert result["clis"][0]["name"] == "gimp"
+        mock_get.assert_called_once()
+
     @patch("cli_hub.registry.fetch_public_registry", return_value=None)
     @patch("cli_hub.registry.fetch_registry")
     def test_fetch_all_clis_does_not_mutate_registry_entries(self, mock_fetch_registry, mock_fetch_public):
@@ -474,6 +492,24 @@ class TestMatrixRegistry:
         mock_get.return_value = mock_resp
 
         result = fetch_matrix_registry(force_refresh=True)
+        assert result["matrices"][0]["name"] == "video-creation"
+        mock_get.assert_called_once()
+
+    @pytest.mark.parametrize("cache_contents", [b"\xff", b"[]"])
+    @patch("cli_hub.matrix.requests.get")
+    def test_fetch_matrix_registry_recovers_from_invalid_cache(
+        self, mock_get, tmp_path, cache_contents
+    ):
+        cache_file = tmp_path / "matrix_registry_cache.json"
+        cache_file.write_bytes(cache_contents)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = SAMPLE_MATRIX_REGISTRY
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        with patch("cli_hub.matrix.MATRIX_CACHE_FILE", cache_file):
+            result = fetch_matrix_registry()
+
         assert result["matrices"][0]["name"] == "video-creation"
         mock_get.assert_called_once()
 


### PR DESCRIPTION
## Description

CLI-Hub currently treats malformed JSON as a cache miss, but a registry cache containing non-UTF-8 bytes or an unexpected JSON shape raises before the hub can refresh it. This can leave registry and matrix commands unusable until the cache is deleted manually.

Treat cache read, decode, and shape errors as cache misses in both registry readers, and use explicit UTF-8 for cache I/O. The next command can then fetch fresh data and replace the damaged cache normally.

## Type of Change

- [x] **Bug Fix** — fixes incorrect behavior

## General Checklist

- [x] Code follows existing patterns and conventions
- [x] No new commands or command flags were added
- [x] Commit message follows the conventional format
- [x] I have tested my changes locally

## Test Results

```text
155 passed in 2.50s
```
