### PR TITLE
fix(browser): bare cat for root/empty path in fs cat

### DIFF
--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -147,32 +147,55 @@ def test_cat_relative_no_wrap(mock_call):
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_cat_root_path_does_not_raise_and_returns_parseable_result(mock_call):
-    """backend.cat("/") and backend.cat("") at the absolute root should
-    NOT raise a Python ValueError. Pre-migration behavior was to send
-    ``cat ''`` to DOMShell and surface its ``Usage: cat <name>`` error
-    string; the round-5 Python-side guard converted the kernel error
-    into a ValueError, which broke ``fs.read_element(session, "")``
-    callers landed at ``/``. @yuh-yang R3 blocker 1 required restoring
-    pre-migration behavior — guard removed, both inputs now reach
-    DOMShell, which has the same ``if (!targetName)`` check and
-    returns its standard Usage error.
+def test_cat_root_path_translates_to_bare_cat_at_anchor(mock_call):
+    """backend.cat("/") anchors at tab root, then issues bare `cat`.
+
+    Empty-after-translation absolute paths are the natural no-arg form
+    (``fs cat`` with ``session.working_dir == "/"``). Sending ``cat ''``
+    would hit DOMShell's Usage error; bare ``cat`` operates on the
+    cursor the anchor just parked at the tab root.
     """
-    mock_call.return_value = _make_result(
-        "\x1b[31mUsage: cat <name> (see cat --help)\x1b[0m\n[lane: shared]"
-    )
-    sess = _make_session(working_dir="/")  # satisfies absolute branch's session check
+    mock_call.return_value = _make_result("button: Submit\n[lane: 1]")
+    sess = _make_session(working_dir="/")
 
-    # MUST NOT raise — that was the regression.
-    result_root = backend.cat("/", session=sess)
-    result_empty = backend.cat("")
+    result = backend.cat("/", session=sess)
 
-    # Both surface DOMShell's error as a parsed dict, not a Python exception.
-    for r in (result_root, result_empty):
-        assert isinstance(r, dict)
-        # _parse_execute_result detects ANSI red → routes through error path.
-        assert "error" in r
+    assert isinstance(result, dict)
+    assert "error" not in result
+    assert mock_call.call_count == 3
+    assert mock_call.call_args_list[0].args[0] == "cd %here%"
+    assert mock_call.call_args_list[1].args[0] == "cat"
+    assert mock_call.call_args_list[2].args[0] == "cd %here%"
 
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_cat_empty_relative_path_is_bare_cat(mock_call):
+    """backend.cat("") is bare cat on the lane's current cursor."""
+    mock_call.return_value = _make_result("button: Submit\n[lane: 1]")
+
+    result = backend.cat("")
+
+    assert isinstance(result, dict)
+    assert "error" not in result
+    assert mock_call.call_count == 1
+    assert mock_call.call_args.args[0] == "cat"
+
+
+@patch.object(backend, "_call_execute", new_callable=AsyncMock)
+def test_read_element_empty_path_at_root_does_not_raise(mock_call):
+    """fs.read_element(session, "") at default working_dir="/" must not raise."""
+    from cli_anything.browser.core import fs as fs_mod
+
+    mock_call.return_value = _make_result("root content\n[lane: 1]")
+    sess = _make_session(working_dir="/")
+
+    result = fs_mod.read_element(sess, "")
+
+    assert isinstance(result, dict)
+    assert "error" not in result
+    # Falls through to working_dir="/", so absolute split-and-check path.
+    assert mock_call.call_count == 3
+    assert mock_call.call_args_list[1].args[0] == "cat"
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_click_absolute_path_uses_three_separate_calls(mock_call):

--- a/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/tests/test_domshell_backend.py
@@ -147,15 +147,14 @@ def test_cat_relative_no_wrap(mock_call):
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_cat_root_path_translates_to_bare_cat_at_anchor(mock_call):
-    """backend.cat("/") anchors at tab root, then issues bare `cat`.
+def test_cat_root_path_reads_current_node_at_anchor(mock_call):
+    """backend.cat("/") anchors at tab root, then issues bare `read`.
 
     Empty-after-translation absolute paths are the natural no-arg form
-    (``fs cat`` with ``session.working_dir == "/"``). Sending ``cat ''``
-    would hit DOMShell's Usage error; bare ``cat`` operates on the
-    cursor the anchor just parked at the tab root.
+    (``fs cat`` with ``session.working_dir == "/"``). DOMShell requires
+    a target for ``cat``; ``read`` is its supported current-node operation.
     """
-    mock_call.return_value = _make_result("button: Submit\n[lane: 1]")
+    mock_call.return_value = _make_result("root [document]\n  button [button]\n[lane: 1]")
     sess = _make_session(working_dir="/")
 
     result = backend.cat("/", session=sess)
@@ -164,21 +163,21 @@ def test_cat_root_path_translates_to_bare_cat_at_anchor(mock_call):
     assert "error" not in result
     assert mock_call.call_count == 3
     assert mock_call.call_args_list[0].args[0] == "cd %here%"
-    assert mock_call.call_args_list[1].args[0] == "cat"
+    assert mock_call.call_args_list[1].args[0] == "read"
     assert mock_call.call_args_list[2].args[0] == "cd %here%"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
-def test_cat_empty_relative_path_is_bare_cat(mock_call):
-    """backend.cat("") is bare cat on the lane's current cursor."""
-    mock_call.return_value = _make_result("button: Submit\n[lane: 1]")
+def test_cat_empty_relative_path_reads_current_node(mock_call):
+    """backend.cat("") uses DOMShell read on the lane's current cursor."""
+    mock_call.return_value = _make_result("button [button]\n[lane: 1]")
 
     result = backend.cat("")
 
     assert isinstance(result, dict)
     assert "error" not in result
     assert mock_call.call_count == 1
-    assert mock_call.call_args.args[0] == "cat"
+    assert mock_call.call_args.args[0] == "read"
 
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
@@ -186,7 +185,7 @@ def test_read_element_empty_path_at_root_does_not_raise(mock_call):
     """fs.read_element(session, "") at default working_dir="/" must not raise."""
     from cli_anything.browser.core import fs as fs_mod
 
-    mock_call.return_value = _make_result("root content\n[lane: 1]")
+    mock_call.return_value = _make_result("root [document]\n  content [text]\n[lane: 1]")
     sess = _make_session(working_dir="/")
 
     result = fs_mod.read_element(sess, "")
@@ -195,7 +194,8 @@ def test_read_element_empty_path_at_root_does_not_raise(mock_call):
     assert "error" not in result
     # Falls through to working_dir="/", so absolute split-and-check path.
     assert mock_call.call_count == 3
-    assert mock_call.call_args_list[1].args[0] == "cat"
+    assert mock_call.call_args_list[1].args[0] == "read"
+
 
 @patch.object(backend, "_call_execute", new_callable=AsyncMock)
 def test_click_absolute_path_uses_three_separate_calls(mock_call):

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -788,17 +788,14 @@ def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         {"output": "button: Submit\n..."}
     """
     translated, is_absolute = _translate_path(path)
-    # Empty translated path is the natural no-arg form:
-    # - absolute `/`  → anchor at tab root, then bare `cat` (current cursor)
-    # - relative `""` → bare `cat` on the lane's current cursor
-    # Named elements keep `cat <name>`. This preserves the advertised
-    # `fs cat [path]` no-arg behaviour and avoids `cat ''` (DOMShell
-    # Usage error) / the earlier Python ValueError regression.
-    cat_cmd = "cat" if not translated else f"cat {_q(translated)}"
+    # DOMShell's `cat` requires a child name; its no-argument `read`
+    # command is the supported way to read the current cursor.
+    command = "read" if not translated else f"cat {_q(translated)}"
     if is_absolute:
         _require_session_for_split_check("cat", session, use_daemon)
         # Split-and-check: anchor at tab root, halt if anchor fails,
-        # otherwise run relative/bare cat, restore. Anchor success is
+        # otherwise read the current cursor or named child, then restore.
+        # Anchor success is
         # load-bearing — without it cat resolves against the wrong cwd.
         anchor = asyncio.run(_call_execute(
             _anchor_path_cmd(""), use_daemon, session=session,
@@ -806,14 +803,14 @@ def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
         if _is_error(anchor):
             return _parse_execute_result(anchor, "cat")
         op = asyncio.run(_call_execute(
-            cat_cmd, use_daemon, session=session,
+            command, use_daemon, session=session,
         ))
         asyncio.run(_call_execute(
             _restore_cwd_cmd(session), use_daemon, session=session,
         ))
         return _parse_execute_result(op, "cat")
     op = asyncio.run(_call_execute(
-        cat_cmd, use_daemon, session=session,
+        command, use_daemon, session=session,
     ))
     return _parse_execute_result(op, "cat")
 

--- a/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
+++ b/browser/agent-harness/cli_anything/browser/utils/domshell_backend.py
@@ -785,40 +785,37 @@ def cat(path: str, use_daemon: bool = False, *, session: Any = None) -> dict:
 
     Example:
         >>> cat("/main/button[0]", session=session)   # required for absolute paths
-        {"output": "button: Submit\\n..."}
+        {"output": "button: Submit\n..."}
     """
     translated, is_absolute = _translate_path(path)
-    # Note: a falsy `translated` (root path `/` or empty string) is no
-    # longer rejected here. Pre-migration `fs cat` at the root surfaced
-    # DOMShell's own `Usage: cat <name>` error string; the round-5 guard
-    # converted that into a Python ValueError, which broke the
-    # `fs.read_element(session, "")` fall-through to `session.working_dir`
-    # for callers landed at `/`. Removed per @yuh-yang R3 review of
-    # `b684732` — `cat ''` reaches DOMShell, which has the same
-    # `if (!targetName)` check and returns its standard Usage error.
+    # Empty translated path is the natural no-arg form:
+    # - absolute `/`  → anchor at tab root, then bare `cat` (current cursor)
+    # - relative `""` → bare `cat` on the lane's current cursor
+    # Named elements keep `cat <name>`. This preserves the advertised
+    # `fs cat [path]` no-arg behaviour and avoids `cat ''` (DOMShell
+    # Usage error) / the earlier Python ValueError regression.
+    cat_cmd = "cat" if not translated else f"cat {_q(translated)}"
     if is_absolute:
         _require_session_for_split_check("cat", session, use_daemon)
         # Split-and-check: anchor at tab root, halt if anchor fails,
-        # otherwise run relative cat, restore. Anchor success is
-        # load-bearing — without it cat resolves the relative path
-        # against the wrong cwd.
+        # otherwise run relative/bare cat, restore. Anchor success is
+        # load-bearing — without it cat resolves against the wrong cwd.
         anchor = asyncio.run(_call_execute(
             _anchor_path_cmd(""), use_daemon, session=session,
         ))
         if _is_error(anchor):
             return _parse_execute_result(anchor, "cat")
         op = asyncio.run(_call_execute(
-            f"cat {_q(translated)}", use_daemon, session=session,
+            cat_cmd, use_daemon, session=session,
         ))
         asyncio.run(_call_execute(
             _restore_cwd_cmd(session), use_daemon, session=session,
         ))
         return _parse_execute_result(op, "cat")
     op = asyncio.run(_call_execute(
-        f"cat {_q(translated)}", use_daemon, session=session,
+        cat_cmd, use_daemon, session=session,
     ))
     return _parse_execute_result(op, "cat")
-
 
 def grep(
     pattern: str,


### PR DESCRIPTION
## Description

`fs cat` with no path previously translated to a targetless DOMShell `cat` command, which only returns `Usage: cat <name>`

Empty and root paths now use the supported DOMShell no-argument `read` command for the current node. Named paths continue to use `cat <name>`

Fixes #330

## Type of Change

- [x] **Bug Fix** - fixes incorrect behavior

### For Existing CLI Modifications

- [x] All unit tests pass
- [ ] All E2E tests pass - 11 tests require a live DOMShell browser extension and were skipped
- [x] No previously passing tests were removed or weakened
- [x] `registry.json` is unchanged because package metadata did not change

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] No new commands were added
- [x] Commit messages follow the conventional format
- [x] Changes were tested locally

## Test Results

```text
python3.12 -m pytest cli_anything/browser/tests -q
195 passed, 11 skipped, 1 warning in 0.54s
```