### PR TITLE
fix(skill-generator): parse common install commands

### DIFF
--- a/cli-anything-plugin/skill_generator.py
+++ b/cli-anything-plugin/skill_generator.py
@@ -180,21 +180,14 @@ def extract_system_package(content: str) -> Optional[str]:
     """Extract system package installation command from README."""
     # Look for apt/brew install patterns
     patterns = [
-        r"`apt install ([\w\-]+)`",
-        r"`brew install ([\w\-]+)`",
-        r"`apt-get install ([\w\-]+)`",
+        r"`((?:sudo\s+)?apt(?:-get)?\s+install\s+[\w.+/-]+(?:\s+[\w.+/-]+)*)`",
+        r"`(brew\s+install(?:\s+--cask)?\s+[\w.+@/-]+(?:\s+[\w.+@/-]+)*)`",
     ]
 
     for pattern in patterns:
         match = re.search(pattern, content)
         if match:
-            package = match.group(1)
-            if "apt-get" in pattern:
-                return f"apt-get install {package}"
-            elif "apt" in pattern:
-                return f"apt install {package}"
-            elif "brew" in pattern:
-                return f"brew install {package}"
+            return match.group(1)
 
     return None
 

--- a/cli-anything-plugin/tests/test_skill_generator.py
+++ b/cli-anything-plugin/tests/test_skill_generator.py
@@ -361,10 +361,22 @@ class TestExtractSystemPackage:
         result = extract_system_package(content)
         assert result == "brew install mytool"
 
+    def test_sudo_apt_install(self):
+        content = "Install with `sudo apt install freecad`."
+        result = extract_system_package(content)
+        assert result == "sudo apt install freecad"
+
+    def test_brew_cask_install(self):
+        content = "Install with `brew install --cask krita`."
+        result = extract_system_package(content)
+        assert result == "brew install --cask krita"
+
+    def test_multiple_apt_packages(self):
+        content = "Install with `apt install melt ffmpeg`."
+        result = extract_system_package(content)
+        assert result == "apt install melt ffmpeg"
+
     def test_apt_get_install_returns_apt_get_command(self):
-        # Regression: apt-get pattern contains "apt" as a substring, so the
-        # condition must check "apt-get" before "apt" to avoid returning the
-        # wrong command ("apt install" instead of "apt-get install").
         content = "Install with `apt-get install mytool`."
         result = extract_system_package(content)
         assert result == "apt-get install mytool", (


### PR DESCRIPTION
## Description

The SKILL.md generator only recognizes bare, single-package `apt`, `apt-get`, and Homebrew commands. Existing harness READMEs use common forms such as `sudo apt install freecad`, `brew install --cask krita`, and multi-package installs, so generated skills can silently omit useful prerequisite instructions.

Preserve the complete documented install command while accepting those common forms. The parser remains limited to inline code spans and the supported apt/Homebrew package managers.

## Type of Change

- [x] **Bug Fix** — fixes incorrect behavior

## General Checklist

- [x] Code follows existing patterns and conventions
- [x] No new commands or command flags were added
- [x] Commit message follows the conventional format
- [x] I have tested my changes locally

## Test Results

```text
41 passed in 0.42s
```

Also verified parsing against the existing FreeCAD and Krita harness READMEs.
