### PR TITLE
feat(registry): add solidity-snippets CLI — first web3 harness

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1513,6 +1513,25 @@
           "url": "https://github.com/workcr"
         }
       ]
+    },
+    {
+      "name": "solidity-snippets",
+      "display_name": "Solidity Snippets",
+      "version": "1.0.0",
+      "description": "50+ battle-tested Solidity snippets for smart contract development — preview in terminal, buy full access for $1 (ETH/USDT). Zero dependencies.",
+      "requires": null,
+      "homepage": "https://solidity-snippets.vercel.app",
+      "source_url": "https://github.com/tiancaijb366-pixel/cli-anything-solidity-snippets",
+      "install_cmd": "pip install git+https://github.com/tiancaijb366-pixel/cli-anything-solidity-snippets.git",
+      "entry_point": "cli-anything-solidity-snippets",
+      "skill_md": "https://raw.githubusercontent.com/tiancaijb366-pixel/cli-anything-solidity-snippets/main/cli_anything/solidity_snippets/skills/SKILL.md",
+      "category": "web3",
+      "contributors": [
+        {
+          "name": "tiancaijb366-pixel",
+          "url": "https://github.com/tiancaijb366-pixel"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description

Adds `solidity-snippets` to the registry — a terminal-based preview CLI for Solidity smart contract snippets.

### Why web3?

Solidity/blockchain/web3 developers are an underserved audience in the current registry. This harness fills that gap with 10 previewable Solidity snippets across 5 categories (ERC Standards, Security, Gas Optimization, Access Control, Math & Utils).

### Distribution

- **Standalone repo:** tiancaijb366-pixel/cli-anything-solidity-snippets
- **Install:** `pip install git+https://github.com/tiancaijb366-pixel/cli-anything-solidity-snippets.git`
- **Category:** `web3`

### Commands

| Command | Description |
|---------|------------|
| `list` | Browse available snippets |
| `preview <id>` | Show truncated preview + purchase info |
| `buy` | Display payment address |
| `info` | Product metadata |
| `repl` | Interactive REPL mode |

### Testing

15/15 unit tests passing. Zero external dependencies beyond `click>=8.0`.

### Monetization note

This is a freemium CLI — preview is free, full snippet pack costs $1 (ETH/USDT). The payment address is displayed in the CLI directly.
