### PR TITLE
Add Cursor generator plugin (slash commands + installers)

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "cli-anything",
+  "owner": {
+    "name": "cli-anything contributors"
+  },
+  "metadata": {
+    "description": "CLI-Anything Cursor marketplace: generator plugin with slash commands. Consumer Hub/skills install separately via npx skills."
+  },
+  "plugins": [
+    {
+      "name": "cli-anything",
+      "source": "./cursor-plugin",
+      "description": "Build powerful, stateful CLI interfaces for any GUI application using the cli-anything harness methodology.",
+      "author": {
+        "name": "cli-anything contributors"
+      },
+      "category": "development",
+      "keywords": [
+        "cli-anything",
+        "harness",
+        "generator"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/check-cursor-plugin.yml
+++ b/.github/workflows/check-cursor-plugin.yml
@@ -1,0 +1,43 @@
+name: Check Cursor Plugin
+
+on:
+  pull_request:
+    paths:
+      - 'cursor-plugin/**'
+      - '.cursor-plugin/**'
+      - 'cli-anything-plugin/**'
+      - 'docs/PREVIEW_PROTOCOL.md'
+      - '.github/workflows/check-cursor-plugin.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'cursor-plugin/**'
+      - '.cursor-plugin/**'
+      - 'cli-anything-plugin/**'
+      - 'docs/PREVIEW_PROTOCOL.md'
+      - '.github/workflows/check-cursor-plugin.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-installer-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Test Cursor plugin installer (bash)
+        run: bash cursor-plugin/tests/test_install.sh
+
+  test-installer-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Test Cursor plugin installer (PowerShell)
+        shell: pwsh
+        run: ./cursor-plugin/tests/test_install.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 !/.pi-extension/
 /.pi-extension/cli-anything/node_modules
 !/.claude-plugin/
+!/.cursor-plugin/
 !/.github/
 /.github/*
 !/.github/workflows/
@@ -32,6 +33,7 @@
 
 # Step 3: Allow cli-anything-plugin, codex-skill, and skill_generation tests
 !/cli-anything-plugin/
+!/cursor-plugin/
 !/codex-skill/
 !/hermes-skill/
 !/reasonix-skill/

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Use the CLI-Anything generator when you need a new harness for software, a codeb
 
 - **Python 3.10+**
 - Target software or source repo available locally or online
-- A supported AI coding agent: [Claude Code](#-claude-code) | [Pi](#-pi-coding-agent) | [OpenClaw](#-openclaw) | [OpenCode](#-opencode) | [Codex](#-codex) | [Hermes](#-hermes) | [Reasonix](#-reasonix) | [Qodercli](#-qodercli) | [GitHub Copilot CLI](#-github-copilot-cli) | [More Platforms](#-more-platforms-coming-soon)
+- A supported AI coding agent: [Claude Code](#-claude-code) | [Cursor](#-cursor) | [Pi](#-pi-coding-agent) | [OpenClaw](#-openclaw) | [OpenCode](#-opencode) | [Codex](#-codex) | [Hermes](#-hermes) | [Reasonix](#-reasonix) | [Qodercli](#-qodercli) | [GitHub Copilot CLI](#-github-copilot-cli) | [More Platforms](#-more-platforms-coming-soon)
 
 ### Pick Your Agent Platform
 
@@ -533,6 +533,63 @@ The skill follows the same 7-phase methodology as Claude Code and OpenCode.
 
 <details>
 
+<summary><h4 id="-cursor">⚡ Cursor</h4></summary>
+
+Cursor gets **both** tracks:
+
+| Track | Purpose | Install |
+|-------|---------|---------|
+| **Generator** | Build new harnesses with `/cli-anything` (and refine/test/validate/list) | Cursor plugin in `cursor-plugin/` |
+| **Consumer** | Find/install/use published CLIs from CLI-Hub | `npx skills` + `cli-hub` (unchanged) |
+
+**Generator — install the Cursor plugin**
+
+```bash
+git clone https://github.com/HKUDS/CLI-Anything.git
+bash CLI-Anything/cursor-plugin/scripts/install.sh
+```
+
+Windows PowerShell:
+
+```powershell
+.\CLI-Anything\cursor-plugin\scripts\install.ps1
+```
+
+Upgrade with `--force` / `-Force`. Default install path is
+`~/.cursor/plugins/local/cli-anything` (override with `CURSOR_PLUGINS_HOME` pointing at a
+directory named `plugins`). The installer vendors `cli-anything-plugin/` methodology
+resources and writes `PLUGIN_ROOT.txt` plus `~/.cursor/cli-anything-generator.root`
+so Cursor agents can resolve absolute methodology paths.
+
+Reload the Cursor window (**Developer: Reload Window**), then:
+
+```text
+/cli-anything ./gimp
+/cli-anything-refine ./shotcut "picture-in-picture workflows"
+/cli-anything-test ./libreoffice
+/cli-anything-validate ./libreoffice
+/cli-anything-list
+```
+
+**Consumer — Hub / skills (separate from the generator plugin)**
+
+```bash
+npx skills add HKUDS/CLI-Anything --skill cli-hub-meta-skill -g -y
+# or a per-app skill, e.g. cli-anything-blender
+pip install cli-anything-hub
+```
+
+Verify the plugin installer locally:
+
+```bash
+bash CLI-Anything/cursor-plugin/tests/test_install.sh
+```
+
+See [`cursor-plugin/README.md`](cursor-plugin/README.md) for troubleshooting local plugin loading.
+</details>
+
+<details>
+
 <summary><h4 id="-codex">⚡ Codex <sup><code>Experimental</code></sup> <sup><code>Community</code></sup></h4></summary>
 
 **Step 1: Install the Skill**
@@ -696,8 +753,8 @@ This installs the CLI-Anything plugin to GitHub Copilot CLI. The plugin should n
 
 CLI-Anything is designed to be platform-agnostic. Support for more AI coding agents is planned:
 
+- **Cursor** — available via the Cursor plugin in `cursor-plugin/` (generator) plus Hub/skills (consumer)
 - **Codex** — available via the bundled skill in `codex-skill/`
-- **Cursor** — coming soon
 - **Windsurf** — coming soon
 - **Your favorite tool** — contributions welcome! See the `opencode-commands/` directory for a reference implementation.
 
@@ -1429,6 +1486,13 @@ cli-anything/
 │   └── scripts/
 │       └── setup-cli-anything.sh         # Setup script
 │
+├── 🖱️ cursor-plugin/                     # Cursor Desktop generator plugin
+│   ├── .cursor-plugin/plugin.json        # Cursor plugin manifest
+│   ├── commands/                         # /cli-anything slash commands
+│   ├── skills/                           # Supporting generator skill
+│   ├── rules/                            # Phase-gate guidance
+│   ├── scripts/                          # Bash/PowerShell installers + vendored helpers
+│   └── tests/                            # Installer resource-sync regression tests
 ├── 🤖 codex-skill/                      # Self-contained Codex skill installer
 │   ├── SKILL.md                         # Codex workflow entry point
 │   ├── agents/                          # Codex UI metadata

--- a/README_CN.md
+++ b/README_CN.md
@@ -59,7 +59,7 @@ CLI 是人类和 AI Agent 共通的万能接口：
 
 - **Python 3.10+**
 - 目标软件已安装（如 GIMP、Blender、LibreOffice 或你自己的应用）
-- 支持的 AI 编程工具之一：[Claude Code](#-claude-code) | [OpenClaw](#-openclaw) | [OpenCode](#-opencode) | [Codex](#-codex) | [Qodercli](#-qodercli) | [GitHub Copilot CLI](#-github-copilot-cli) | [更多平台](#-更多平台即将支持)
+- 支持的 AI 编程工具之一：[Claude Code](#-claude-code) | [Cursor](#-cursor) | [OpenClaw](#-openclaw) | [OpenCode](#-opencode) | [Codex](#-codex) | [Qodercli](#-qodercli) | [GitHub Copilot CLI](#-github-copilot-cli) | [更多平台](#-更多平台即将支持)
 
 ### 选择你的平台
 
@@ -257,6 +257,62 @@ cp CLI-Anything/openclaw-skill/SKILL.md ~/.openclaw/skills/cli-anything/SKILL.md
 
 <details>
 
+<summary><h4 id="-cursor">⚡ Cursor</h4></summary>
+
+Cursor 同时提供两条能力：
+
+| 轨道 | 用途 | 安装方式 |
+|------|------|----------|
+| **生成器** | 用 `/cli-anything` 等斜杠命令构建新 harness | `cursor-plugin/` Cursor 插件 |
+| **消费端** | 从 CLI-Hub 查找/安装/使用已发布 CLI | `npx skills` + `cli-hub`（不变） |
+
+**生成器 — 安装 Cursor 插件**
+
+```bash
+git clone https://github.com/HKUDS/CLI-Anything.git
+bash CLI-Anything/cursor-plugin/scripts/install.sh
+```
+
+Windows PowerShell：
+
+```powershell
+.\CLI-Anything\cursor-plugin\scripts\install.ps1
+```
+
+升级使用 `--force` / `-Force`。默认安装路径为
+`~/.cursor/plugins/local/cli-anything`（`CURSOR_PLUGINS_HOME` 必须指向名为 `plugins` 的目录）。
+安装器会把 `cli-anything-plugin/` 中的方法论资源 vendor 进插件，并写入 `PLUGIN_ROOT.txt`
+与 `~/.cursor/cli-anything-generator.root`，以便 Cursor Agent 用绝对路径读取 HARNESS。
+
+在 Cursor 中执行 **Developer: Reload Window**，然后：
+
+```text
+/cli-anything ./gimp
+/cli-anything-refine ./shotcut "picture-in-picture workflows"
+/cli-anything-test ./libreoffice
+/cli-anything-validate ./libreoffice
+/cli-anything-list
+```
+
+**消费端 — Hub / skills（与生成器插件分离）**
+
+```bash
+npx skills add HKUDS/CLI-Anything --skill cli-hub-meta-skill -g -y
+# 或某个单应用 skill，例如 cli-anything-blender
+pip install cli-anything-hub
+```
+
+本地验证安装器：
+
+```bash
+bash CLI-Anything/cursor-plugin/tests/test_install.sh
+```
+
+更多说明见 [`cursor-plugin/README.md`](cursor-plugin/README.md)。
+</details>
+
+<details>
+
 <summary><h4 id="-codex">⚡ Codex <sup><code>实验性</code></sup> <sup><code>社区贡献</code></sup></h4></summary>
 
 **第一步：安装 Skill**
@@ -333,8 +389,8 @@ copilot plugin install ./cli-anything-plugin
 
 CLI-Anything 的设计是平台无关的，计划支持更多 AI 编程工具：
 
+- **Cursor** — 已通过 `cursor-plugin/` 提供生成器插件，消费端继续用 Hub/skills
 - **Codex** — 已通过 `codex-skill/` 提供接入
-- **Cursor** — 即将支持
 - **Windsurf** — 即将支持
 - **你喜欢的工具** — 欢迎贡献！参考 `opencode-commands/` 目录的实现。
 
@@ -757,6 +813,13 @@ cli-anything/
 │   ├── cli-anything-validate.md         # 标准验证
 │   └── cli-anything-list.md             # 列出所有 CLI 工具
 │
+├── 🖱️ cursor-plugin/                     # Cursor Desktop 生成器插件
+│   ├── .cursor-plugin/plugin.json        # Cursor 插件清单
+│   ├── commands/                         # /cli-anything 斜杠命令
+│   ├── skills/                           # 辅助生成器 skill
+│   ├── rules/                            # 阶段门禁规则
+│   ├── scripts/                          # 安装脚本与 vendor 辅助文件
+│   └── tests/                            # 安装器回归测试
 ├── 🤖 codex-skill/                      # 可独立安装的 Codex skill
 │   ├── SKILL.md                         # Codex 工作流入口
 │   ├── agents/                          # Codex 界面元数据

--- a/cursor-plugin/.cursor-plugin/plugin.json
+++ b/cursor-plugin/.cursor-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "cli-anything",
+  "version": "1.0.0",
+  "description": "Build, refine, test, validate, and list CLI-Anything harnesses in Cursor. Generator plugin with slash commands; consumer Hub/skills remain separate.",
+  "author": {
+    "name": "cli-anything contributors"
+  },
+  "homepage": "https://github.com/HKUDS/CLI-Anything",
+  "repository": "https://github.com/HKUDS/CLI-Anything",
+  "license": "Apache-2.0",
+  "keywords": [
+    "cli-anything",
+    "harness",
+    "agent-native",
+    "generator"
+  ]
+}

--- a/cursor-plugin/README.md
+++ b/cursor-plugin/README.md
@@ -1,0 +1,106 @@
+# CLI-Anything Cursor Plugin
+
+Cursor Desktop adapter that delivers the **full generator** (slash commands + vendored `cli-anything-plugin` methodology) while keeping the **consumer** path (CLI-Hub / meta-skill / per-app skills) separate and intact.
+
+This is a real **Cursor plugin** (`.cursor-plugin/plugin.json`), not a Claude Code `.claude-plugin` copy and not a skill-only substitute.
+
+## Two tracks
+
+| Track | What you get | How |
+|-------|----------------|-----|
+| **Generator** | `/cli-anything`, refine / test / validate / list | Install this plugin |
+| **Consumer** | Find/install/use published CLIs | `npx skills` + `cli-hub` |
+
+```bash
+# Consumer (unchanged Hub path)
+npx skills add HKUDS/CLI-Anything --skill cli-hub-meta-skill -g -y
+
+# Generator (this plugin)
+bash cursor-plugin/scripts/install.sh
+# Windows:
+#   .\cursor-plugin\scripts\install.ps1
+```
+
+Then **Developer: Reload Window** in Cursor and run:
+
+```text
+/cli-anything ./your-software
+/cli-anything-refine ./your-software "focus area"
+/cli-anything-test ./your-software
+/cli-anything-validate ./your-software
+/cli-anything-list
+```
+
+## Install details
+
+Default destination:
+
+```text
+~/.cursor/plugins/local/cli-anything
+```
+
+`CURSOR_PLUGINS_HOME` must resolve to a directory **named** `plugins` (example: `~/.cursor/plugins`). The installer writes:
+
+| File | Purpose |
+|------|---------|
+| `{install}/PLUGIN_ROOT.txt` | Absolute plugin root stamp |
+| `~/.cursor/cli-anything-generator.root` | Discovery pointer for Cursor agents (always under the user `.cursor` dir) |
+
+Upgrade / reinstall:
+
+```bash
+bash cursor-plugin/scripts/install.sh --force
+# PowerShell: .\cursor-plugin\scripts\install.ps1 -Force
+```
+
+Uninstall (removes `.../plugins/local/cli-anything` and clears `~/.cursor/cli-anything-generator.root` when it points at that install):
+
+```bash
+bash cursor-plugin/scripts/uninstall.sh
+# PowerShell: .\cursor-plugin\scripts\uninstall.ps1
+```
+
+If a `--force` upgrade is interrupted after the old install was moved aside, look for
+`~/.cursor/plugins/local/.cli-anything.bak.*` and rename it back to `cli-anything`.
+
+The installer vendors from repo `cli-anything-plugin/` + `docs/PREVIEW_PROTOCOL.md` into the installed plugin (`references/`, helper `scripts/`). Source of truth remains `cli-anything-plugin/`.
+
+On Windows, `install.sh` (Git Bash) converts stamps to `C:\...` host paths via `cygpath` when available so Cursor tools can resolve them.
+
+### Local plugin loading notes
+
+- Ensure third-party / local plugins are allowed in Cursor settings.
+- Prefer a physical copy (this installer); avoid symlinks.
+- Enterprise orgs may need “Allow Local Plugin Imports”.
+
+Repo also ships [`.cursor-plugin/marketplace.json`](../.cursor-plugin/marketplace.json) for marketplace-style discovery of `./cursor-plugin`.
+
+## Quality bar
+
+Same harness output as Claude Code / Codex: HARNESS-driven 7 phases, `cli_anything.<software>` namespace, `--json`, tests, packaging, skill generation.
+
+Cursor-specific additions:
+
+- Machine-discoverable `PLUGIN_ROOT` (stamp + discovery pointer)
+- Explicit Cursor tool bindings
+- Generator rule (on-demand via globs / description, not always-on) + progress at
+  `{software}/agent-harness/.cli-anything-progress.json`
+- `uninstall.sh` / `uninstall.ps1` to remove the local plugin and matching discovery pointer
+- Shared `scripts/lib.sh` / `scripts/lib.ps1` for path validation and host-path conversion
+
+Prefer the uninstall scripts over manually deleting folders so the discovery pointer
+does not go stale.
+
+## Tests
+
+```bash
+bash cursor-plugin/tests/test_install.sh
+```
+
+Windows:
+
+```powershell
+.\cursor-plugin\tests\test_install.ps1
+```
+
+CI: `.github/workflows/check-cursor-plugin.yml` (Ubuntu bash + Windows PowerShell).

--- a/cursor-plugin/commands/cli-anything-list.md
+++ b/cursor-plugin/commands/cli-anything-list.md
@@ -1,0 +1,39 @@
+---
+name: cli-anything-list
+description: List installed and generated CLI-Anything tools (human or JSON)
+---
+
+# cli-anything-list Command
+
+Discover installed and generated CLI-Anything tools.
+
+## CRITICAL: Resolve PLUGIN_ROOT (absolute paths only)
+
+1. Read `~/.cursor/cli-anything-generator.root` / `%USERPROFILE%\.cursor\cli-anything-generator.root`
+2. Else install dir `PLUGIN_ROOT.txt` / default `.../plugins/local/cli-anything`
+3. Read `{PLUGIN_ROOT}/references/commands/list.md` via absolute path (HARNESS optional for list)
+
+## Cursor Tool Bindings
+
+| Cursor tool | Role |
+|-------------|------|
+| Shell | `python` / `importlib.metadata`, `which` / `Get-Command`, directory scans |
+| Glob / Grep | Find `agent-harness` trees under a search path |
+
+## Options
+
+Honor the same options as the canonical list command:
+
+- `--path <directory>` search root (default: workspace / cwd)
+- `--depth <n>` recursion limit
+- `--json` machine-readable output
+
+## What This Command Does
+
+Follow `{PLUGIN_ROOT}/references/commands/list.md`:
+
+1. List installed `cli-anything-*` packages and entry points.
+2. Scan for generated `agent-harness` trees.
+3. Present human-readable or JSON output as requested.
+
+List mode does not require a progress file unless the user asks to persist results.

--- a/cursor-plugin/commands/cli-anything-refine.md
+++ b/cursor-plugin/commands/cli-anything-refine.md
@@ -1,0 +1,55 @@
+---
+name: cli-anything-refine
+description: Refine an existing CLI-Anything harness to expand coverage and add missing capabilities
+---
+
+# cli-anything-refine Command
+
+Refine an existing CLI harness after a successful `/cli-anything` build.
+
+**Target software**: first argument (local path required).
+**Focus area**: optional second argument / trailing natural-language focus.
+
+## CRITICAL: Resolve PLUGIN_ROOT (absolute paths only)
+
+Resolve `PLUGIN_ROOT` in this order (first hit with `references/HARNESS.md` wins):
+
+1. Read `%USERPROFILE%\.cursor\cli-anything-generator.root` or `~/.cursor/cli-anything-generator.root`
+2. Else `{default-or-$CURSOR_PLUGINS_HOME}/local/cli-anything/PLUGIN_ROOT.txt`
+3. Else that candidate directory if `references/HARNESS.md` exists
+4. Else workspace / cloned `cli-anything-plugin/`
+
+Then read `{PLUGIN_ROOT}/references/HARNESS.md` and `{PLUGIN_ROOT}/references/commands/refine.md` with absolute paths.
+
+## Cursor Tool Bindings
+
+| Cursor tool | Role |
+|-------------|------|
+| Read / Grep / Glob | Inventory current CLI coverage and target APIs |
+| Shell | Run existing tests; verify new commands |
+| Write / StrReplace | Add commands, modules, and tests |
+
+## Arguments
+
+- Local software path only (same tree used for the original build). Clone first with `/cli-anything` if needed.
+- Optional focus area narrows gap analysis (e.g. `"picture-in-picture features"`).
+
+## Phase Gates and Resume (hard gate)
+
+Progress: `{software-root}/agent-harness/.cli-anything-progress.json` with `"mode": "refine"`.
+
+- Steps: inventory → capability scan → gap analysis → implement → test → document.
+- Do not advance a step until the previous is `completed` in the progress file.
+- Resume incomplete refine runs; do not remove existing commands unless the user requests a breaking change.
+- Mark `terminal: true` when refine completes or is permanently aborted.
+
+## Refine checklist
+
+- Inventory current commands/tests before coding
+- Prefer high-impact gaps and thin wrappers around real backend APIs
+- Add matching unit/E2E coverage for every new command surface
+- Keep HARNESS packaging and `--json` / REPL standards
+
+## What This Command Does
+
+Follow `{PLUGIN_ROOT}/references/commands/refine.md` for the full procedure.

--- a/cursor-plugin/commands/cli-anything-test.md
+++ b/cursor-plugin/commands/cli-anything-test.md
@@ -1,0 +1,42 @@
+---
+name: cli-anything-test
+description: Run CLI-Anything harness tests against the real backend and update TEST.md with passing results
+---
+
+# cli-anything-test Command
+
+Run and document tests for an existing harness.
+
+**Target software**: local path argument (required).
+
+## CRITICAL: Resolve PLUGIN_ROOT (absolute paths only)
+
+1. Read `~/.cursor/cli-anything-generator.root` / `%USERPROFILE%\.cursor\cli-anything-generator.root`
+2. Else install dir `PLUGIN_ROOT.txt` / default `.../plugins/local/cli-anything`
+3. Read `{PLUGIN_ROOT}/references/HARNESS.md` and `{PLUGIN_ROOT}/references/commands/test.md` via absolute paths
+
+## Cursor Tool Bindings
+
+| Cursor tool | Role |
+|-------------|------|
+| Shell | `pytest`, installed `cli-anything-<software>`, environment checks |
+| Read / Grep | Locate tests, parse failures, update TEST.md |
+| Write / StrReplace | Fix tests or harness bugs uncovered by failures |
+
+## Phase Gates and Resume (hard gate)
+
+Progress: `{software-root}/agent-harness/.cli-anything-progress.json` with `"mode": "test"`.
+
+- Track unit / e2e / installed-CLI / TEST.md update steps; do not skip ahead without marking completion.
+- Resume if interrupted; only append **passing** evidence to `TEST.md`.
+- Prefer `CLI_ANYTHING_FORCE_INSTALLED=1` for release-style installed-command checks when documented by HARNESS / test command.
+
+## Test checklist
+
+- Run unit + E2E suites
+- Verify installed `cli-anything-<software>` via subprocess / `_resolve_cli`
+- Update `TEST.md` only with passing results
+
+## What This Command Does
+
+Follow `{PLUGIN_ROOT}/references/commands/test.md`.

--- a/cursor-plugin/commands/cli-anything-validate.md
+++ b/cursor-plugin/commands/cli-anything-validate.md
@@ -1,0 +1,43 @@
+---
+name: cli-anything-validate
+description: Validate a CLI-Anything harness against the full HARNESS checklist
+---
+
+# cli-anything-validate Command
+
+Validate an existing harness against directory, implementation, test, docs, packaging, and code-quality requirements.
+
+**Target software**: local path argument (required).
+
+## CRITICAL: Resolve PLUGIN_ROOT (absolute paths only)
+
+1. Read `~/.cursor/cli-anything-generator.root` / `%USERPROFILE%\.cursor\cli-anything-generator.root`
+2. Else install dir `PLUGIN_ROOT.txt` / default `.../plugins/local/cli-anything`
+3. Read `{PLUGIN_ROOT}/references/HARNESS.md` and `{PLUGIN_ROOT}/references/commands/validate.md` via absolute paths
+
+## Cursor Tool Bindings
+
+| Cursor tool | Role |
+|-------------|------|
+| Glob / Grep / Read | Checklist inventory of harness layout and APIs |
+| Shell | Optional smoke tests, import checks, `pip show` / entry-point checks |
+| Write | Only to record validation report if the user asks for a file |
+
+## Phase Gates and Resume (hard gate)
+
+Progress: `{software-root}/agent-harness/.cli-anything-progress.json` with `"mode": "validate"`.
+
+- Walk checklist sections; mark each section completed before moving on.
+- Resume incomplete validation; finish with a clear pass/fail summary and concrete gaps.
+
+## Validate checklist (summary)
+
+- Directory layout under `agent-harness/cli_anything/<software>/`
+- Implementation: Click + REPL + `--json` + session patterns per HARNESS
+- Tests: unit + E2E + installed CLI
+- Docs: README, SOFTWARE.md, TEST.md, skills
+- Packaging: namespace packages + console_scripts
+
+## What This Command Does
+
+Follow `{PLUGIN_ROOT}/references/commands/validate.md`. Do not silently lower the quality bar.

--- a/cursor-plugin/commands/cli-anything.md
+++ b/cursor-plugin/commands/cli-anything.md
@@ -1,0 +1,123 @@
+---
+name: cli-anything
+description: Build a complete CLI-Anything harness for any GUI application (all 7 phases)
+---
+
+# cli-anything Command
+
+Build a complete, stateful CLI harness for any GUI application.
+
+**Target software**: use the path or repo URL supplied with this command.
+
+## CRITICAL: Resolve PLUGIN_ROOT (absolute paths only)
+
+Cursor tools often resolve relative paths against the **workspace** root, not this plugin. Before anything else, resolve `PLUGIN_ROOT` using this order — stop at the first hit that contains `references/HARNESS.md`:
+
+1. Read the discovery pointer (absolute path on one line):
+   - Windows: `%USERPROFILE%\.cursor\cli-anything-generator.root`
+   - Unix: `~/.cursor/cli-anything-generator.root`
+   Then use that directory as `PLUGIN_ROOT`.
+2. Else read `{candidate}/PLUGIN_ROOT.txt` where `candidate` is:
+   - `%USERPROFILE%\.cursor\plugins\local\cli-anything` / `~/.cursor/plugins/local/cli-anything`
+   - or `$CURSOR_PLUGINS_HOME/local/cli-anything` if the env var is set (Shell: printenv / `$env:CURSOR_PLUGINS_HOME`)
+3. Else, if `candidate/references/HARNESS.md` exists, use `candidate`.
+4. Else, if the workspace is a CLI-Anything checkout, use `{workspace}/cli-anything-plugin` for methodology (and still prefer an installed plugin when present).
+5. Else clone `https://github.com/HKUDS/CLI-Anything` and use `cli-anything-plugin/`.
+
+Always **Read** `{PLUGIN_ROOT}/references/HARNESS.md` with an absolute path. Also read `{PLUGIN_ROOT}/references/commands/cli-anything.md`. Use `{PLUGIN_ROOT}/references/guides/` on demand. Do not use workspace-relative `./HARNESS.md`.
+
+## Cursor Tool Bindings
+
+| Cursor tool | Role in harness workflow |
+|-------------|--------------------------|
+| Read | Read HARNESS, guides, target source, generated files |
+| Grep / Glob | Map APIs, locate entry points, inventory coverage |
+| Shell | Clone repos, run pytest, pip install, invoke CLIs |
+| Write / StrReplace | Implement harness modules, tests, packaging, docs |
+| Task | Optional parallel analysis subtasks |
+
+## Arguments
+
+- First argument is the **software path or repo URL** (required):
+  - Local path (e.g. `/home/user/gimp`, `./blender`)
+  - GitHub repository URL
+  - Software names alone (e.g. `gimp`) are NOT accepted
+
+If a GitHub URL is provided, clone locally first, then work on the local copy. Derive the software name from the directory name.
+
+## Phase Gates and Resume (hard gate)
+
+Progress file (create `agent-harness/` as soon as tracking starts, even before full implementation):
+
+`{software-root}/agent-harness/.cli-anything-progress.json`
+
+Schema:
+
+```json
+{
+  "software": "<name>",
+  "mode": "build",
+  "target": "<absolute software path>",
+  "phases": {
+    "0": { "status": "completed", "updated_at": "<ISO-8601>" },
+    "1": { "status": "in_progress", "updated_at": "<ISO-8601>" }
+  },
+  "terminal": false,
+  "terminal_status": null
+}
+```
+
+Rules:
+
+- Phases: `0` source acquisition through `7` packaging/install (same as HARNESS / Claude plugin).
+- **Do not start the next phase until the progress file records the previous phase as `completed`.**
+- After finishing a phase, set it to `completed` and set the next to `in_progress`.
+- On session start, if a non-terminal progress file exists for this target, **resume** from the first non-completed phase. Do not redo completed phases unless the user asks.
+- Set `terminal: true` and `terminal_status` to `success` or `failed` only when the whole build mode finishes or aborts permanently.
+- A terminal progress file is historical; start a new build only when the user requests a rebuild (then reset or replace the file).
+
+## What This Command Does
+
+Implements the complete cli-anything methodology. **All phases follow HARNESS.md.**
+
+### Phase 0: Source Acquisition
+- Clone URL targets if needed; verify local source exists; derive software name
+- Create `agent-harness/` and initialize the progress file
+
+### Phase 1: Codebase Analysis
+- Backend/data model, GUI-to-API map, existing CLIs, architecture notes
+
+### Phase 2: CLI Architecture Design
+- Command groups, state model, output formats, software-specific SOP (`<SOFTWARE>.md`)
+
+### Phase 3: Implementation
+- `agent-harness/cli_anything/<software>/` with core, utils, Click CLI + REPL, `--json`
+- Imports use `cli_anything.<software>.*`
+- Copy `{PLUGIN_ROOT}/scripts/repl_skin.py` (and preview helpers when applicable)
+
+### Phase 4: Test Planning
+- `TEST.md` with unit, E2E, and workflow plans
+
+### Phase 5: Test Implementation
+- `test_core.py`, `test_full_e2e.py`, workflow tests, `_resolve_cli("cli-anything-<software>")`
+
+### Phase 6: Test Documentation
+- Run `pytest -v --tb=no`; append results to `TEST.md`
+
+### Phase 7: Packaging and Installation
+- `setup.py` with namespace packages; `cli-anything-<software>` console script
+- `pip install -e .`; verify PATH; generate CLI-specific `SKILL.md` via `{PLUGIN_ROOT}/scripts/skill_generator.py`
+
+## Quality Bar Checklist (do not skip)
+
+- Real software backend preferred over reimplementation
+- One-shot Click subcommands + default REPL
+- `--json` machine-readable output
+- Session state with undo/redo where supported; locked session writes; auto-save / `--dry-run` per guides
+- Unit (`test_core.py`) + E2E (`test_full_e2e.py`) + installed-command subprocess coverage
+- Namespace packaging: `cli_anything.<software>`, no top-level `cli_anything/__init__.py`
+- Generate CLI-specific skills via vendored `skill_generator.py`
+
+## Output Expectations
+
+Report phases completed, harness path, test summary, install command, and resume state in `agent-harness/.cli-anything-progress.json`.

--- a/cursor-plugin/rules/cli-anything-generator.mdc
+++ b/cursor-plugin/rules/cli-anything-generator.mdc
@@ -1,0 +1,26 @@
+---
+description: >-
+  CLI-Anything generator phase gates and absolute PLUGIN_ROOT resolution.
+  Apply when building, refining, testing, or validating CLI-Anything harnesses,
+  editing agent-harness/, or using /cli-anything commands.
+alwaysApply: false
+globs:
+  - "**/agent-harness/**"
+  - "**/.cli-anything-progress.json"
+  - "**/cli_anything/**"
+---
+
+# CLI-Anything Generator Rule
+
+When building, refining, testing, validating, or listing CLI-Anything harnesses — or when `/cli-anything*` is used — apply these rules:
+
+1. Resolve `PLUGIN_ROOT` before reading methodology:
+   - Read `%USERPROFILE%\.cursor\cli-anything-generator.root` or `~/.cursor/cli-anything-generator.root`
+   - Else `{plugins}/local/cli-anything/PLUGIN_ROOT.txt` (default plugins dir or `$CURSOR_PLUGINS_HOME`)
+   - Use absolute paths only; never workspace-relative `./HARNESS.md`
+2. Read `{PLUGIN_ROOT}/references/HARNESS.md` and the matching `references/commands/*.md`.
+3. Prefer slash commands `/cli-anything`, `/cli-anything-refine`, `/cli-anything-test`, `/cli-anything-validate`, `/cli-anything-list`.
+4. Persist progress at `{software-root}/agent-harness/.cli-anything-progress.json`.
+   Create `agent-harness/` when tracking starts. Do not advance a phase until the previous is `completed`. Resume non-terminal runs.
+5. Keep generated harness format identical to Claude Code / Codex outputs.
+6. Consumer Hub/skills (`cli-hub-meta-skill`, `skills/cli-anything-*`) are separate from this generator.

--- a/cursor-plugin/scripts/install.ps1
+++ b/cursor-plugin/scripts/install.ps1
@@ -1,0 +1,124 @@
+# Install the CLI-Anything Cursor plugin with vendored methodology resources.
+param(
+    [switch]$Force,
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($Help) {
+    Write-Host "Usage: .\install.ps1 [-Force]"
+    Write-Host "Install the CLI-Anything Cursor plugin with vendored methodology resources."
+    Write-Host "Destination: `$env:CURSOR_PLUGINS_HOME\local\cli-anything (default: %USERPROFILE%\.cursor\plugins\local\cli-anything)"
+    exit 0
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $scriptDir "lib.ps1")
+
+$pluginSrc = Split-Path -Parent $scriptDir
+$repoRoot = Split-Path -Parent $pluginSrc
+$canonicalPlugin = Join-Path $repoRoot "cli-anything-plugin"
+$previewProtocol = Join-Path $repoRoot "docs\PREVIEW_PROTOCOL.md"
+
+if ($env:CURSOR_PLUGINS_HOME) {
+    $pluginsHome = Resolve-CliAnythingPluginsHome -Raw $env:CURSOR_PLUGINS_HOME -Create
+} elseif ($env:USERPROFILE) {
+    $pluginsHome = Resolve-CliAnythingPluginsHome -Raw (Join-Path $env:USERPROFILE ".cursor\plugins") -Create
+} else {
+    throw "CURSOR_PLUGINS_HOME is not set and USERPROFILE is unavailable."
+}
+
+$discoveryPointer = Get-CliAnythingDiscoveryPointerPath
+$userCursor = Split-Path -Parent $discoveryPointer
+$destRoot = Join-Path $pluginsHome "local"
+$destDir = Join-Path $destRoot "cli-anything"
+$stagingDir = $null
+$backupDir = $null
+
+if (-not (Test-Path (Join-Path $canonicalPlugin "HARNESS.md"))) {
+    throw "Cannot find canonical CLI-Anything resources at: $canonicalPlugin`nRun this installer from a full CLI-Anything repository checkout."
+}
+
+if (-not (Test-Path $previewProtocol)) {
+    throw "Cannot find preview protocol at: $previewProtocol`nRun this installer from a full CLI-Anything repository checkout."
+}
+
+if (-not (Test-Path (Join-Path $pluginSrc ".cursor-plugin\plugin.json"))) {
+    throw "Cannot find Cursor plugin manifest at: $(Join-Path $pluginSrc '.cursor-plugin\plugin.json')"
+}
+
+New-Item -ItemType Directory -Path $destRoot -Force | Out-Null
+New-Item -ItemType Directory -Path $userCursor -Force | Out-Null
+
+if (Test-Path $destDir) {
+    if (-not $Force) {
+        throw "Refusing to overwrite existing plugin: $destDir`nRe-run with -Force to upgrade, or remove it manually."
+    }
+}
+
+try {
+    $stagingDir = Join-Path $destRoot (".cli-anything.tmp." + [System.Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $stagingDir | Out-Null
+
+    Get-ChildItem -LiteralPath $pluginSrc -Force | ForEach-Object {
+        if ($_.Name -in @("tests", "references", ".git")) {
+            return
+        }
+        Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $stagingDir $_.Name) -Recurse -Force
+    }
+
+    $referenceDir = Join-Path $stagingDir "references"
+    $referenceCommands = Join-Path $referenceDir "commands"
+    $referenceDocs = Join-Path $referenceDir "docs"
+    $referenceGuides = Join-Path $referenceDir "guides"
+    $resourceScripts = Join-Path $stagingDir "scripts"
+    $scriptTemplates = Join-Path $resourceScripts "templates"
+
+    New-Item -ItemType Directory -Path $referenceCommands, $referenceDocs, $referenceGuides, $scriptTemplates -Force | Out-Null
+
+    Copy-Item -Path (Join-Path $canonicalPlugin "HARNESS.md") -Destination (Join-Path $referenceDir "HARNESS.md")
+    Copy-Item -Path (Join-Path $canonicalPlugin "commands\*.md") -Destination $referenceCommands
+    Copy-Item -Path (Join-Path $canonicalPlugin "guides\*.md") -Destination $referenceGuides
+    Copy-Item -Path (Join-Path $canonicalPlugin "repl_skin.py") -Destination (Join-Path $resourceScripts "repl_skin.py")
+    Copy-Item -Path (Join-Path $canonicalPlugin "preview_bundle.py") -Destination (Join-Path $resourceScripts "preview_bundle.py")
+    Copy-Item -Path (Join-Path $canonicalPlugin "skill_generator.py") -Destination (Join-Path $resourceScripts "skill_generator.py")
+    Copy-Item -Path (Join-Path $canonicalPlugin "templates\*") -Destination $scriptTemplates
+    Copy-Item -Path $previewProtocol -Destination (Join-Path $referenceDocs "PREVIEW_PROTOCOL.md")
+
+    # If interrupted after moving the old install aside, look for
+    # $destRoot\.cli-anything.bak.* and restore it manually.
+    if (Test-Path $destDir) {
+        $backupDir = Join-Path $destRoot (".cli-anything.bak." + [System.Guid]::NewGuid().ToString("N"))
+        Move-Item -LiteralPath $destDir -Destination $backupDir
+        try {
+            Move-Item -LiteralPath $stagingDir -Destination $destDir
+            $stagingDir = $null
+            Remove-Item -LiteralPath $backupDir -Recurse -Force
+            $backupDir = $null
+        } catch {
+            if ($backupDir -and (Test-Path $backupDir)) {
+                Move-Item -LiteralPath $backupDir -Destination $destDir -Force
+            }
+            throw
+        }
+    } else {
+        Move-Item -LiteralPath $stagingDir -Destination $destDir
+        $stagingDir = $null
+    }
+} finally {
+    if ($stagingDir -and (Test-Path $stagingDir)) {
+        Remove-Item -LiteralPath $stagingDir -Recurse -Force
+    }
+}
+
+$pluginRoot = [System.IO.Path]::GetFullPath($destDir)
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText((Join-Path $pluginRoot "PLUGIN_ROOT.txt"), ($pluginRoot + [Environment]::NewLine), $utf8NoBom)
+[System.IO.File]::WriteAllText($discoveryPointer, ($pluginRoot + [Environment]::NewLine), $utf8NoBom)
+
+Write-Host "Installed Cursor plugin to: $pluginRoot"
+Write-Host "Wrote PLUGIN_ROOT stamp and discovery pointer: $discoveryPointer"
+Write-Host "Vendored CLI-Anything methodology resources into the installed plugin."
+Write-Host "Reload the Cursor window (Developer: Reload Window) to pick up commands."
+Write-Host "Consumer Hub/skills are separate: npx skills add HKUDS/CLI-Anything --skill cli-hub-meta-skill -g -y"

--- a/cursor-plugin/scripts/install.sh
+++ b/cursor-plugin/scripts/install.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+FORCE=0
+for arg in "$@"; do
+  case "${arg}" in
+    --force|-f)
+      FORCE=1
+      ;;
+    --help|-h)
+      echo "Usage: $0 [--force]"
+      echo "Install the CLI-Anything Cursor plugin with vendored methodology resources."
+      echo "Destination: \${CURSOR_PLUGINS_HOME:-~/.cursor/plugins}/local/cli-anything"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: ${arg}" >&2
+      echo "Usage: $0 [--force]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+PLUGIN_SRC="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${PLUGIN_SRC}/.." && pwd)"
+CANONICAL_PLUGIN="${REPO_ROOT}/cli-anything-plugin"
+PREVIEW_PROTOCOL="${REPO_ROOT}/docs/PREVIEW_PROTOCOL.md"
+
+if [[ -n "${CURSOR_PLUGINS_HOME:-}" ]]; then
+  PLUGINS_HOME="$(resolve_plugins_home "${CURSOR_PLUGINS_HOME}" create)"
+else
+  PLUGINS_HOME="$(resolve_plugins_home "${HOME}/.cursor/plugins" create)"
+fi
+
+DEST_ROOT="${PLUGINS_HOME}/local"
+DEST_DIR="${DEST_ROOT}/cli-anything"
+DISCOVERY_POINTER="$(discovery_pointer_path)"
+STAGING_DIR=""
+
+if [[ ! -f "${CANONICAL_PLUGIN}/HARNESS.md" ]]; then
+  echo "Cannot find canonical CLI-Anything resources at: ${CANONICAL_PLUGIN}" >&2
+  echo "Run this installer from a full CLI-Anything repository checkout." >&2
+  exit 1
+fi
+
+if [[ ! -f "${PREVIEW_PROTOCOL}" ]]; then
+  echo "Cannot find preview protocol at: ${PREVIEW_PROTOCOL}" >&2
+  echo "Run this installer from a full CLI-Anything repository checkout." >&2
+  exit 1
+fi
+
+if [[ ! -f "${PLUGIN_SRC}/.cursor-plugin/plugin.json" ]]; then
+  echo "Cannot find Cursor plugin manifest at: ${PLUGIN_SRC}/.cursor-plugin/plugin.json" >&2
+  exit 1
+fi
+
+mkdir -p "${DEST_ROOT}"
+mkdir -p "${HOME}/.cursor"
+
+if [[ -e "${DEST_DIR}" ]]; then
+  if [[ "${FORCE}" -ne 1 ]]; then
+    echo "Refusing to overwrite existing plugin: ${DEST_DIR}" >&2
+    echo "Re-run with --force to upgrade, or remove it manually." >&2
+    exit 1
+  fi
+fi
+
+cleanup() {
+  if [[ -n "${STAGING_DIR}" && -d "${STAGING_DIR}" ]]; then
+    rm -rf "${STAGING_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+STAGING_DIR="$(mktemp -d "${DEST_ROOT}/.cli-anything.tmp.XXXXXX")"
+
+# Copy adapter package (exclude tests and any pre-existing local references/).
+while IFS= read -r -d '' entry; do
+  base="$(basename "${entry}")"
+  case "${base}" in
+    tests|references|.git)
+      continue
+      ;;
+  esac
+  cp -R "${entry}" "${STAGING_DIR}/"
+done < <(find "${PLUGIN_SRC}" -mindepth 1 -maxdepth 1 -print0)
+
+mkdir -p \
+  "${STAGING_DIR}/references/commands" \
+  "${STAGING_DIR}/references/docs" \
+  "${STAGING_DIR}/references/guides" \
+  "${STAGING_DIR}/scripts/templates"
+
+cp "${CANONICAL_PLUGIN}/HARNESS.md" "${STAGING_DIR}/references/HARNESS.md"
+cp "${CANONICAL_PLUGIN}/commands/"*.md "${STAGING_DIR}/references/commands/"
+cp "${CANONICAL_PLUGIN}/guides/"*.md "${STAGING_DIR}/references/guides/"
+cp "${CANONICAL_PLUGIN}/repl_skin.py" "${STAGING_DIR}/scripts/repl_skin.py"
+cp "${CANONICAL_PLUGIN}/preview_bundle.py" "${STAGING_DIR}/scripts/preview_bundle.py"
+cp "${CANONICAL_PLUGIN}/skill_generator.py" "${STAGING_DIR}/scripts/skill_generator.py"
+cp "${CANONICAL_PLUGIN}/templates/"* "${STAGING_DIR}/scripts/templates/"
+cp "${PREVIEW_PROTOCOL}" "${STAGING_DIR}/references/docs/PREVIEW_PROTOCOL.md"
+
+# Atomic replace when upgrading.
+# If interrupted after moving the old install aside, look for
+# ${DEST_ROOT}/.cli-anything.bak.* and restore it manually.
+if [[ -e "${DEST_DIR}" ]]; then
+  BACKUP_DIR="${DEST_ROOT}/.cli-anything.bak.$(date +%s)"
+  mv "${DEST_DIR}" "${BACKUP_DIR}"
+  if ! mv "${STAGING_DIR}" "${DEST_DIR}"; then
+    mv "${BACKUP_DIR}" "${DEST_DIR}"
+    echo "Failed to install plugin; previous install restored." >&2
+    exit 1
+  fi
+  rm -rf "${BACKUP_DIR}"
+else
+  mv "${STAGING_DIR}" "${DEST_DIR}"
+fi
+STAGING_DIR=""
+
+# Resolve final absolute plugin root and stamp it for Cursor tool resolution.
+PLUGIN_ROOT="$(to_host_path "$(cd "${DEST_DIR}" && pwd -P)")"
+printf '%s\n' "${PLUGIN_ROOT}" > "${DEST_DIR}/PLUGIN_ROOT.txt"
+printf '%s\n' "${PLUGIN_ROOT}" > "${DISCOVERY_POINTER}"
+
+echo "Installed Cursor plugin to: ${DEST_DIR}"
+echo "PLUGIN_ROOT stamp: ${PLUGIN_ROOT}"
+echo "Discovery pointer: ${DISCOVERY_POINTER}"
+echo "Vendored CLI-Anything methodology resources into the installed plugin."
+echo "Reload the Cursor window (Developer: Reload Window) to pick up commands."
+echo "Consumer Hub/skills are separate: npx skills add HKUDS/CLI-Anything --skill cli-hub-meta-skill -g -y"

--- a/cursor-plugin/scripts/lib.ps1
+++ b/cursor-plugin/scripts/lib.ps1
@@ -1,0 +1,58 @@
+# Shared helpers for CLI-Anything Cursor plugin install/uninstall (PowerShell).
+
+function Normalize-CliAnythingPathKey {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return $Path.Replace("/", "\").TrimEnd("\").ToLowerInvariant()
+}
+
+function Resolve-CliAnythingPluginsHome {
+    param(
+        [Parameter(Mandatory = $true)][string]$Raw,
+        [switch]$Create
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Raw) -or $Raw -eq "." -or $Raw -eq "..") {
+        throw "Invalid CURSOR_PLUGINS_HOME: $Raw"
+    }
+
+    if ($Raw.StartsWith("~")) {
+        $homePath = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:HOME }
+        $Raw = Join-Path $homePath $Raw.Substring(1).TrimStart("\", "/")
+    }
+
+    if (-not [System.IO.Path]::IsPathRooted($Raw)) {
+        $Raw = Join-Path (Get-Location).Path $Raw
+    }
+
+    # GetFullPath collapses ".." without creating the directory.
+    $full = [System.IO.Path]::GetFullPath($Raw)
+    $name = [System.IO.Path]::GetFileName($full.TrimEnd("\", "/"))
+    if ($name -ne "plugins") {
+        throw "CURSOR_PLUGINS_HOME must resolve to a directory named 'plugins' (got: $full)`nExample: $env:USERPROFILE\.cursor\plugins"
+    }
+
+    if ($Create) {
+        New-Item -ItemType Directory -Path $full -Force | Out-Null
+    }
+    return $full
+}
+
+function Test-CliAnythingInstallPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    $key = Normalize-CliAnythingPathKey $Path
+    if (-not $key.EndsWith("\local\cli-anything")) {
+        return $false
+    }
+    return ([System.IO.Path]::GetFileName($key) -eq "cli-anything")
+}
+
+function Get-CliAnythingDiscoveryPointerPath {
+    $userCursor = if ($env:USERPROFILE) {
+        Join-Path $env:USERPROFILE ".cursor"
+    } elseif ($env:HOME) {
+        Join-Path $env:HOME ".cursor"
+    } else {
+        throw "USERPROFILE/HOME unavailable."
+    }
+    return (Join-Path $userCursor "cli-anything-generator.root")
+}

--- a/cursor-plugin/scripts/lib.sh
+++ b/cursor-plugin/scripts/lib.sh
@@ -1,0 +1,102 @@
+# Shared helpers for CLI-Anything Cursor plugin install/uninstall (bash).
+# shellcheck shell=bash
+
+normalize_path_key() {
+  printf '%s' "${1}" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's:/*$::'
+}
+
+# Convert Git Bash / MSYS / Cygwin / WSL-style paths to Windows host paths for Cursor tools.
+to_host_path() {
+  local p="${1}"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "${p}"
+    return 0
+  fi
+  case "$(uname -s 2>/dev/null || true)" in
+    MINGW*|MSYS*|CYGWIN*|Linux)
+      if [[ "${p}" =~ ^/([a-zA-Z])/(.*)$ ]]; then
+        local drive rest
+        drive="$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:lower:]' '[:upper:]')"
+        rest="${BASH_REMATCH[2]//\//\\}"
+        printf '%s:\\%s' "${drive}" "${rest}"
+        return 0
+      fi
+      if [[ "${p}" =~ ^/mnt/([a-zA-Z])/(.*)$ ]]; then
+        local drive rest
+        drive="$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:lower:]' '[:upper:]')"
+        rest="${BASH_REMATCH[2]//\//\\}"
+        printf '%s:\\%s' "${drive}" "${rest}"
+        return 0
+      fi
+      ;;
+  esac
+  printf '%s' "${p}"
+}
+
+# Resolve CURSOR_PLUGINS_HOME / default plugins root.
+# Second arg: "create" to mkdir (install), anything else skips creating.
+resolve_plugins_home() {
+  local raw="${1}"
+  local mode="${2:-}"
+  if [[ -z "${raw}" || "${raw}" == "." || "${raw}" == ".." ]]; then
+    echo "Invalid CURSOR_PLUGINS_HOME: ${raw}" >&2
+    return 1
+  fi
+
+  # Canonicalize without creating the path (abspath collapses ".." safely).
+  if command -v python3 >/dev/null 2>&1; then
+    raw="$(python3 -c 'import os,sys; print(os.path.abspath(os.path.expanduser(sys.argv[1])))' "${raw}")"
+  elif command -v python >/dev/null 2>&1; then
+    raw="$(python -c 'import os,sys; print(os.path.abspath(os.path.expanduser(sys.argv[1])))' "${raw}")"
+  else
+    if [[ "${raw}" == "~"* ]]; then
+      raw="${HOME}${raw:1}"
+    fi
+    if [[ "${raw}" != /* && "${raw}" != [A-Za-z]:* && "${raw}" != \\* ]]; then
+      raw="$(pwd)/${raw}"
+    fi
+    case "${raw}" in
+      *..*)
+        echo "Invalid CURSOR_PLUGINS_HOME (refuses '..' without python): ${raw}" >&2
+        return 1
+        ;;
+    esac
+  fi
+
+  if [[ "$(basename "${raw}")" != "plugins" ]]; then
+    echo "CURSOR_PLUGINS_HOME must resolve to a directory named 'plugins' (got: ${raw})" >&2
+    echo "Example: ~/.cursor/plugins or /custom/path/plugins" >&2
+    return 1
+  fi
+
+  if [[ "${mode}" == "create" ]]; then
+    mkdir -p "${raw}"
+    if command -v realpath >/dev/null 2>&1; then
+      raw="$(realpath "${raw}")"
+    else
+      raw="$(cd "${raw}" && pwd -P)"
+    fi
+  elif [[ -d "${raw}" ]]; then
+    if command -v realpath >/dev/null 2>&1; then
+      raw="$(realpath "${raw}")"
+    else
+      raw="$(cd "${raw}" && pwd -P)"
+    fi
+  fi
+  printf '%s' "${raw}"
+}
+
+# True when path is .../local/cli-anything (slash or backslash).
+is_cli_anything_install_path() {
+  local key
+  key="$(normalize_path_key "${1}")"
+  [[ "$(basename "${key}")" == "cli-anything" ]] || return 1
+  case "${key}" in
+    */local/cli-anything) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+discovery_pointer_path() {
+  printf '%s' "${HOME}/.cursor/cli-anything-generator.root"
+}

--- a/cursor-plugin/scripts/uninstall.ps1
+++ b/cursor-plugin/scripts/uninstall.ps1
@@ -1,0 +1,61 @@
+# Uninstall the CLI-Anything Cursor local plugin and clear the discovery pointer.
+param(
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($Help) {
+    Write-Host "Usage: .\uninstall.ps1"
+    Write-Host "Uninstall the CLI-Anything Cursor local plugin and clear the discovery pointer."
+    exit 0
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $scriptDir "lib.ps1")
+
+$pluginSrc = Split-Path -Parent $scriptDir
+$discoveryPointer = Get-CliAnythingDiscoveryPointerPath
+
+$stampFile = Join-Path $pluginSrc "PLUGIN_ROOT.txt"
+$manifest = Join-Path $pluginSrc ".cursor-plugin\plugin.json"
+
+if ((Test-Path -LiteralPath $stampFile) -and (Test-Path -LiteralPath $manifest)) {
+    $destDir = [System.IO.Path]::GetFullPath($pluginSrc)
+} else {
+    if ($env:CURSOR_PLUGINS_HOME) {
+        $pluginsHome = Resolve-CliAnythingPluginsHome -Raw $env:CURSOR_PLUGINS_HOME
+    } elseif ($env:USERPROFILE) {
+        $pluginsHome = Resolve-CliAnythingPluginsHome -Raw (Join-Path $env:USERPROFILE ".cursor\plugins")
+    } else {
+        throw "CURSOR_PLUGINS_HOME is not set and USERPROFILE is unavailable."
+    }
+    $destDir = [System.IO.Path]::GetFullPath((Join-Path $pluginsHome "local\cli-anything"))
+}
+
+if (-not (Test-CliAnythingInstallPath -Path $destDir)) {
+    throw "Refusing to uninstall unexpected path: $destDir"
+}
+
+if (Test-Path -LiteralPath $destDir) {
+    Remove-Item -LiteralPath $destDir -Recurse -Force
+    Write-Host "Removed plugin directory: $destDir"
+} else {
+    Write-Host "Plugin directory not found (already removed): $destDir"
+}
+
+if (Test-Path -LiteralPath $discoveryPointer) {
+    $pointer = (Get-Content -LiteralPath $discoveryPointer -Raw).Trim()
+    $ptrNorm = Normalize-CliAnythingPathKey $pointer
+    $destNorm = Normalize-CliAnythingPathKey $destDir
+    if ($ptrNorm -eq $destNorm) {
+        Remove-Item -LiteralPath $discoveryPointer -Force
+        Write-Host "Removed discovery pointer: $discoveryPointer"
+    } else {
+        Write-Host "Left discovery pointer unchanged (points elsewhere): $pointer"
+    }
+} else {
+    Write-Host "Discovery pointer not present: $discoveryPointer"
+}
+
+Write-Host "Uninstall complete. Reload the Cursor window if it is open."

--- a/cursor-plugin/scripts/uninstall.sh
+++ b/cursor-plugin/scripts/uninstall.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+for arg in "$@"; do
+  case "${arg}" in
+    --help|-h)
+      echo "Usage: $0"
+      echo "Uninstall the CLI-Anything Cursor local plugin and clear the discovery pointer."
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: ${arg}" >&2
+      echo "Usage: $0" >&2
+      exit 2
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+PLUGIN_SRC="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DISCOVERY_POINTER="$(discovery_pointer_path)"
+
+if [[ -f "${PLUGIN_SRC}/PLUGIN_ROOT.txt" && -f "${PLUGIN_SRC}/.cursor-plugin/plugin.json" ]]; then
+  DEST_DIR="${PLUGIN_SRC}"
+else
+  if [[ -n "${CURSOR_PLUGINS_HOME:-}" ]]; then
+    PLUGINS_HOME="$(resolve_plugins_home "${CURSOR_PLUGINS_HOME}")"
+  else
+    PLUGINS_HOME="$(resolve_plugins_home "${HOME}/.cursor/plugins")"
+  fi
+  DEST_DIR="${PLUGINS_HOME}/local/cli-anything"
+fi
+
+if ! is_cli_anything_install_path "${DEST_DIR}"; then
+  echo "Refusing to uninstall unexpected path (expected .../local/cli-anything): ${DEST_DIR}" >&2
+  exit 1
+fi
+
+DEST_HOST="$(to_host_path "${DEST_DIR}")"
+if [[ -d "${DEST_DIR}" ]]; then
+  DEST_HOST="$(to_host_path "$(cd "${DEST_DIR}" && pwd -P)")"
+fi
+
+if [[ -e "${DEST_DIR}" ]]; then
+  rm -rf "${DEST_DIR}"
+  echo "Removed plugin directory: ${DEST_DIR}"
+else
+  echo "Plugin directory not found (already removed): ${DEST_DIR}"
+fi
+
+if [[ -f "${DISCOVERY_POINTER}" ]]; then
+  POINTER="$(tr -d '\r\n' < "${DISCOVERY_POINTER}")"
+  PTR_KEY="$(normalize_path_key "${POINTER}")"
+  DEST_KEY="$(normalize_path_key "${DEST_HOST}")"
+  DEST_UNIX_KEY="$(normalize_path_key "${DEST_DIR}")"
+  if [[ "${PTR_KEY}" == "${DEST_KEY}" || "${PTR_KEY}" == "${DEST_UNIX_KEY}" ]]; then
+    rm -f "${DISCOVERY_POINTER}"
+    echo "Removed discovery pointer: ${DISCOVERY_POINTER}"
+  else
+    echo "Left discovery pointer unchanged (points elsewhere): ${POINTER}"
+  fi
+else
+  echo "Discovery pointer not present: ${DISCOVERY_POINTER}"
+fi
+
+echo "Uninstall complete. Reload the Cursor window if it is open."

--- a/cursor-plugin/skills/cli-anything-generator/SKILL.md
+++ b/cursor-plugin/skills/cli-anything-generator/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: cli-anything-generator
+description: >-
+  Build, refine, test, validate, or list CLI-Anything harnesses for GUI
+  applications in Cursor. Prefer slash commands /cli-anything,
+  /cli-anything-refine, /cli-anything-test, /cli-anything-validate, and
+  /cli-anything-list when available. This skill supports natural-language
+  discovery of the generator; it does not replace those commands. Discovering
+  already-published CLIs from CLI-Hub is a separate consumer skill
+  (cli-hub-meta-skill).
+---
+
+# CLI-Anything Generator (Cursor Plugin Skill)
+
+This skill is packaged **inside the Cursor plugin** as a supporting entry point.
+The primary generator UX is the plugin slash commands.
+
+## Prefer Slash Commands
+
+| Goal | Command |
+|------|---------|
+| Full 7-phase build | `/cli-anything <path-or-repo>` |
+| Expand coverage | `/cli-anything-refine <path> [focus]` |
+| Run tests | `/cli-anything-test <path>` |
+| Validate checklist | `/cli-anything-validate <path>` |
+| List tools | `/cli-anything-list` |
+
+If the user speaks naturally ("build a CLI for ./gimp"), run the same workflow as the matching command.
+
+## Consumer Path (Separate)
+
+This skill is **not** the Hub consumer. For finding/installing published CLIs:
+
+```bash
+npx skills add HKUDS/CLI-Anything --skill cli-hub-meta-skill -g -y
+```
+
+Per-app skills live under the repo `skills/` tree and install via `npx skills add`.
+
+## PLUGIN_ROOT and Methodology
+
+1. Resolve `PLUGIN_ROOT` via discovery pointer then stamp:
+   - `~/.cursor/cli-anything-generator.root` / `%USERPROFILE%\.cursor\cli-anything-generator.root`
+   - `{install}/PLUGIN_ROOT.txt`
+   - default `~/.cursor/plugins/local/cli-anything` if `references/HARNESS.md` exists there
+2. Read `{PLUGIN_ROOT}/references/HARNESS.md` with an absolute path.
+3. Read the matching file under `{PLUGIN_ROOT}/references/commands/`.
+4. Use guides under `{PLUGIN_ROOT}/references/guides/` on demand.
+5. Helper scripts: `{PLUGIN_ROOT}/scripts/repl_skin.py`, `preview_bundle.py`,
+   `skill_generator.py`, `templates/`.
+
+### Path remapping (from HARNESS / plugin docs)
+
+| Document reference | Installed plugin path |
+|--------------------|----------------------|
+| `guides/...` | `references/guides/...` |
+| `cli-anything-plugin/repl_skin.py` | `scripts/repl_skin.py` |
+| `cli-anything-plugin/preview_bundle.py` | `scripts/preview_bundle.py` |
+| `cli-anything-plugin/skill_generator.py` | `scripts/skill_generator.py` |
+| `templates/SKILL.md.template` | `scripts/templates/SKILL.md.template` |
+| `docs/PREVIEW_PROTOCOL.md` | `references/docs/PREVIEW_PROTOCOL.md` |
+
+## Cursor Tool Bindings
+
+| Cursor tool | Role |
+|-------------|------|
+| Read | Methodology and source analysis |
+| Grep / Glob | API and file discovery |
+| Shell | Clone, pytest, pip, CLI invocation |
+| Write / StrReplace | Harness implementation |
+| Task | Optional parallel subtasks |
+
+## Phase Gates
+
+For build/refine/test/validate, maintain
+`{software-root}/agent-harness/.cli-anything-progress.json`.
+Create `agent-harness/` when tracking starts. Do not advance without completing
+the previous phase. Resume non-terminal runs.
+
+## Quality Bar
+
+Match Claude Code plugin / Codex skill output: same harness layout, namespace
+packaging, `--json`, tests, and skill generation. Do not invent a different
+harness format.

--- a/cursor-plugin/tests/test_install.ps1
+++ b/cursor-plugin/tests/test_install.ps1
@@ -1,0 +1,266 @@
+# Regression tests for the Cursor plugin installer (Windows).
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$pluginSrc = Split-Path -Parent $scriptDir
+$repoRoot = Split-Path -Parent $pluginSrc
+$canonicalPlugin = Join-Path $repoRoot "cli-anything-plugin"
+$previewProtocol = Join-Path $repoRoot "docs\PREVIEW_PROTOCOL.md"
+
+$tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("cli-anything-cursor-test-" + [System.Guid]::NewGuid().ToString("N"))
+$userHome = Join-Path $tmpDir "home"
+$pluginsHome = Join-Path $tmpDir "plugins"
+$installedDir = Join-Path $pluginsHome "local\cli-anything"
+$staleStaging = Join-Path $pluginsHome "local\.cli-anything.tmp.stale"
+$discoveryPointer = Join-Path $userHome ".cursor\cli-anything-generator.root"
+
+function Fail([string]$Message) {
+    throw "FAIL: $Message"
+}
+
+function Assert-File([string]$Path) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Fail "expected file: $Path"
+    }
+}
+
+function Assert-SameFile([string]$Left, [string]$Right) {
+    $a = Get-FileHash -LiteralPath $Left -Algorithm SHA256
+    $b = Get-FileHash -LiteralPath $Right -Algorithm SHA256
+    if ($a.Hash -ne $b.Hash) {
+        Fail "files differ: $Left $Right"
+    }
+}
+
+$oldUserProfile = $env:USERPROFILE
+$oldPluginsHome = $env:CURSOR_PLUGINS_HOME
+
+try {
+    New-Item -ItemType Directory -Path $userHome -Force | Out-Null
+    New-Item -ItemType Directory -Path $staleStaging -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $staleStaging "stale.txt") -Value "left over from an interrupted install"
+
+    $env:USERPROFILE = $userHome
+    $env:CURSOR_PLUGINS_HOME = $pluginsHome
+    & (Join-Path $pluginSrc "scripts\install.ps1")
+
+    Assert-File (Join-Path $installedDir ".cursor-plugin\plugin.json")
+    Assert-File (Join-Path $installedDir "PLUGIN_ROOT.txt")
+    Assert-File $discoveryPointer
+    Assert-File (Join-Path $installedDir "commands\cli-anything.md")
+    Assert-File (Join-Path $installedDir "commands\cli-anything-refine.md")
+    Assert-File (Join-Path $installedDir "commands\cli-anything-test.md")
+    Assert-File (Join-Path $installedDir "commands\cli-anything-validate.md")
+    Assert-File (Join-Path $installedDir "commands\cli-anything-list.md")
+    Assert-File (Join-Path $installedDir "skills\cli-anything-generator\SKILL.md")
+    Assert-File (Join-Path $installedDir "rules\cli-anything-generator.mdc")
+    Assert-File (Join-Path $installedDir "references\HARNESS.md")
+    Assert-File (Join-Path $installedDir "references\commands\cli-anything.md")
+    Assert-File (Join-Path $installedDir "references\commands\refine.md")
+    Assert-File (Join-Path $installedDir "references\commands\test.md")
+    Assert-File (Join-Path $installedDir "references\commands\validate.md")
+    Assert-File (Join-Path $installedDir "references\commands\list.md")
+    Assert-File (Join-Path $installedDir "scripts\repl_skin.py")
+    Assert-File (Join-Path $installedDir "scripts\preview_bundle.py")
+    Assert-File (Join-Path $installedDir "scripts\skill_generator.py")
+    Assert-File (Join-Path $installedDir "scripts\templates\SKILL.md.template")
+    Assert-File (Join-Path $installedDir "references\docs\PREVIEW_PROTOCOL.md")
+
+    $stamp = (Get-Content -LiteralPath (Join-Path $installedDir "PLUGIN_ROOT.txt") -Raw).Trim()
+    $pointer = (Get-Content -LiteralPath $discoveryPointer -Raw).Trim()
+    if (-not (Test-Path -LiteralPath (Join-Path $stamp "references\HARNESS.md"))) {
+        Fail "stamped PLUGIN_ROOT missing HARNESS.md: $stamp"
+    }
+    if ($stamp -ne $pointer) {
+        Fail "discovery pointer mismatch: $pointer != $stamp"
+    }
+
+    if (-not (Test-Path -LiteralPath $staleStaging)) {
+        Fail "installer reused or removed the stale staging directory"
+    }
+    if (Test-Path -LiteralPath (Join-Path $installedDir "tests")) {
+        Fail "installer copied tests/ into the installed plugin"
+    }
+    if (Test-Path -LiteralPath (Join-Path $installedDir "skills\cli-anything")) {
+        Fail "old skills/cli-anything name should not be installed"
+    }
+
+    Assert-SameFile (Join-Path $canonicalPlugin "HARNESS.md") (Join-Path $installedDir "references\HARNESS.md")
+    Assert-SameFile (Join-Path $canonicalPlugin "repl_skin.py") (Join-Path $installedDir "scripts\repl_skin.py")
+    Assert-SameFile (Join-Path $canonicalPlugin "preview_bundle.py") (Join-Path $installedDir "scripts\preview_bundle.py")
+    Assert-SameFile (Join-Path $canonicalPlugin "skill_generator.py") (Join-Path $installedDir "scripts\skill_generator.py")
+    Assert-SameFile $previewProtocol (Join-Path $installedDir "references\docs\PREVIEW_PROTOCOL.md")
+
+    foreach ($name in (Get-ChildItem (Join-Path $canonicalPlugin "commands\*.md")).Name) {
+        Assert-SameFile (Join-Path $canonicalPlugin "commands\$name") (Join-Path $installedDir "references\commands\$name")
+    }
+    foreach ($name in (Get-ChildItem (Join-Path $canonicalPlugin "guides\*.md")).Name) {
+        Assert-SameFile (Join-Path $canonicalPlugin "guides\$name") (Join-Path $installedDir "references\guides\$name")
+    }
+    foreach ($name in (Get-ChildItem (Join-Path $canonicalPlugin "templates\*")).Name) {
+        Assert-SameFile (Join-Path $canonicalPlugin "templates\$name") (Join-Path $installedDir "scripts\templates\$name")
+    }
+
+    $py = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $py) { $py = Get-Command python3 -ErrorAction SilentlyContinue }
+    if ($py) {
+        & $py.Source -m py_compile `
+            (Join-Path $installedDir "scripts\repl_skin.py") `
+            (Join-Path $installedDir "scripts\preview_bundle.py") `
+            (Join-Path $installedDir "scripts\skill_generator.py")
+        if ($LASTEXITCODE -ne 0) {
+            Fail "py_compile failed for vendored scripts"
+        }
+    } else {
+        Fail "python/python3 not available for py_compile"
+    }
+
+    $refused = $false
+    try {
+        & (Join-Path $pluginSrc "scripts\install.ps1")
+    } catch {
+        $refused = $true
+    }
+    if (-not $refused) {
+        Fail "installer overwrote an existing plugin without -Force"
+    }
+
+    $marker = Join-Path $installedDir ".install-marker"
+    Set-Content -LiteralPath $marker -Value "first-install"
+    & (Join-Path $pluginSrc "scripts\install.ps1") -Force
+    if (Test-Path -LiteralPath $marker) {
+        Fail "-Force upgrade did not replace the previous install"
+    }
+    Assert-File (Join-Path $installedDir "PLUGIN_ROOT.txt")
+    Assert-File (Join-Path $installedDir "references\HARNESS.md")
+
+    $cmdText = Get-Content -LiteralPath (Join-Path $installedDir "commands\cli-anything.md") -Raw
+    if ($cmdText -notmatch "cli-anything-generator\.root") {
+        Fail "installed command does not document discovery pointer"
+    }
+    if ($cmdText -notmatch "agent-harness/\.cli-anything-progress\.json") {
+        Fail "installed command does not use agent-harness progress path"
+    }
+
+    $ruleText = Get-Content -LiteralPath (Join-Path $installedDir "rules\cli-anything-generator.mdc") -Raw
+    if ($ruleText -notmatch "alwaysApply:\s*false") {
+        Fail "generator rule must be alwaysApply false (avoid global context pollution)"
+    }
+    if ($ruleText -notmatch "agent-harness/\*\*") {
+        Fail "generator rule must include agent-harness globs"
+    }
+
+    $skillText = Get-Content -LiteralPath (Join-Path $installedDir "skills\cli-anything-generator\SKILL.md") -Raw
+    if ($skillText -notmatch "references/HARNESS.md") {
+        Fail "installed skill does not point to vendored HARNESS.md"
+    }
+    if ($skillText -notmatch "cli-hub-meta-skill") {
+        Fail "installed skill does not document consumer Hub path"
+    }
+
+    $manifest = Get-Content -LiteralPath (Join-Path $installedDir ".cursor-plugin\plugin.json") -Raw | ConvertFrom-Json
+    if ($manifest.name -ne "cli-anything") {
+        Fail "plugin manifest name mismatch"
+    }
+
+    $marketplacePath = Join-Path $repoRoot ".cursor-plugin\marketplace.json"
+    Assert-File $marketplacePath
+    $marketplace = Get-Content -LiteralPath $marketplacePath -Raw | ConvertFrom-Json
+    $sources = @($marketplace.plugins | ForEach-Object { $_.source })
+    if ($sources -notcontains "./cursor-plugin") {
+        Fail "marketplace.json does not point at ./cursor-plugin"
+    }
+
+    $detachedRoot = Join-Path $tmpDir "detached"
+    New-Item -ItemType Directory -Path $detachedRoot -Force | Out-Null
+    Copy-Item -LiteralPath $pluginSrc -Destination (Join-Path $detachedRoot "cursor-plugin") -Recurse -Force
+    $detachedFailed = $false
+    try {
+        $env:CURSOR_PLUGINS_HOME = Join-Path $tmpDir "detached-plugins\plugins"
+        & (Join-Path $detachedRoot "cursor-plugin\scripts\install.ps1") 2>&1 | Out-Null
+    } catch {
+        $detachedFailed = $true
+        if ($_.Exception.Message -notmatch "Cannot find canonical CLI-Anything resources") {
+            Fail "detached install did not explain missing canonical resources"
+        }
+    }
+    if (-not $detachedFailed) {
+        Fail "installer accepted a detached plugin without canonical resources"
+    }
+
+    $badFailed = $false
+    $badHomePath = Join-Path $tmpDir "not-plugins-dir"
+    try {
+        $env:CURSOR_PLUGINS_HOME = $badHomePath
+        & (Join-Path $pluginSrc "scripts\install.ps1") 2>&1 | Out-Null
+    } catch {
+        $badFailed = $true
+        if ($_.Exception.Message -notmatch "named 'plugins'") {
+            Fail "installer did not reject non-plugins CURSOR_PLUGINS_HOME"
+        }
+    }
+    if (-not $badFailed) {
+        Fail "installer accepted CURSOR_PLUGINS_HOME whose basename is not plugins"
+    }
+    if (Test-Path -LiteralPath $badHomePath) {
+        Fail "rejected CURSOR_PLUGINS_HOME should not create the target directory"
+    }
+
+    # Uninstall clears install dir + matching discovery pointer.
+    $env:CURSOR_PLUGINS_HOME = $pluginsHome
+    & (Join-Path $pluginSrc "scripts\uninstall.ps1")
+    if (Test-Path -LiteralPath $installedDir) {
+        Fail "uninstall left plugin directory behind"
+    }
+    if (Test-Path -LiteralPath $discoveryPointer) {
+        Fail "uninstall left discovery pointer behind"
+    }
+
+    # Reinstall, then foreign pointer must be preserved across uninstall.
+    & (Join-Path $pluginSrc "scripts\install.ps1")
+    Assert-File (Join-Path $installedDir "references\HARNESS.md")
+    $foreignRoot = Join-Path $tmpDir "some-other-plugin-root"
+    Set-Content -LiteralPath $discoveryPointer -Value $foreignRoot
+    & (Join-Path $pluginSrc "scripts\uninstall.ps1")
+    if (Test-Path -LiteralPath $installedDir) {
+        Fail "uninstall left plugin directory behind after foreign-pointer case"
+    }
+    if (-not (Test-Path -LiteralPath $discoveryPointer)) {
+        Fail "uninstall removed a non-matching discovery pointer"
+    }
+    $leftPointer = (Get-Content -LiteralPath $discoveryPointer -Raw).Trim()
+    if ($leftPointer -ne $foreignRoot) {
+        Fail "foreign discovery pointer changed: $leftPointer"
+    }
+
+    . (Join-Path $pluginSrc "scripts\lib.ps1")
+    if (-not (Test-CliAnythingInstallPath -Path "C:\Users\x\.cursor\plugins\local\cli-anything")) {
+        Fail "Test-CliAnythingInstallPath should accept Windows local install path"
+    }
+    if (Test-CliAnythingInstallPath -Path "D:\repo\CLI-Anything\cursor-plugin") {
+        Fail "Test-CliAnythingInstallPath must reject repo cursor-plugin path"
+    }
+
+    # Final reinstall for a clean installed tree at end of test.
+    & (Join-Path $pluginSrc "scripts\install.ps1")
+    Assert-File (Join-Path $installedDir "references\HARNESS.md")
+    Assert-File $discoveryPointer
+    Assert-File (Join-Path $installedDir "scripts\lib.ps1")
+    Assert-File (Join-Path $installedDir "scripts\lib.sh")
+
+    Write-Host "PASS: Cursor plugin installer vendors the complete CLI-Anything resource set."
+} finally {
+    if (Test-Path -LiteralPath $tmpDir) {
+        Remove-Item -LiteralPath $tmpDir -Recurse -Force
+    }
+    if ($null -ne $oldUserProfile) {
+        $env:USERPROFILE = $oldUserProfile
+    } else {
+        Remove-Item Env:USERPROFILE -ErrorAction SilentlyContinue
+    }
+    if ($null -ne $oldPluginsHome) {
+        $env:CURSOR_PLUGINS_HOME = $oldPluginsHome
+    } else {
+        Remove-Item Env:CURSOR_PLUGINS_HOME -ErrorAction SilentlyContinue
+    }
+}

--- a/cursor-plugin/tests/test_install.sh
+++ b/cursor-plugin/tests/test_install.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_SRC="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${PLUGIN_SRC}/.." && pwd)"
+CANONICAL_PLUGIN="${REPO_ROOT}/cli-anything-plugin"
+TMP_DIR="$(mktemp -d)"
+# Isolate HOME so discovery pointer and default paths stay inside the temp tree.
+export HOME="${TMP_DIR}/home"
+mkdir -p "${HOME}"
+PLUGINS_HOME="${TMP_DIR}/plugins"
+INSTALLED_DIR="${PLUGINS_HOME}/local/cli-anything"
+STALE_STAGING_DIR="${PLUGINS_HOME}/local/.cli-anything.tmp.stale"
+DISCOVERY_POINTER="${HOME}/.cursor/cli-anything-generator.root"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file() {
+  [[ -f "$1" ]] || fail "expected file: $1"
+}
+
+assert_same() {
+  cmp -s "$1" "$2" || fail "files differ: $1 $2"
+}
+
+assert_tree_same() {
+  diff -qr "$1" "$2" >/dev/null || fail "directories differ: $1 $2"
+}
+
+mkdir -p "${STALE_STAGING_DIR}"
+echo "left over from an interrupted install" > "${STALE_STAGING_DIR}/stale.txt"
+
+CURSOR_PLUGINS_HOME="${PLUGINS_HOME}" bash "${PLUGIN_SRC}/scripts/install.sh"
+
+assert_file "${INSTALLED_DIR}/.cursor-plugin/plugin.json"
+assert_file "${INSTALLED_DIR}/PLUGIN_ROOT.txt"
+assert_file "${DISCOVERY_POINTER}"
+assert_file "${INSTALLED_DIR}/commands/cli-anything.md"
+assert_file "${INSTALLED_DIR}/commands/cli-anything-refine.md"
+assert_file "${INSTALLED_DIR}/commands/cli-anything-test.md"
+assert_file "${INSTALLED_DIR}/commands/cli-anything-validate.md"
+assert_file "${INSTALLED_DIR}/commands/cli-anything-list.md"
+assert_file "${INSTALLED_DIR}/skills/cli-anything-generator/SKILL.md"
+assert_file "${INSTALLED_DIR}/rules/cli-anything-generator.mdc"
+assert_file "${INSTALLED_DIR}/references/HARNESS.md"
+assert_file "${INSTALLED_DIR}/references/commands/cli-anything.md"
+assert_file "${INSTALLED_DIR}/references/commands/refine.md"
+assert_file "${INSTALLED_DIR}/references/commands/test.md"
+assert_file "${INSTALLED_DIR}/references/commands/validate.md"
+assert_file "${INSTALLED_DIR}/references/commands/list.md"
+assert_file "${INSTALLED_DIR}/references/guides/auto-save-dry-run.md"
+assert_file "${INSTALLED_DIR}/references/guides/session-locking.md"
+assert_file "${INSTALLED_DIR}/references/guides/preview-methodology.md"
+assert_file "${INSTALLED_DIR}/scripts/repl_skin.py"
+assert_file "${INSTALLED_DIR}/scripts/preview_bundle.py"
+assert_file "${INSTALLED_DIR}/scripts/skill_generator.py"
+assert_file "${INSTALLED_DIR}/scripts/templates/SKILL.md.template"
+assert_file "${INSTALLED_DIR}/references/docs/PREVIEW_PROTOCOL.md"
+assert_file "${INSTALLED_DIR}/scripts/install.sh"
+assert_file "${INSTALLED_DIR}/scripts/install.ps1"
+assert_file "${INSTALLED_DIR}/scripts/uninstall.sh"
+assert_file "${INSTALLED_DIR}/scripts/uninstall.ps1"
+assert_file "${INSTALLED_DIR}/scripts/lib.sh"
+assert_file "${INSTALLED_DIR}/scripts/lib.ps1"
+
+STAMP="$(tr -d '\r\n' < "${INSTALLED_DIR}/PLUGIN_ROOT.txt")"
+POINTER="$(tr -d '\r\n' < "${DISCOVERY_POINTER}")"
+[[ -n "${STAMP}" ]] || fail "PLUGIN_ROOT.txt is empty"
+[[ "${STAMP}" == "${POINTER}" ]] || fail "discovery pointer mismatch: ${POINTER} != ${STAMP}"
+assert_file "${INSTALLED_DIR}/references/HARNESS.md"
+
+# On Git Bash / MSYS, stamps must be Windows host paths for Cursor Read tools.
+case "$(uname -s 2>/dev/null || true)" in
+  MINGW*|MSYS*|CYGWIN*)
+    [[ "${STAMP}" =~ ^[A-Za-z]:\\ ]] ||
+      fail "Windows Git Bash install must stamp a drive path, got: ${STAMP}"
+    if command -v cygpath >/dev/null 2>&1; then
+      STAMP_UNIX="$(cygpath -u "${STAMP}")"
+      assert_file "${STAMP_UNIX}/references/HARNESS.md"
+    fi
+    ;;
+  *)
+    assert_file "${STAMP}/references/HARNESS.md"
+    ;;
+esac
+
+[[ -d "${STALE_STAGING_DIR}" ]] ||
+  fail "installer reused or removed the stale staging directory"
+[[ ! -d "${INSTALLED_DIR}/tests" ]] ||
+  fail "installer copied tests/ into the installed plugin"
+[[ ! -d "${INSTALLED_DIR}/cursor-plugin" ]] ||
+  fail "installer created a nested cursor-plugin directory"
+[[ ! -d "${INSTALLED_DIR}/skills/cli-anything" ]] ||
+  fail "old skills/cli-anything name should not be installed"
+
+assert_same "${CANONICAL_PLUGIN}/HARNESS.md" "${INSTALLED_DIR}/references/HARNESS.md"
+assert_same "${CANONICAL_PLUGIN}/repl_skin.py" "${INSTALLED_DIR}/scripts/repl_skin.py"
+assert_same "${CANONICAL_PLUGIN}/preview_bundle.py" "${INSTALLED_DIR}/scripts/preview_bundle.py"
+assert_same "${CANONICAL_PLUGIN}/skill_generator.py" "${INSTALLED_DIR}/scripts/skill_generator.py"
+assert_same "${REPO_ROOT}/docs/PREVIEW_PROTOCOL.md" "${INSTALLED_DIR}/references/docs/PREVIEW_PROTOCOL.md"
+assert_tree_same "${CANONICAL_PLUGIN}/commands" "${INSTALLED_DIR}/references/commands"
+assert_tree_same "${CANONICAL_PLUGIN}/guides" "${INSTALLED_DIR}/references/guides"
+assert_tree_same "${CANONICAL_PLUGIN}/templates" "${INSTALLED_DIR}/scripts/templates"
+
+python3 -m py_compile \
+  "${INSTALLED_DIR}/scripts/repl_skin.py" \
+  "${INSTALLED_DIR}/scripts/preview_bundle.py" \
+  "${INSTALLED_DIR}/scripts/skill_generator.py"
+
+if CURSOR_PLUGINS_HOME="${PLUGINS_HOME}" bash "${PLUGIN_SRC}/scripts/install.sh" >/dev/null 2>&1; then
+  fail "installer overwrote an existing plugin without --force"
+fi
+
+MARKER="${INSTALLED_DIR}/.install-marker"
+echo "first-install" > "${MARKER}"
+CURSOR_PLUGINS_HOME="${PLUGINS_HOME}" bash "${PLUGIN_SRC}/scripts/install.sh" --force
+[[ ! -f "${MARKER}" ]] || fail "--force upgrade did not replace the previous install"
+assert_file "${INSTALLED_DIR}/references/HARNESS.md"
+assert_file "${INSTALLED_DIR}/PLUGIN_ROOT.txt"
+STAMP2="$(tr -d '\r\n' < "${INSTALLED_DIR}/PLUGIN_ROOT.txt")"
+[[ -n "${STAMP2}" ]] || fail "stamp after --force is empty"
+assert_file "${INSTALLED_DIR}/references/HARNESS.md"
+
+grep -q 'cli-anything-generator.root' "${INSTALLED_DIR}/commands/cli-anything.md" ||
+  fail "installed command does not document discovery pointer"
+grep -q 'agent-harness/.cli-anything-progress.json' "${INSTALLED_DIR}/commands/cli-anything.md" ||
+  fail "installed command does not use agent-harness progress path"
+grep -q 'alwaysApply: false' "${INSTALLED_DIR}/rules/cli-anything-generator.mdc" ||
+  fail "generator rule must be alwaysApply false (avoid global context pollution)"
+grep -q 'agent-harness/\*\*' "${INSTALLED_DIR}/rules/cli-anything-generator.mdc" ||
+  fail "generator rule must include agent-harness globs"
+grep -q 'references/HARNESS.md' "${INSTALLED_DIR}/skills/cli-anything-generator/SKILL.md" ||
+  fail "installed skill does not point to vendored HARNESS.md"
+grep -q 'cli-hub-meta-skill' "${INSTALLED_DIR}/skills/cli-anything-generator/SKILL.md" ||
+  fail "installed skill does not document consumer Hub path"
+
+python3 - <<'PY' "${INSTALLED_DIR}/.cursor-plugin/plugin.json"
+import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+assert data.get("name") == "cli-anything", data
+PY
+
+MARKETPLACE="${REPO_ROOT}/.cursor-plugin/marketplace.json"
+assert_file "${MARKETPLACE}"
+python3 - <<'PY' "${MARKETPLACE}"
+import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+names = [p.get("name") for p in data.get("plugins", [])]
+assert "cli-anything" in names, names
+sources = [p.get("source") for p in data.get("plugins", [])]
+assert "./cursor-plugin" in sources, sources
+PY
+
+DETACHED_ROOT="${TMP_DIR}/detached"
+DETACHED_LOG="${TMP_DIR}/detached-install.log"
+mkdir -p "${DETACHED_ROOT}"
+cp -R "${PLUGIN_SRC}" "${DETACHED_ROOT}/cursor-plugin"
+if CURSOR_PLUGINS_HOME="${TMP_DIR}/detached-plugins/plugins" bash "${DETACHED_ROOT}/cursor-plugin/scripts/install.sh" >"${DETACHED_LOG}" 2>&1; then
+  fail "installer accepted a detached plugin without canonical resources"
+fi
+grep -q 'Cannot find canonical CLI-Anything resources' "${DETACHED_LOG}" ||
+  fail "detached install did not explain the missing canonical resources"
+
+BAD_HOME_LOG="${TMP_DIR}/bad-home.log"
+BAD_HOME_PATH="${TMP_DIR}/not-plugins-dir"
+if CURSOR_PLUGINS_HOME="${BAD_HOME_PATH}" bash "${PLUGIN_SRC}/scripts/install.sh" >"${BAD_HOME_LOG}" 2>&1; then
+  fail "installer accepted CURSOR_PLUGINS_HOME whose basename is not plugins"
+fi
+grep -q "named 'plugins'" "${BAD_HOME_LOG}" ||
+  fail "installer did not reject non-plugins CURSOR_PLUGINS_HOME"
+[[ ! -e "${BAD_HOME_PATH}" ]] ||
+  fail "rejected CURSOR_PLUGINS_HOME should not create the target directory"
+
+TRAVERSAL_LOG="${TMP_DIR}/traversal.log"
+TRAVERSAL_OUTSIDE="${TMP_DIR}/outside"
+# After normalization this becomes TMP_DIR/outside (basename outside), not plugins.
+if CURSOR_PLUGINS_HOME="${TMP_DIR}/evil/../outside" bash "${PLUGIN_SRC}/scripts/install.sh" >"${TRAVERSAL_LOG}" 2>&1; then
+  fail "installer accepted traversed CURSOR_PLUGINS_HOME"
+fi
+grep -q "named 'plugins'" "${TRAVERSAL_LOG}" ||
+  fail "installer did not reject traversed CURSOR_PLUGINS_HOME"
+[[ ! -e "${TRAVERSAL_OUTSIDE}" ]] ||
+  fail "rejected traversed CURSOR_PLUGINS_HOME should not create the outside directory"
+
+# Uninstall clears install dir + matching discovery pointer.
+CURSOR_PLUGINS_HOME="${PLUGINS_HOME}" bash "${PLUGIN_SRC}/scripts/uninstall.sh"
+[[ ! -e "${INSTALLED_DIR}" ]] || fail "uninstall left plugin directory behind"
+[[ ! -e "${DISCOVERY_POINTER}" ]] || fail "uninstall left discovery pointer behind"
+
+# Reinstall, then foreign pointer must be preserved across uninstall.
+CURSOR_PLUGINS_HOME="${PLUGINS_HOME}" bash "${PLUGIN_SRC}/scripts/install.sh"
+assert_file "${INSTALLED_DIR}/references/HARNESS.md"
+FOREIGN_ROOT="${TMP_DIR}/some-other-plugin-root"
+printf '%s\n' "${FOREIGN_ROOT}" > "${DISCOVERY_POINTER}"
+CURSOR_PLUGINS_HOME="${PLUGINS_HOME}" bash "${PLUGIN_SRC}/scripts/uninstall.sh"
+[[ ! -e "${INSTALLED_DIR}" ]] || fail "uninstall left plugin directory behind after foreign-pointer case"
+[[ -f "${DISCOVERY_POINTER}" ]] || fail "uninstall removed a non-matching discovery pointer"
+LEFT_POINTER="$(tr -d '\r\n' < "${DISCOVERY_POINTER}")"
+[[ "${LEFT_POINTER}" == "${FOREIGN_ROOT}" ]] ||
+  fail "foreign discovery pointer changed: ${LEFT_POINTER}"
+
+# Shared lib path helpers
+# shellcheck source=../scripts/lib.sh
+source "${PLUGIN_SRC}/scripts/lib.sh"
+is_cli_anything_install_path "/tmp/foo/local/cli-anything" ||
+  fail "is_cli_anything_install_path should accept .../local/cli-anything"
+is_cli_anything_install_path 'C:\Users\x\.cursor\plugins\local\cli-anything' ||
+  fail "is_cli_anything_install_path should accept Windows ...\\local\\cli-anything"
+if is_cli_anything_install_path "/tmp/CLI-Anything/cursor-plugin"; then
+  fail "is_cli_anything_install_path must reject repo cursor-plugin path"
+fi
+
+# Final reinstall for a clean installed tree at end of test.
+CURSOR_PLUGINS_HOME="${PLUGINS_HOME}" bash "${PLUGIN_SRC}/scripts/install.sh"
+assert_file "${INSTALLED_DIR}/references/HARNESS.md"
+assert_file "${DISCOVERY_POINTER}"
+
+echo "PASS: Cursor plugin installer vendors the complete CLI-Anything resource set."


### PR DESCRIPTION
## Summary
- Add a Cursor generator plugin under `cursor-plugin/` with `/cli-anything`, refine/test/validate/list slash commands, skill, rules, and marketplace manifest.
- Ship bash/PowerShell installers plus CI installer tests, and document Cursor generator vs Hub consumer paths in README/README_CN.

## Test plan
- [ ] `bash cursor-plugin/tests/test_install.sh` (or CI Ubuntu job) passes
- [ ] `./cursor-plugin/tests/test_install.ps1` (or CI Windows job) passes
- [ ] Install plugin, reload Cursor window, confirm slash commands appear
- [ ] Run `/cli-anything-list` and a dry `/cli-anything` against a small local project path