### PR TITLE
fix(openrefine): support non-TTY REPL input

### DIFF
--- a/openrefine/agent-harness/cli_anything/openrefine/__init__.py
+++ b/openrefine/agent-harness/cli_anything/openrefine/__init__.py
@@ -1,3 +1,3 @@
 """CLI-Anything harness for OpenRefine."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/openrefine/agent-harness/cli_anything/openrefine/openrefine_cli.py
+++ b/openrefine/agent-harness/cli_anything/openrefine/openrefine_cli.py
@@ -69,7 +69,11 @@ def repl(ctx: click.Context) -> None:
     history_file = _repl_history_file(ctx)
     skin = ReplSkin("openrefine", version=__version__, history_file=history_file)
     skin.print_banner()
-    prompt = skin.create_prompt_session()
+    prompt = (
+        skin.create_prompt_session()
+        if sys.stdin.isatty() and sys.stdout.isatty()
+        else None
+    )
     commands = {
         "status": "Check backend and session",
         "projects": "List OpenRefine projects",

--- a/openrefine/agent-harness/cli_anything/openrefine/tests/test_core.py
+++ b/openrefine/agent-harness/cli_anything/openrefine/tests/test_core.py
@@ -463,10 +463,11 @@ def test_cli_default_enters_repl_and_exits(monkeypatch):
         "create_prompt_session",
         fail_if_prompt_session_is_created,
     )
-    result = CliRunner().invoke(cli, input="exit\n")
+    result = CliRunner().invoke(cli, input="help\nexit\n")
     assert result.exit_code == 0
     assert "cli-anything" in result.output
     assert "Openrefine" in result.output
+    assert "Commands" in result.output
 
 
 def test_openrefine_error_is_runtime_error():

--- a/openrefine/agent-harness/cli_anything/openrefine/tests/test_core.py
+++ b/openrefine/agent-harness/cli_anything/openrefine/tests/test_core.py
@@ -454,7 +454,15 @@ def test_cli_session_show_json_uses_custom_path(tmp_path):
     assert json.loads(result.output)["base_url"].startswith("http")
 
 
-def test_cli_default_enters_repl_and_exits():
+def test_cli_default_enters_repl_and_exits(monkeypatch):
+    def fail_if_prompt_session_is_created(self):
+        raise AssertionError("PromptSession should not be created for non-TTY Click streams")
+
+    monkeypatch.setattr(
+        openrefine_cli.ReplSkin,
+        "create_prompt_session",
+        fail_if_prompt_session_is_created,
+    )
     result = CliRunner().invoke(cli, input="exit\n")
     assert result.exit_code == 0
     assert "cli-anything" in result.output

--- a/openrefine/agent-harness/setup.py
+++ b/openrefine/agent-harness/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_namespace_packages, setup
 
 setup(
     name="cli-anything-openrefine",
-    version="1.0.0",
+    version="1.0.1",
     description="CLI-Anything harness for OpenRefine data wrangling workflows",
     long_description="Agent-native Click CLI for OpenRefine's local HTTP API, operation histories, exports, and sessions.",
     author="CLI-Anything-Team",

--- a/registry.json
+++ b/registry.json
@@ -27,7 +27,7 @@
     {
       "name": "openrefine",
       "display_name": "OpenRefine",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Agent-native CLI for OpenRefine import, operation-history cleaning, row inspection, export, and session undo/redo through the real local HTTP API.",
       "requires": "OpenRefine 3.10.x or newer running as a local web server",
       "homepage": "https://openrefine.org/",


### PR DESCRIPTION
## Description

Use the plain `input()` REPL path when stdin or stdout is redirected instead of constructing a prompt-toolkit session that requires an interactive Windows console. Interactive terminals still retain prompt-toolkit history, styling, and completion.

Fixes #384

## Type of Change

- [ ] **New Software CLI (in-repo)** — adds a CLI harness inside this monorepo
- [ ] **New Software CLI (standalone repo)** — registry-only PR pointing to an external repo
- [ ] **New Feature** — adds new functionality to an existing harness or the plugin
- [x] **Bug Fix** — fixes incorrect behavior
- [ ] **Documentation** — updates docs only
- [ ] **Other** — please describe:

### For Existing CLI Modifications

- [x] All unit tests pass: `python3 -m pytest cli_anything/openrefine/tests/test_core.py -v`
- [ ] All E2E tests pass: requires a running OpenRefine backend, which was not available locally
- [x] No test regressions — no previously passing tests were removed or weakened
- [x] `registry.json` entry is updated for version 1.0.1

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands (no new commands)
- [x] Commit messages follow the conventional format
- [x] I have tested my changes locally

## Test Results

```text
$ python3 -m pytest cli_anything/openrefine/tests/test_core.py -q
........................................................................ [ 94%]
....                                                                     [100%]
76 passed in 0.08s
```

Redirected subprocess check on macOS/Python 3.12:

```text
$ printf 'help\nexit\n' | cli-anything-openrefine
# REPL displayed the command list, consumed both commands, printed Goodbye!, and exited 0.
```
