### PR TITLE
fix(obs-studio): reject NaN in validate_range

### DIFF
--- a/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_range_nan.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_range_nan.py
@@ -1,0 +1,21 @@
+"""validate_range must reject non-finite opacity-like values."""
+
+from __future__ import annotations
+
+import pytest
+
+from cli_anything.obs_studio.utils.obs_utils import validate_range
+
+
+def test_nan_rejected() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        validate_range(float("nan"), 0.0, 1.0, "Opacity")
+
+
+def test_inf_rejected() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        validate_range(float("inf"), 0.0, 1.0, "Opacity")
+
+
+def test_in_range_ok() -> None:
+    assert validate_range(0.5, 0.0, 1.0, "Opacity") == 0.5

--- a/obs-studio/agent-harness/cli_anything/obs_studio/utils/obs_utils.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/utils/obs_utils.py
@@ -1,6 +1,7 @@
 """OBS Studio CLI - JSON helpers and utilities."""
 
 import json
+import math
 import os
 import copy
 from typing import Dict, Any, List, Optional
@@ -27,6 +28,8 @@ def unique_name(name: str, items: List[Dict[str, Any]], key: str = "name") -> st
 def validate_range(value: float, min_val: float, max_val: float, name: str) -> float:
     """Validate that a value is within range."""
     val = float(value)
+    if not math.isfinite(val):
+        raise ValueError(f"{name} must be a finite number, got {val}")
     if val < min_val or val > max_val:
         raise ValueError(f"{name} must be between {min_val} and {max_val}, got {val}")
     return val


### PR DESCRIPTION
`validate_range` is used for opacity, volume, and similar bounded floats. `NaN` made both min and max comparisons false, so the value was accepted and could be written into project JSON.

Non-finite values are now rejected before the range check.

Repro: `validate_range(float("nan"), 0.0, 1.0, "Opacity")` returned `nan` on main and now raises `ValueError`.