### PR TITLE
Refresh MiniMax model and endpoint catalogs

### DIFF
--- a/minimax/agent-harness/cli_anything/minimax/README.md
+++ b/minimax/agent-harness/cli_anything/minimax/README.md
@@ -37,8 +37,8 @@ cli-anything-minimax tts --text "Hello world" --output hello.mp3
 # Simple chat (default model: MiniMax-M3)
 cli-anything-minimax chat --prompt "Explain quantum computing"
 
-# High-speed model
-cli-anything-minimax chat --prompt "Quick answer please" --model MiniMax-M2.7-highspeed
+# Alternate chat model
+cli-anything-minimax chat --prompt "Quick answer please" --model MiniMax-M2.7
 
 # Streaming output
 cli-anything-minimax stream --prompt "Write a haiku about AI"
@@ -109,7 +109,6 @@ cli-anything-minimax models --tts
 |-------|-------------|
 | `MiniMax-M3` | Next-generation flagship model (default) |
 | `MiniMax-M2.7` | Peak Performance. Ultimate Value. |
-| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |
 
 ### TTS
 
@@ -117,12 +116,19 @@ cli-anything-minimax models --tts
 |-------|-------------|
 | `speech-2.8-hd` | High-definition TTS (default) |
 | `speech-2.8-turbo` | Fast TTS |
+| `speech-2.6-hd` | High-definition TTS |
+| `speech-2.6-turbo` | Fast TTS |
+| `speech-02-hd` | High-definition TTS |
+| `speech-02-turbo` | Fast TTS |
+| `speech-01-hd` | High-definition TTS |
+| `speech-01-turbo` | Fast TTS |
 
 ## Environment Variables
 
 | Variable | Description |
 |----------|-------------|
 | `MINIMAX_API_KEY` | MiniMax API key (required) |
+| `MINIMAX_REGION` | Select `global_en` or `cn_zh` regional endpoints |
 | `MINIMAX_BASE_URL` | Override API base URL (optional) |
 
 ## Validation

--- a/minimax/agent-harness/cli_anything/minimax/skills/SKILL.md
+++ b/minimax/agent-harness/cli_anything/minimax/skills/SKILL.md
@@ -33,8 +33,8 @@ cli-anything-minimax
 # Chat with MiniMax-M3
 cli-anything-minimax chat --prompt "What is AI?"
 
-# High-speed model
-cli-anything-minimax chat --prompt "Quick answer" --model MiniMax-M2.7-highspeed
+# Alternate chat model
+cli-anything-minimax chat --prompt "Quick answer" --model MiniMax-M2.7
 
 # Stream chat response
 cli-anything-minimax stream --prompt "Write a poem about code"
@@ -124,7 +124,6 @@ cli-anything-minimax tts --text "Fast" --model speech-2.8-turbo --voice English_
 |----------|-------------|
 | `MiniMax-M3` | Next-generation flagship model (default) |
 | `MiniMax-M2.7` | Peak Performance. Ultimate Value. |
-| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |
 
 ## TTS Models
 
@@ -132,6 +131,12 @@ cli-anything-minimax tts --text "Fast" --model speech-2.8-turbo --voice English_
 |----------|-------------|
 | `speech-2.8-hd` | High-definition TTS (default) |
 | `speech-2.8-turbo` | Fast TTS |
+| `speech-2.6-hd` | High-definition TTS |
+| `speech-2.6-turbo` | Fast TTS |
+| `speech-02-hd` | High-definition TTS |
+| `speech-02-turbo` | Fast TTS |
+| `speech-01-hd` | High-definition TTS |
+| `speech-01-turbo` | Fast TTS |
 
 ## For AI Agents
 

--- a/minimax/agent-harness/cli_anything/minimax/tests/test_core.py
+++ b/minimax/agent-harness/cli_anything/minimax/tests/test_core.py
@@ -12,6 +12,9 @@ from cli_anything.minimax.utils.minimax_backend import (
     chat_completion_stream,
     tts_synthesize,
     run_full_workflow,
+    REGIONAL_ENDPOINTS,
+    TEXT_MODEL_CONFIG,
+    MULTIMODAL_CONFIG,
     CHAT_MODELS,
     TTS_MODELS,
     TTS_VOICES,
@@ -63,21 +66,60 @@ def test_save_and_load_config(tmp_path):
 
 # ── Chat models ────────────────────────────────────────────────────────────────
 
-def test_chat_models_list():
-    """MiniMax-M3, MiniMax-M2.7 and MiniMax-M2.7-highspeed must be in the model list."""
+def test_text_model_catalog():
+    """The text catalog must match the refreshed MiniMax target models."""
+    assert TEXT_MODEL_CONFIG["model_id"] == "MiniMax-M3"
+    assert TEXT_MODEL_CONFIG["model_ids"] == ["MiniMax-M3", "MiniMax-M2.7"]
+
     model_ids = [m["id"] for m in CHAT_MODELS]
-    assert "MiniMax-M3" in model_ids
-    assert "MiniMax-M2.7" in model_ids
-    assert "MiniMax-M2.7-highspeed" in model_ids
-    assert len(CHAT_MODELS) == 3
-    # M3 must be the first (default) model
+    assert model_ids == ["MiniMax-M3", "MiniMax-M2.7"]
+    assert len(CHAT_MODELS) == 2
     assert CHAT_MODELS[0]["id"] == "MiniMax-M3"
+    assert CHAT_MODELS[0]["context_window"] == 1000000
+    assert CHAT_MODELS[0]["pricing_usd_per_million_tokens"] == {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_read": 0.12,
+        "cache_write": None,
+    }
+    assert CHAT_MODELS[0]["input_modalities"] == ["text", "image", "video"]
+    assert CHAT_MODELS[0]["thinking"] == ["adaptive", "disabled"]
+    assert CHAT_MODELS[1]["id"] == "MiniMax-M2.7"
+    assert CHAT_MODELS[1]["context_window"] == 204800
+    assert CHAT_MODELS[1]["pricing_usd_per_million_tokens"] == {
+        "input": 0.3,
+        "output": 1.2,
+        "cache_read": 0.06,
+        "cache_write": 0.375,
+    }
+    assert CHAT_MODELS[1]["input_modalities"] == ["text"]
+    assert CHAT_MODELS[1]["thinking"] == ["always_on"]
+
+
+def test_regional_endpoints_catalog():
+    """The regional endpoint catalog must include global and CN entries."""
+    assert REGIONAL_ENDPOINTS == [
+        {
+            "region": "global_en",
+            "openai_base_url": "https://api.minimax.io/v1",
+            "anthropic_base_url": "https://api.minimax.io/anthropic",
+            "docs_root": "https://platform.minimax.io/docs",
+        },
+        {
+            "region": "cn_zh",
+            "openai_base_url": "https://api.minimaxi.com/v1",
+            "anthropic_base_url": "https://api.minimaxi.com/anthropic",
+            "docs_root": "https://platform.minimaxi.com/docs",
+        },
+    ]
 
 
 def test_tts_models_list():
-    """speech-2.8-hd must be the first (default) TTS model."""
+    """The TTS catalog must expose the full speech-2.x model set."""
+    assert [m["id"] for m in TTS_MODELS] == MULTIMODAL_CONFIG["speech"]["models"]
+    assert len(TTS_MODELS) == 8
     assert TTS_MODELS[0]["id"] == "speech-2.8-hd"
-    assert any(m["id"] == "speech-2.8-turbo" for m in TTS_MODELS)
+    assert TTS_MODELS[0]["description"] == "High-definition TTS (recommended default)"
 
 
 def test_tts_voices_list():
@@ -113,8 +155,8 @@ def test_chat_completion_success():
         assert result["usage"]["total_tokens"] == 22
 
 
-def test_chat_completion_uses_minimax_base_url():
-    """Verify chat completion calls api.minimax.io/v1."""
+def test_chat_completion_uses_global_region_base_url():
+    """Verify chat completion calls the global OpenAI-compatible endpoint."""
     with patch("requests.post") as mock_post:
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -124,8 +166,22 @@ def test_chat_completion_uses_minimax_base_url():
         chat_completion(api_key="key", model="MiniMax-M3", messages=[])
 
         call_url = mock_post.call_args[0][0]
-        assert "minimax.io" in call_url
-        assert "/v1/chat/completions" in call_url
+        assert call_url == "https://api.minimax.io/v1/chat/completions"
+
+
+def test_chat_completion_uses_cn_region_base_url():
+    """Verify chat completion switches to the CN region endpoint."""
+    with patch.dict("os.environ", {"MINIMAX_REGION": "cn_zh"}, clear=True):
+        with patch("requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+            mock_post.return_value = mock_resp
+
+            chat_completion(api_key="key", model="MiniMax-M3", messages=[])
+
+            call_url = mock_post.call_args[0][0]
+            assert call_url == "https://api.minimaxi.com/v1/chat/completions"
 
 
 def test_chat_completion_default_temperature():
@@ -235,7 +291,7 @@ def test_tts_synthesize_hex_decoding(tmp_path):
 
 
 def test_tts_synthesize_uses_correct_endpoint():
-    """TTS must call /v1/t2a_v2."""
+    """TTS must call the global speech endpoint."""
     with patch("requests.post") as mock_post:
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -245,7 +301,22 @@ def test_tts_synthesize_uses_correct_endpoint():
         tts_synthesize(api_key="key", text="test")
 
         call_url = mock_post.call_args[0][0]
-        assert "/v1/t2a_v2" in call_url
+        assert call_url == "https://api.minimax.io/v1/t2a_v2"
+
+
+def test_tts_synthesize_uses_cn_region_endpoint():
+    """TTS must switch to the CN speech endpoint when requested."""
+    with patch.dict("os.environ", {"MINIMAX_REGION": "cn_zh"}, clear=True):
+        with patch("requests.post") as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.iter_content.return_value = []
+            mock_post.return_value = mock_resp
+
+            tts_synthesize(api_key="key", text="test")
+
+            call_url = mock_post.call_args[0][0]
+            assert call_url == "https://api.minimaxi.com/v1/t2a_v2"
 
 
 def test_tts_synthesize_api_error():

--- a/minimax/agent-harness/cli_anything/minimax/tests/test_full_e2e.py
+++ b/minimax/agent-harness/cli_anything/minimax/tests/test_full_e2e.py
@@ -158,11 +158,25 @@ class TestCLISubprocessSmoke:
         models = self._run(["models"], tmp_path)
         assert "MiniMax-M3" in models.stdout
         assert "MiniMax-M2.7" in models.stdout
+        assert "MiniMax-M2.7-highspeed" not in models.stdout
 
         models_json = self._run(["--json", "models"], tmp_path)
         model_payload = json.loads(models_json.stdout)
         assert isinstance(model_payload, list)
-        assert model_payload[0]["id"] == "MiniMax-M3"
+        assert [m["id"] for m in model_payload] == ["MiniMax-M3", "MiniMax-M2.7"]
+
+        tts_models = self._run(["--json", "models", "--tts"], tmp_path)
+        tts_model_payload = json.loads(tts_models.stdout)
+        assert [m["id"] for m in tts_model_payload] == [
+            "speech-2.8-hd",
+            "speech-2.8-turbo",
+            "speech-2.6-hd",
+            "speech-2.6-turbo",
+            "speech-02-hd",
+            "speech-02-turbo",
+            "speech-01-hd",
+            "speech-01-turbo",
+        ]
 
         voices = self._run(["voices"], tmp_path)
         assert "English_Graceful_Lady" in voices.stdout
@@ -274,8 +288,8 @@ def test_chat_completion_e2e():
     assert result["choices"][0]["message"]["content"]
 
 
-def test_chat_completion_highspeed_model_e2e():
-    """Test MiniMax-M2.7-highspeed model."""
+def test_chat_completion_m27_model_e2e():
+    """Test MiniMax-M2.7 model."""
     if not API_KEY:
         mock_response = {
             "choices": [{"message": {"role": "assistant", "content": "done"}}],
@@ -289,17 +303,17 @@ def test_chat_completion_highspeed_model_e2e():
 
             result = chat_completion(
                 api_key="sk-mock",
-                model="MiniMax-M2.7-highspeed",
+                model="MiniMax-M2.7",
                 messages=[{"role": "user", "content": "Say done"}],
             )
             body = mock_post.call_args[1]["json"]
-            assert body["model"] == "MiniMax-M2.7-highspeed"
+            assert body["model"] == "MiniMax-M2.7"
             assert result["choices"][0]["message"]["content"] == "done"
         return
 
     result = chat_completion(
         api_key=API_KEY,
-        model="MiniMax-M2.7-highspeed",
+        model="MiniMax-M2.7",
         messages=[{"role": "user", "content": "Say 'done'"}],
         max_tokens=10,
     )

--- a/minimax/agent-harness/cli_anything/minimax/utils/minimax_backend.py
+++ b/minimax/agent-harness/cli_anything/minimax/utils/minimax_backend.py
@@ -13,21 +13,185 @@ except ImportError:
     print("requests library not found. Install with: pip3 install requests", file=sys.stderr)
     sys.exit(1)
 
-CHAT_API_BASE = os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.io/v1").rstrip("/")
-TTS_API_BASE = os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.io").rstrip("/")
 CONFIG_DIR = Path.home() / ".config" / "cli-anything-minimax"
 CONFIG_FILE = CONFIG_DIR / "config.json"
 ENV_API_KEY = "MINIMAX_API_KEY"
+MINIMAX_REGION_ENV = "MINIMAX_REGION"
+
+REGIONAL_ENDPOINTS = [
+    {
+        "region": "global_en",
+        "openai_base_url": "https://api.minimax.io/v1",
+        "anthropic_base_url": "https://api.minimax.io/anthropic",
+        "docs_root": "https://platform.minimax.io/docs",
+    },
+    {
+        "region": "cn_zh",
+        "openai_base_url": "https://api.minimaxi.com/v1",
+        "anthropic_base_url": "https://api.minimaxi.com/anthropic",
+        "docs_root": "https://platform.minimaxi.com/docs",
+    },
+]
+
+_REGIONAL_ENDPOINTS_BY_REGION = {item["region"]: item for item in REGIONAL_ENDPOINTS}
+
+TEXT_MODEL_CONFIG = {
+    "reason_codes": {
+        "provider_add": "provider-add",
+        "model_add": "model-add",
+        "parameter_refresh": "parameter-refresh",
+        "input_capability": "input-capability",
+    },
+    "model_id": "MiniMax-M3",
+    "model_ids": ["MiniMax-M3", "MiniMax-M2.7"],
+    "models": [
+        {
+            "model_id": "MiniMax-M3",
+            "context_window": 1000000,
+            "pricing_usd_per_million_tokens": {
+                "input": 0.6,
+                "output": 2.4,
+                "cache_read": 0.12,
+                "cache_write": None,
+            },
+            "input_modalities": ["text", "image", "video"],
+            "thinking": ["adaptive", "disabled"],
+        },
+        {
+            "model_id": "MiniMax-M2.7",
+            "context_window": 204800,
+            "pricing_usd_per_million_tokens": {
+                "input": 0.3,
+                "output": 1.2,
+                "cache_read": 0.06,
+                "cache_write": 0.375,
+            },
+            "input_modalities": ["text"],
+            "thinking": ["always_on"],
+        },
+    ],
+    "anthropic_base_url": "https://api.minimax.io/anthropic",
+    "openai_base_url": "https://api.minimax.io/v1",
+    "context_window": 1000000,
+    "pricing_usd_per_million_tokens": {
+        "input": 0.6,
+        "output": 2.4,
+        "cache_read": 0.12,
+        "cache_write": None,
+    },
+    "thinking": ["adaptive", "disabled"],
+}
+
+MULTIMODAL_CONFIG = {
+    "speech": {
+        "reason_code": "tts-tool",
+        "reason_codes": {"tts": "tts-tool"},
+        "docs_urls": [
+            "https://platform.minimax.io/docs/api-reference/speech-t2a-http",
+            "https://platform.minimax.io/docs/api-reference/speech-t2a-async-create",
+            "https://platform.minimax.io/docs/api-reference/speech-t2a-websocket",
+            "https://platform.minimaxi.com/docs/api-reference/speech-t2a-http",
+            "https://platform.minimaxi.com/docs/api-reference/speech-t2a-async-create",
+            "https://platform.minimaxi.com/docs/api-reference/speech-t2a-websocket",
+        ],
+        "endpoints": [
+            {"region": "global_en", "url": "https://api.minimax.io/v1/t2a_v2"},
+            {"region": "cn_zh", "url": "https://api.minimaxi.com/v1/t2a_v2"},
+        ],
+        "default_model": "speech-2.8-hd",
+        "models": [
+            "speech-2.8-hd",
+            "speech-2.8-turbo",
+            "speech-2.6-hd",
+            "speech-2.6-turbo",
+            "speech-02-hd",
+            "speech-02-turbo",
+            "speech-01-hd",
+            "speech-01-turbo",
+        ],
+        "reference": {
+            "authorization": "Bearer",
+            "operations": [
+                {
+                    "operation_id": "textToAudioHttp",
+                    "method": "POST",
+                    "path": "/v1/t2a_v2",
+                    "required_fields": ["model", "text"],
+                    "request_fields": [
+                        "model",
+                        "text",
+                        "stream",
+                        "language_boost",
+                        "output_format",
+                        "voice_setting",
+                        "pronunciation_dict",
+                        "audio_setting",
+                        "voice_modify",
+                        "subtitle_enable",
+                    ],
+                },
+                {
+                    "operation_id": "textToAudioAsyncCreate",
+                    "method": "POST",
+                    "path": "/v1/t2a_async_v2",
+                    "required_fields": ["model", "text"],
+                    "request_fields": [
+                        "model",
+                        "text",
+                        "voice_setting",
+                        "audio_setting",
+                        "language_boost",
+                        "pronunciation_dict",
+                        "voice_modify",
+                    ],
+                },
+                {
+                    "operation_id": "textToAudioWebSocket",
+                    "method": "WSS",
+                    "path": "/ws/v1/t2a_v2",
+                    "required_fields": ["model", "text"],
+                },
+                {
+                    "operation_id": "textToAudioAsyncQuery",
+                    "method": "POST",
+                    "path": "/v1/query/t2a_async_query_v2",
+                    "required_fields": ["task_id"],
+                },
+            ],
+            "audio_formats": ["mp3", "wav", "flac", "pcm"],
+            "response_fields": ["data.audio", "data.status", "base_resp.status_code"],
+        },
+    }
+}
 
 CHAT_MODELS = [
-    {"id": "MiniMax-M3", "description": "Next-generation flagship model (default)"},
-    {"id": "MiniMax-M2.7", "description": "Peak Performance. Ultimate Value. Master the Complex"},
-    {"id": "MiniMax-M2.7-highspeed", "description": "Same performance, faster and more agile"},
+    {
+        "id": model["model_id"],
+        "description": (
+            "Next-generation flagship model (default)"
+            if model["model_id"] == "MiniMax-M3"
+            else "Peak Performance. Ultimate Value."
+        ),
+        "context_window": model["context_window"],
+        "pricing_usd_per_million_tokens": model["pricing_usd_per_million_tokens"],
+        "input_modalities": model["input_modalities"],
+        "thinking": model["thinking"],
+    }
+    for model in TEXT_MODEL_CONFIG["models"]
 ]
 
 TTS_MODELS = [
-    {"id": "speech-2.8-hd", "description": "High-definition TTS (recommended default)"},
-    {"id": "speech-2.8-turbo", "description": "Fast TTS"},
+    {"id": model_id, "description": description}
+    for model_id, description in [
+        ("speech-2.8-hd", "High-definition TTS (recommended default)"),
+        ("speech-2.8-turbo", "Fast TTS"),
+        ("speech-2.6-hd", "High-definition TTS"),
+        ("speech-2.6-turbo", "Fast TTS"),
+        ("speech-02-hd", "High-definition TTS"),
+        ("speech-02-turbo", "Fast TTS"),
+        ("speech-01-hd", "High-definition TTS"),
+        ("speech-01-turbo", "Fast TTS"),
+    ]
 ]
 
 TTS_VOICES = [
@@ -90,6 +254,20 @@ def _make_auth_headers(api_key: str) -> dict:
     }
 
 
+def _get_region_endpoint(region: Optional[str] = None) -> dict:
+    selected_region = region or os.environ.get(MINIMAX_REGION_ENV, "global_en")
+    return _REGIONAL_ENDPOINTS_BY_REGION.get(
+        selected_region, _REGIONAL_ENDPOINTS_BY_REGION["global_en"]
+    )
+
+
+def _get_api_base() -> str:
+    override = os.environ.get("MINIMAX_BASE_URL")
+    if override:
+        return override.rstrip("/")
+    return _get_region_endpoint()["openai_base_url"].rstrip("/")
+
+
 def chat_completion(
     api_key: Optional[str] = None,
     model: str = "MiniMax-M3",
@@ -107,9 +285,10 @@ def chat_completion(
         body["max_tokens"] = max_tokens
     headers = _make_auth_headers(api_key)
     resp = None
+    api_base = _get_api_base()
     try:
         resp = requests.post(
-            f"{CHAT_API_BASE}/chat/completions",
+            f"{api_base}/chat/completions",
             json=body,
             headers=headers,
             timeout=60,
@@ -144,9 +323,10 @@ def chat_completion_stream(
         body["max_tokens"] = max_tokens
     headers = _make_auth_headers(api_key)
     full_response = ""
+    api_base = _get_api_base()
     try:
         resp = requests.post(
-            f"{CHAT_API_BASE}/chat/completions",
+            f"{api_base}/chat/completions",
             json=body,
             headers=headers,
             timeout=120,
@@ -211,9 +391,11 @@ def tts_synthesize(
             "channel": channel,
         },
     }
+    api_base = _get_api_base()
+    tts_path = "/v1/t2a_v2" if os.environ.get("MINIMAX_BASE_URL") else "/t2a_v2"
     try:
         resp = requests.post(
-            f"{TTS_API_BASE}/v1/t2a_v2",
+            f"{api_base}{tts_path}",
             json=body,
             headers=headers,
             timeout=120,

--- a/minimax/agent-harness/setup.py
+++ b/minimax/agent-harness/setup.py
@@ -15,7 +15,7 @@ setup(
     version="1.1.0",
     author="cli-anything contributors",
     author_email="",
-    description="CLI harness for MiniMax AI — chat (MiniMax-M3) and TTS via MiniMax API. Requires: MINIMAX_API_KEY",
+    description="CLI harness for MiniMax AI — chat (MiniMax-M3, MiniMax-M2.7) and speech-2.x TTS via MiniMax API. Requires: MINIMAX_API_KEY",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/HKUDS/CLI-Anything",

--- a/registry.json
+++ b/registry.json
@@ -1365,7 +1365,7 @@
       "name": "minimax",
       "display_name": "MiniMax",
       "version": "1.1.0",
-      "description": "Chat and TTS via MiniMax AI API — MiniMax-M3 chat models and speech-2.8-hd TTS",
+      "description": "Chat and TTS via MiniMax AI API — MiniMax-M3 and MiniMax-M2.7 chat models and speech-2.x TTS",
       "requires": "MINIMAX_API_KEY",
       "homepage": "https://platform.minimax.io",
       "source_url": null,

--- a/skills/cli-anything-minimax/SKILL.md
+++ b/skills/cli-anything-minimax/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "cli-anything-minimax"
 description: >-
-  Command-line interface for MiniMax AI — chat (MiniMax-M3) and TTS (speech-2.8-hd) via the MiniMax API.
+  Command-line interface for MiniMax AI — chat (MiniMax-M3, MiniMax-M2.7) and speech-2.x TTS via the MiniMax API.
 ---
 
 # cli-anything-minimax
@@ -32,8 +32,8 @@ cli-anything-minimax
 # Chat with MiniMax-M3
 cli-anything-minimax chat --prompt "What is AI?"
 
-# High-speed model
-cli-anything-minimax chat --prompt "Quick answer" --model MiniMax-M2.7-highspeed
+# Alternate chat model
+cli-anything-minimax chat --prompt "Quick answer" --model MiniMax-M2.7
 
 # Stream chat response
 cli-anything-minimax stream --prompt "Write a poem about code"
@@ -123,7 +123,6 @@ cli-anything-minimax tts --text "Fast" --model speech-2.8-turbo --voice English_
 |----------|-------------|
 | `MiniMax-M3` | Next-generation flagship model (default) |
 | `MiniMax-M2.7` | Peak Performance. Ultimate Value. |
-| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |
 
 ## TTS Models
 
@@ -131,6 +130,12 @@ cli-anything-minimax tts --text "Fast" --model speech-2.8-turbo --voice English_
 |----------|-------------|
 | `speech-2.8-hd` | High-definition TTS (default) |
 | `speech-2.8-turbo` | Fast TTS |
+| `speech-2.6-hd` | High-definition TTS |
+| `speech-2.6-turbo` | Fast TTS |
+| `speech-02-hd` | High-definition TTS |
+| `speech-02-turbo` | Fast TTS |
+| `speech-01-hd` | High-definition TTS |
+| `speech-01-turbo` | Fast TTS |
 
 ## For AI Agents
 


### PR DESCRIPTION
Reason: Refresh the MiniMax endpoint and model catalogs to match the current target configuration.

Changes:
- Added region-aware endpoint catalogs for `global_en` and `cn_zh`.
- Replaced the chat catalog with `MiniMax-M3` and `MiniMax-M2.7` plus target metadata.
- Expanded the TTS catalog to the full speech-2.x set.
- Updated the MiniMax harness docs and registry description to match the new catalogs.

Checks:
- `python3 -m py_compile minimax/agent-harness/cli_anything/minimax/minimax_cli.py minimax/agent-harness/cli_anything/minimax/core/session.py minimax/agent-harness/cli_anything/minimax/utils/minimax_backend.py minimax/agent-harness/cli_anything/minimax/tests/test_core.py minimax/agent-harness/cli_anything/minimax/tests/test_full_e2e.py minimax/agent-harness/cli_anything/minimax/tests/test_tts_extended.py`
- `PYTHONPATH=./repos/CLI-Anything-recvqf4YBb5tz1/minimax/agent-harness ./.octopatch-venv/bin/python -m pytest ./repos/CLI-Anything-recvqf4YBb5tz1/minimax/agent-harness/cli_anything/minimax/tests/test_core.py ./repos/CLI-Anything-recvqf4YBb5tz1/minimax/agent-harness/cli_anything/minimax/tests/test_full_e2e.py ./repos/CLI-Anything-recvqf4YBb5tz1/minimax/agent-harness/cli_anything/minimax/tests/test_tts_extended.py -v`
