### PR TITLE
fix(blender,gimp): unblock rendering on Windows

### DIFF
--- a/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
@@ -552,7 +552,7 @@ def _gen_render_output(
 
     lines.extend([
         "",
-        f"print('Render complete: {output_path}')",
+        f"print(r'Render complete: {output_path}')",
     ])
 
     return lines

--- a/gimp/agent-harness/cli_anything/gimp/utils/gimp_backend.py
+++ b/gimp/agent-harness/cli_anything/gimp/utils/gimp_backend.py
@@ -7,6 +7,7 @@ Requires: gimp (system package)
 """
 
 import os
+import re
 import shutil
 import subprocess
 from typing import Dict, Any, Optional, List
@@ -24,7 +25,13 @@ def _script_fu_escape(value: str) -> str:
 
 def find_gimp() -> str:
     """Find the GIMP executable. Raises RuntimeError if not found."""
-    for name in ("gimp", "gimp-2.10", "gimp-2.99"):
+    # Prefer the console binary: the GUI executable never exits in batch mode
+    # on Windows, hanging the caller until its timeout.
+    for name in (
+        "gimp-console-3.2", "gimp-console-3", "gimp-console",
+        "gimp-console-2.10", "gimp-console-2.99",
+        "gimp", "gimp-2.10", "gimp-2.99",
+    ):
         path = shutil.which(name)
         if path:
             return path
@@ -58,7 +65,13 @@ def batch_script_fu(
         Dict with stdout, stderr, return code
     """
     gimp = find_gimp()
-    cmd = [gimp, "-i", "-b", script, "-b", "(gimp-quit 0)"]
+    # GIMP 3 no longer defaults to Script-Fu for -b; without an explicit
+    # interpreter the process never exits.
+    cmd = [
+        gimp, "-i",
+        "--batch-interpreter", "plug-in-script-fu-eval",
+        "-b", script, "-b", "(gimp-quit 0)",
+    ]
 
     result = subprocess.run(
         cmd,
@@ -226,12 +239,28 @@ def apply_filter_and_export(
 # ---------------------------------------------------------------------------
 
 def is_available() -> bool:
-    """Return True if GIMP is installed and reachable on $PATH."""
+    """Return True if a usable GIMP is installed and reachable on $PATH.
+
+    The Script-Fu below targets the GIMP 2.10 PDB.  GIMP 3.x removed several
+    of those procedures (``gimp-palette-set-foreground``,
+    ``gimp-image-get-active-drawable``, ...), and its batch mode *hangs*
+    rather than exiting when a script errors -- so an unusable GIMP 3 costs a
+    full subprocess timeout per render before the Pillow fallback kicks in.
+    Treat it as unavailable until the Script-Fu is ported.
+    """
     try:
-        find_gimp()
-        return True
+        gimp = find_gimp()
     except RuntimeError:
         return False
+    try:
+        version = subprocess.run(
+            [gimp, "--version"],
+            capture_output=True, text=True, timeout=30,
+        ).stdout
+    except (subprocess.SubprocessError, OSError):
+        return False
+    match = re.search(r"version (\d+)\.", version)
+    return bool(match) and int(match.group(1)) < 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two independent fixes for harnesses that cannot render at all on Windows. Both were found by using the harnesses rather than by running their test suites, and both are verified before/after on the same machine.

Happy to split this into two PRs if you'd prefer — the commits are independent and touch different harnesses.

## 1. Blender — one character, unblocks every render

`bpy_gen.py` interpolated `output_path` into a **non-raw** Python string literal, so a Windows path beginning `C:\Users\...` is parsed as a `\U` unicode escape and Blender aborts before rendering:

```
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 19-20: truncated \UXXXXXXXX escape
```

Lines 147 and 535 of the same file already use `r'...'`; only the final `print()` did not.

This is [#343](https://github.com/HKUDS/CLI-Anything/issues/343), open since 5 June and independently reported twice. It is structurally impossible to reproduce on Linux, where `/tmp/...` contains no backslashes.

| Blender harness suite | Before | After |
|---|---|---|
| Windows 11 / Blender 5.2.0 LTS | 211 passed / 17 failed | **218 passed / 10 failed** |

All six `TestBlenderRenderE2E` failures clear, plus `TestPreviewE2E::test_capture_preview_bundle` and `TestCLISubprocess::test_cli_preview_capture`. A real EEVEE render then completes end to end.

The 10 remaining failures are unrelated to this change — 7 × `WinError 1314` symlink privilege, 1 × the `BLENDER_EEVEE_NEXT` rename in Blender 5.x, 2 downstream of the symlink ones. Filed separately as [#402](https://github.com/HKUDS/CLI-Anything/issues/402).

**Not included, but worth doing in the same area:** `blender_backend.py:114` raises with `result['stdout']` only. The `SyntaxError` above goes to **stderr**, so the user sees "produced no output file" plus the Blender banner and nothing about the actual cause. Adding `stderr` to that message would have turned this into a two-minute diagnosis. Say the word and I'll add it here.

## 2. GIMP — installing the documented dependency made things worse

Detail is in [#400](https://github.com/HKUDS/CLI-Anything/issues/400). Summary of the three compounding problems:

1. **`find_gimp()` picked the GUI binary.** It searched only `("gimp", "gimp-2.10", "gimp-2.99")`, so `shutil.which("gimp")` resolves to `gimp.EXE`, which never exits in batch mode even with `-i`. Now prefers `gimp-console*`.

2. **GIMP 3 dropped the default batch interpreter.** Measured with `gimp-console-3.2`:

   ```
   -i -b "(gimp-quit 0)"                                             HUNG (>40s)
   -i --batch-interpreter plug-in-script-fu-eval -b "(gimp-quit 0)"  EXITED
   ```

3. **The emitted Script-Fu targets the GIMP 2.10 PDB.** GIMP 3 removed several of those procedures, *and* hangs on any script error rather than exiting non-zero:

   ```
   (gimp-version)                     -> exits, "batch command executed successfully"
   (no-such-proc)                     -> hangs
   (gimp-context-set-foreground ...)  -> exits          # GIMP 3 name
   (gimp-palette-set-foreground ...)  -> hangs          # GIMP 2.10 name, removed
   ```

**Porting the Script-Fu is the real fix and this PR does not attempt it.** What it does is stop the harness paying a full 120-second subprocess timeout to arrive at the Pillow fallback it was going to use anyway — `render()` already documents "falls back to Pillow when GIMP is not installed" and already wraps the backend in `try/except`. `is_available()` now reports GIMP 3 as unavailable so that fallback engages immediately.

| GIMP harness, GIMP 3.2.4 on PATH | Before | After |
|---|---|---|
| Test suite | hung indefinitely | **113 passed / 2 failed**, terminates in 122s |
| `export render` via CLI | ~120s stall | **0.2s** |

The 2 remaining failures are `TestGIMPRenderE2E::test_create_and_export_{png,jpeg}`, which call `render_project()` directly and bypass `is_available()`. They exercise the 2.10 Script-Fu and will keep failing until it is ported — which is the outcome I'd want, since they are the tests that would catch the port landing.

If you would rather this errored loudly on GIMP 3 than fell back silently, that is a one-line change to the same function and I'm happy to make it — but it would contradict the docstring on `render()`, so I went with the documented behaviour.

Note this half is **not** Windows-specific. `registry.json` says `requires: gimp (apt install gimp)`, which on current distros installs GIMP 3, so the same hang should reproduce on Linux.

## Testing

Windows 11 Pro 26100 · Python 3.14.6 · GIMP 3.2.4 · Blender 5.2.0 LTS · branched from `bc536c9`.

Full suites run for both harnesses before and after, with `--timeout` to bound the GIMP hang. Beyond the tests, both harnesses were then used to produce real artefacts — a 7-object EEVEE render and a six-filter contact sheet composited from it — to confirm the fixes hold outside the test suite.

## Related

Found during a wider pass over five harnesses on Windows: [#400](https://github.com/HKUDS/CLI-Anything/issues/400) · [#401](https://github.com/HKUDS/CLI-Anything/issues/401) · [#402](https://github.com/HKUDS/CLI-Anything/issues/402) · [#403](https://github.com/HKUDS/CLI-Anything/issues/403) · [#404](https://github.com/HKUDS/CLI-Anything/issues/404) · [#405](https://github.com/HKUDS/CLI-Anything/issues/405) · [#406](https://github.com/HKUDS/CLI-Anything/issues/406) · [#407](https://github.com/HKUDS/CLI-Anything/issues/407)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
