### PR TITLE
fix(obs-studio): reject non-finite geometry in source transforms

### DIFF
--- a/obs-studio/agent-harness/cli_anything/obs_studio/core/sources.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/core/sources.py
@@ -1,7 +1,6 @@
 """OBS Studio CLI - Source management."""
 
 import copy
-import math
 from typing import Dict, Any, List, Optional
 from cli_anything.obs_studio.utils.obs_utils import (
     generate_id,
@@ -11,6 +10,7 @@ from cli_anything.obs_studio.utils.obs_utils import (
     validate_position,
     validate_size,
     validate_crop,
+    _finite_number,
 )
 
 
@@ -144,7 +144,7 @@ def add_source(
 def remove_source(project: Dict[str, Any], source_index: int, scene_index: int = 0) -> Dict[str, Any]:
     """Remove a source from a scene."""
     sources = _get_scene_sources(project, scene_index)
-    source = get_item(sources, source_index, "source")
+    get_item(sources, source_index, "source")
     return sources.pop(source_index)
 
 
@@ -205,29 +205,43 @@ def transform_source(
     sources = _get_scene_sources(project, scene_index)
     source = get_item(sources, source_index, "source")
 
+    new_pos = None
     if position:
-        source["position"] = validate_position(
+        new_pos = validate_position(
             {
                 "x": position.get("x", source["position"]["x"]),
                 "y": position.get("y", source["position"]["y"]),
             }
         )
+
+    new_size = None
     if size:
-        source["size"] = validate_size(
+        new_size = validate_size(
             {
                 "width": size.get("width", source["size"]["width"]),
                 "height": size.get("height", source["size"]["height"]),
             }
         )
+
+    new_crop = None
     if crop:
         merged_crop = dict(source.get("crop") or {})
         merged_crop.update(crop)
-        source["crop"] = validate_crop(merged_crop)
+        new_crop = validate_crop(merged_crop)
+
+    new_rot = None
     if rotation is not None:
-        rot = float(rotation)
-        if not math.isfinite(rot):
-            raise ValueError(f"Rotation must be a finite number, got {rot}")
-        source["rotation"] = rot
+        rot = _finite_number(rotation, "Rotation")
+        new_rot = float(rot)
+
+    if new_pos is not None:
+        source["position"] = new_pos
+    if new_size is not None:
+        source["size"] = new_size
+    if new_crop is not None:
+        source["crop"] = new_crop
+    if new_rot is not None:
+        source["rotation"] = new_rot
 
     return source
 

--- a/obs-studio/agent-harness/cli_anything/obs_studio/core/sources.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/core/sources.py
@@ -1,8 +1,17 @@
 """OBS Studio CLI - Source management."""
 
 import copy
+import math
 from typing import Dict, Any, List, Optional
-from cli_anything.obs_studio.utils.obs_utils import generate_id, unique_name, get_item, validate_range
+from cli_anything.obs_studio.utils.obs_utils import (
+    generate_id,
+    unique_name,
+    get_item,
+    validate_range,
+    validate_position,
+    validate_size,
+    validate_crop,
+)
 
 
 SOURCE_TYPES = {
@@ -122,13 +131,9 @@ def add_source(
     src["visible"] = visible
 
     if position:
-        src["position"] = {"x": float(position.get("x", 0)), "y": float(position.get("y", 0))}
+        src["position"] = validate_position(position)
     if size:
-        w = int(size.get("width", 1920))
-        h = int(size.get("height", 1080))
-        if w < 1 or h < 1:
-            raise ValueError(f"Size must be positive: {w}x{h}")
-        src["size"] = {"width": w, "height": h}
+        src["size"] = validate_size(size)
     if settings:
         src["settings"].update(settings)
 
@@ -201,25 +206,28 @@ def transform_source(
     source = get_item(sources, source_index, "source")
 
     if position:
-        source["position"] = {
-            "x": float(position.get("x", source["position"]["x"])),
-            "y": float(position.get("y", source["position"]["y"])),
-        }
+        source["position"] = validate_position(
+            {
+                "x": position.get("x", source["position"]["x"]),
+                "y": position.get("y", source["position"]["y"]),
+            }
+        )
     if size:
-        w = int(size.get("width", source["size"]["width"]))
-        h = int(size.get("height", source["size"]["height"]))
-        if w < 1 or h < 1:
-            raise ValueError(f"Size must be positive: {w}x{h}")
-        source["size"] = {"width": w, "height": h}
+        source["size"] = validate_size(
+            {
+                "width": size.get("width", source["size"]["width"]),
+                "height": size.get("height", source["size"]["height"]),
+            }
+        )
     if crop:
-        for key in ("top", "bottom", "left", "right"):
-            if key in crop:
-                val = int(crop[key])
-                if val < 0:
-                    raise ValueError(f"Crop {key} must be non-negative, got {val}")
-                source["crop"][key] = val
+        merged_crop = dict(source.get("crop") or {})
+        merged_crop.update(crop)
+        source["crop"] = validate_crop(merged_crop)
     if rotation is not None:
-        source["rotation"] = float(rotation)
+        rot = float(rotation)
+        if not math.isfinite(rot):
+            raise ValueError(f"Rotation must be a finite number, got {rot}")
+        source["rotation"] = rot
 
     return source
 

--- a/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
@@ -55,6 +55,34 @@ def test_validate_crop_rejects_inf():
 def test_validate_position_accepts_finite():
     assert validate_position({"x": 1.5, "y": -2.0}) == {"x": 1.5, "y": -2.0}
 
+def test_validate_position_preserves_large_int():
+    assert validate_position({"x": 2 ** 53 + 1, "y": -(2 ** 53 + 3)}) == {
+        "x": 2 ** 53 + 1,
+        "y": -(2 ** 53 + 3),
+    }
+
+
+def test_validate_size_preserves_large_int():
+    assert validate_size(
+        {"width": 2 ** 53 + 1, "height": 2 ** 53 + 3}
+    ) == {"width": 2 ** 53 + 1, "height": 2 ** 53 + 3}
+
+
+def test_validate_crop_preserves_large_int():
+    assert validate_crop(
+        {
+            "top": 2 ** 53 + 1,
+            "bottom": 2 ** 53 + 3,
+            "left": 2 ** 53 + 5,
+            "right": 2 ** 53 + 7,
+        }
+    ) == {
+        "top": 2 ** 53 + 1,
+        "bottom": 2 ** 53 + 3,
+        "left": 2 ** 53 + 5,
+        "right": 2 ** 53 + 7,
+    }
+
 
 def test_add_source_rejects_nan_position():
     with pytest.raises(ValueError, match="finite"):

--- a/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
@@ -78,6 +78,7 @@ def test_validate_size_preserves_large_int():
     ],
 )
 def test_validate_size_preserves_decimal_integer_strings(value, expected):
+    """Keep signed, boundary, and large size strings exact before int conversion."""
     assert validate_size({"width": value, "height": value}) == {
         "width": expected,
         "height": expected,
@@ -86,6 +87,7 @@ def test_validate_size_preserves_decimal_integer_strings(value, expected):
 
 @pytest.mark.parametrize("value", ["0", "-1"])
 def test_validate_size_rejects_non_positive_decimal_integer_strings(value):
+    """Reject size strings at and below the positive lower bound."""
     with pytest.raises(ValueError, match="positive"):
         validate_size({"width": value, "height": 1})
 
@@ -114,6 +116,7 @@ def test_validate_crop_preserves_large_int():
     ],
 )
 def test_validate_crop_preserves_decimal_integer_strings(value, expected):
+    """Keep signed, boundary, and large crop strings exact before int conversion."""
     assert validate_crop(
         {"top": value, "bottom": value, "left": value, "right": value}
     ) == {
@@ -125,6 +128,7 @@ def test_validate_crop_preserves_decimal_integer_strings(value, expected):
 
 
 def test_validate_crop_rejects_negative_decimal_integer_string():
+    """Reject negative crop strings after exact integer parsing."""
     with pytest.raises(ValueError, match="non-negative"):
         validate_crop({"top": "-1"})
 

--- a/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
@@ -1,0 +1,32 @@
+"""Reject non-finite values in OBS geometry validators."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from cli_anything.obs_studio.utils.obs_utils import (
+    validate_crop,
+    validate_position,
+    validate_size,
+)
+
+
+def test_validate_position_rejects_nan():
+    with pytest.raises(ValueError, match="finite"):
+        validate_position({"x": float("nan"), "y": 1.0})
+
+
+def test_validate_size_rejects_nan():
+    with pytest.raises(ValueError, match="finite"):
+        validate_size({"width": float("nan"), "height": 1080})
+
+
+def test_validate_crop_rejects_inf():
+    with pytest.raises(ValueError, match="finite"):
+        validate_crop({"left": float("inf"), "right": 0, "top": 0, "bottom": 0})
+
+
+def test_validate_position_accepts_finite():
+    assert validate_position({"x": 1.5, "y": -2.0}) == {"x": 1.5, "y": -2.0}

--- a/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
@@ -4,11 +4,37 @@ from __future__ import annotations
 
 import pytest
 
+from cli_anything.obs_studio.core.sources import add_source, transform_source
 from cli_anything.obs_studio.utils.obs_utils import (
     validate_crop,
     validate_position,
     validate_size,
 )
+
+
+def _project() -> dict:
+    return {
+        "scenes": [
+            {
+                "name": "Scene",
+                "sources": [
+                    {
+                        "id": 0,
+                        "name": "Cam",
+                        "type": "browser",
+                        "visible": True,
+                        "locked": False,
+                        "opacity": 1.0,
+                        "rotation": 0.0,
+                        "position": {"x": 0.0, "y": 0.0},
+                        "size": {"width": 1920, "height": 1080},
+                        "crop": {"top": 0, "bottom": 0, "left": 0, "right": 0},
+                        "settings": {},
+                    }
+                ],
+            }
+        ]
+    }
 
 
 def test_validate_position_rejects_nan():
@@ -28,3 +54,17 @@ def test_validate_crop_rejects_inf():
 
 def test_validate_position_accepts_finite():
     assert validate_position({"x": 1.5, "y": -2.0}) == {"x": 1.5, "y": -2.0}
+
+
+def test_add_source_rejects_nan_position():
+    with pytest.raises(ValueError, match="finite"):
+        add_source(
+            _project(),
+            "browser",
+            position={"x": float("nan"), "y": 0},
+        )
+
+
+def test_transform_source_rejects_nan_position():
+    with pytest.raises(ValueError, match="finite"):
+        transform_source(_project(), 0, position={"x": float("nan")})

--- a/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import pytest
+from decimal import Decimal
+from fractions import Fraction
+
 
 from cli_anything.obs_studio.core.sources import add_source, transform_source
 from cli_anything.obs_studio.utils.obs_utils import (
@@ -145,3 +148,42 @@ def test_add_source_rejects_nan_position():
 def test_transform_source_rejects_nan_position():
     with pytest.raises(ValueError, match="finite"):
         transform_source(_project(), 0, position={"x": float("nan")})
+def test_validate_size_preserves_large_int_string():
+    """Locks out regression where string integers were converted to float."""
+    val = str(2 ** 53 + 1)
+    assert validate_size({"width": val, "height": "1080"}) == {
+        "width": 2 ** 53 + 1,
+        "height": 1080,
+    }
+
+
+def test_validate_size_preserves_decimal_and_fraction():
+    """Locks out regression where Decimal and Fraction were converted to float."""
+    dec = Decimal(2 ** 53 + 1)
+    frac = Fraction(2 ** 53 + 3, 1)
+    assert validate_size({"width": dec, "height": frac}) == {
+        "width": 2 ** 53 + 1,
+        "height": 2 ** 53 + 3,
+    }
+
+
+def test_validate_size_rejects_float_strings():
+    """Locks out regression where float strings '1.5' or '1e3' were truncated/accepted as size ints."""
+    with pytest.raises(ValueError, match="integer"):
+        validate_size({"width": "1.5", "height": 1080})
+    with pytest.raises(ValueError, match="integer"):
+        validate_size({"width": "1e3", "height": 1080})
+
+
+def test_transform_source_atomic_validation_on_invalid_rotation():
+    """Locks out regression where earlier fields were mutated prior to rotation validation."""
+    proj = _project()
+    orig_pos = dict(proj["scenes"][0]["sources"][0]["position"])
+    with pytest.raises(ValueError, match="finite"):
+        transform_source(
+            proj,
+            0,
+            position={"x": 100.0, "y": 200.0},
+            rotation=float("nan"),
+        )
+    assert proj["scenes"][0]["sources"][0]["position"] == orig_pos

--- a/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import math
-
 import pytest
 
 from cli_anything.obs_studio.utils.obs_utils import (

--- a/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/tests/test_validate_geometry_nan.py
@@ -68,6 +68,27 @@ def test_validate_size_preserves_large_int():
     ) == {"width": 2 ** 53 + 1, "height": 2 ** 53 + 3}
 
 
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("+42", 42),
+        ("1", 1),
+        (str(2 ** 53 + 1), 2 ** 53 + 1),
+    ],
+)
+def test_validate_size_preserves_decimal_integer_strings(value, expected):
+    assert validate_size({"width": value, "height": value}) == {
+        "width": expected,
+        "height": expected,
+    }
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_validate_size_rejects_non_positive_decimal_integer_strings(value):
+    with pytest.raises(ValueError, match="positive"):
+        validate_size({"width": value, "height": 1})
+
 def test_validate_crop_preserves_large_int():
     assert validate_crop(
         {
@@ -82,6 +103,30 @@ def test_validate_crop_preserves_large_int():
         "left": 2 ** 53 + 5,
         "right": 2 ** 53 + 7,
     }
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("+42", 42),
+        ("0", 0),
+        (str(2 ** 53 + 1), 2 ** 53 + 1),
+    ],
+)
+def test_validate_crop_preserves_decimal_integer_strings(value, expected):
+    assert validate_crop(
+        {"top": value, "bottom": value, "left": value, "right": value}
+    ) == {
+        "top": expected,
+        "bottom": expected,
+        "left": expected,
+        "right": expected,
+    }
+
+
+def test_validate_crop_rejects_negative_decimal_integer_string():
+    with pytest.raises(ValueError, match="non-negative"):
+        validate_crop({"top": "-1"})
 
 
 def test_add_source_rejects_nan_position():

--- a/obs-studio/agent-harness/cli_anything/obs_studio/utils/obs_utils.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/utils/obs_utils.py
@@ -8,30 +8,63 @@ from typing import Dict, Any, List, Optional
 
 
 
-def _finite_number(value: Any, name: str):
-    """Reject non-finite values without float-rounding large ints."""
+def _finite_number(value: Any, name: str) -> float | int:
+    """Reject non-finite values without float-rounding large ints or integer strings."""
     if isinstance(value, bool):
         raise ValueError(f"{name} must be a finite number, got {value!r}")
     if isinstance(value, int):
         return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be a finite number, got {value!r}")
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            pass
+        try:
+            num = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{name} must be a finite number, got {value!r}") from exc
+        if not math.isfinite(num):
+            raise ValueError(f"{name} must be a finite number, got {value!r}")
+        return num
+    try:
+        ival = int(value)
+        if ival == value:
+            return ival
+    except Exception:
+        pass
     try:
         num = float(value)
-    except (TypeError, ValueError) as exc:
+    except Exception as exc:
         raise ValueError(f"{name} must be a finite number, got {value!r}") from exc
     if not math.isfinite(num):
         raise ValueError(f"{name} must be a finite number, got {value!r}")
     return num
 
 
-def _finite_integer(value: Any, name: str) -> int:
-    """Convert a finite value without rounding decimal integer strings."""
+def _finite_int(value: Any, name: str) -> int:
+    """Reject non-finite or non-integer-form values without float rounding."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a finite integer, got {value!r}")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be a finite integer, got {value!r}")
+        return int(value)
     if isinstance(value, str):
         try:
             return int(value)
-        except ValueError:
-            pass
-    return int(_finite_number(value, name))
-
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{name} must be a finite integer, got {value!r}") from exc
+    try:
+        val = int(value)
+    except (TypeError, ValueError, ArithmeticError) as exc:
+        raise ValueError(f"{name} must be a finite integer, got {value!r}") from exc
+    return val
 
 def generate_id(items: List[Dict[str, Any]]) -> int:
     """Generate the next unique ID for a list of items."""
@@ -68,8 +101,8 @@ def validate_position(pos: Dict[str, Any]) -> Dict[str, Any]:
 
 def validate_size(size: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and normalize a size dict."""
-    w = _finite_integer(size.get("width", 1920), "Size width")
-    h = _finite_integer(size.get("height", 1080), "Size height")
+    w = _finite_int(size.get("width", 1920), "Size width")
+    h = _finite_int(size.get("height", 1080), "Size height")
     if w < 1:
         raise ValueError(f"Width must be positive, got {w}")
     if h < 1:
@@ -81,7 +114,7 @@ def validate_crop(crop: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and normalize a crop dict."""
     result = {}
     for key in ("top", "bottom", "left", "right"):
-        val = _finite_integer(crop.get(key, 0), f"Crop {key}")
+        val = _finite_int(crop.get(key, 0), f"Crop {key}")
         if val < 0:
             raise ValueError(f"Crop {key} must be non-negative, got {val}")
         result[key] = val

--- a/obs-studio/agent-harness/cli_anything/obs_studio/utils/obs_utils.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/utils/obs_utils.py
@@ -23,6 +23,16 @@ def _finite_number(value: Any, name: str):
     return num
 
 
+def _finite_integer(value: Any, name: str) -> int:
+    """Convert a finite value without rounding decimal integer strings."""
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            pass
+    return int(_finite_number(value, name))
+
+
 def generate_id(items: List[Dict[str, Any]]) -> int:
     """Generate the next unique ID for a list of items."""
     if not items:
@@ -58,10 +68,8 @@ def validate_position(pos: Dict[str, Any]) -> Dict[str, Any]:
 
 def validate_size(size: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and normalize a size dict."""
-    width_raw = _finite_number(size.get("width", 1920), "Size width")
-    height_raw = _finite_number(size.get("height", 1080), "Size height")
-    w = int(width_raw)
-    h = int(height_raw)
+    w = _finite_integer(size.get("width", 1920), "Size width")
+    h = _finite_integer(size.get("height", 1080), "Size height")
     if w < 1:
         raise ValueError(f"Width must be positive, got {w}")
     if h < 1:
@@ -73,8 +81,7 @@ def validate_crop(crop: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and normalize a crop dict."""
     result = {}
     for key in ("top", "bottom", "left", "right"):
-        raw = _finite_number(crop.get(key, 0), f"Crop {key}")
-        val = int(raw)
+        val = _finite_integer(crop.get(key, 0), f"Crop {key}")
         if val < 0:
             raise ValueError(f"Crop {key} must be non-negative, got {val}")
         result[key] = val

--- a/obs-studio/agent-harness/cli_anything/obs_studio/utils/obs_utils.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/utils/obs_utils.py
@@ -7,6 +7,22 @@ import copy
 from typing import Dict, Any, List, Optional
 
 
+
+def _finite_number(value: Any, name: str):
+    """Reject non-finite values without float-rounding large ints."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a finite number, got {value!r}")
+    if isinstance(value, int):
+        return value
+    try:
+        num = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite number, got {value!r}") from exc
+    if not math.isfinite(num):
+        raise ValueError(f"{name} must be a finite number, got {value!r}")
+    return num
+
+
 def generate_id(items: List[Dict[str, Any]]) -> int:
     """Generate the next unique ID for a list of items."""
     if not items:
@@ -35,21 +51,15 @@ def validate_range(value: float, min_val: float, max_val: float, name: str) -> f
 
 def validate_position(pos: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and normalize a position dict."""
-    x = float(pos.get("x", 0))
-    y = float(pos.get("y", 0))
-    if not math.isfinite(x) or not math.isfinite(y):
-        raise ValueError(f"Position coordinates must be finite numbers, got x={x}, y={y}")
+    x = _finite_number(pos.get("x", 0), "Position x")
+    y = _finite_number(pos.get("y", 0), "Position y")
     return {"x": x, "y": y}
 
 
 def validate_size(size: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and normalize a size dict."""
-    width_raw = float(size.get("width", 1920))
-    height_raw = float(size.get("height", 1080))
-    if not math.isfinite(width_raw) or not math.isfinite(height_raw):
-        raise ValueError(
-            f"Size must be finite numbers, got width={width_raw}, height={height_raw}"
-        )
+    width_raw = _finite_number(size.get("width", 1920), "Size width")
+    height_raw = _finite_number(size.get("height", 1080), "Size height")
     w = int(width_raw)
     h = int(height_raw)
     if w < 1:
@@ -63,9 +73,7 @@ def validate_crop(crop: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and normalize a crop dict."""
     result = {}
     for key in ("top", "bottom", "left", "right"):
-        raw = float(crop.get(key, 0))
-        if not math.isfinite(raw):
-            raise ValueError(f"Crop {key} must be a finite number, got {raw}")
+        raw = _finite_number(crop.get(key, 0), f"Crop {key}")
         val = int(raw)
         if val < 0:
             raise ValueError(f"Crop {key} must be non-negative, got {val}")

--- a/obs-studio/agent-harness/cli_anything/obs_studio/utils/obs_utils.py
+++ b/obs-studio/agent-harness/cli_anything/obs_studio/utils/obs_utils.py
@@ -1,6 +1,7 @@
 """OBS Studio CLI - JSON helpers and utilities."""
 
 import json
+import math
 import os
 import copy
 from typing import Dict, Any, List, Optional
@@ -34,16 +35,23 @@ def validate_range(value: float, min_val: float, max_val: float, name: str) -> f
 
 def validate_position(pos: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and normalize a position dict."""
-    return {
-        "x": float(pos.get("x", 0)),
-        "y": float(pos.get("y", 0)),
-    }
+    x = float(pos.get("x", 0))
+    y = float(pos.get("y", 0))
+    if not math.isfinite(x) or not math.isfinite(y):
+        raise ValueError(f"Position coordinates must be finite numbers, got x={x}, y={y}")
+    return {"x": x, "y": y}
 
 
 def validate_size(size: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and normalize a size dict."""
-    w = int(size.get("width", 1920))
-    h = int(size.get("height", 1080))
+    width_raw = float(size.get("width", 1920))
+    height_raw = float(size.get("height", 1080))
+    if not math.isfinite(width_raw) or not math.isfinite(height_raw):
+        raise ValueError(
+            f"Size must be finite numbers, got width={width_raw}, height={height_raw}"
+        )
+    w = int(width_raw)
+    h = int(height_raw)
     if w < 1:
         raise ValueError(f"Width must be positive, got {w}")
     if h < 1:
@@ -55,7 +63,10 @@ def validate_crop(crop: Dict[str, Any]) -> Dict[str, Any]:
     """Validate and normalize a crop dict."""
     result = {}
     for key in ("top", "bottom", "left", "right"):
-        val = int(crop.get(key, 0))
+        raw = float(crop.get(key, 0))
+        if not math.isfinite(raw):
+            raise ValueError(f"Crop {key} must be a finite number, got {raw}")
+        val = int(raw)
         if val < 0:
             raise ValueError(f"Crop {key} must be non-negative, got {val}")
         result[key] = val


### PR DESCRIPTION
## Problem

`add_source` / `transform_source` accepted `NaN` position coordinates into project JSON. Size/crop hit cryptic `int(NaN)` errors instead of a clear validation failure.

## Repro

```python
from cli_anything.obs_studio.core.sources import transform_source

transform_source(project, 0, position={"x": float("nan")})
# unpatched: writes nan into source["position"]["x"]
```

## Fix

Validate position/size/crop with `math.isfinite` and call those helpers from the live source paths (complements #396 which covers `validate_range` only).