### PR TITLE
fix(minimax): align SKILL.md source with refreshed catalog to fix Check Root Skills

### DIFF
--- a/minimax/agent-harness/cli_anything/minimax/skills/SKILL.md
+++ b/minimax/agent-harness/cli_anything/minimax/skills/SKILL.md
@@ -2,7 +2,7 @@
 name: >-
   cli-anything-minimax
 description: >-
-  Command-line interface for MiniMax AI — chat (MiniMax-M3) and TTS (speech-2.8-hd) via the MiniMax API.
+  Command-line interface for MiniMax AI — chat (MiniMax-M3, MiniMax-M2.7) and speech-2.x TTS via the MiniMax API.
 ---
 
 # cli-anything-minimax


### PR DESCRIPTION
#415 updated the generated mirror `skills/cli-anything-minimax/SKILL.md` with a refreshed description (adds MiniMax-M2.7 / speech-2.x) but did not update the canonical source `minimax/agent-harness/cli_anything/minimax/skills/SKILL.md`. The root-skills validator then flags the mirror as containing content absent from its source, failing **Check Root Skills** on `main`.

This aligns the source description with the mirror. After the change, `python3 .github/scripts/sync_root_skills.py` reports no drift and `validate_root_skills.py` passes.