### PR TITLE
fix(cli-hub): reconfigure stdout/stderr to UTF-8 on GBK consoles (Chinese Windows crash)

### DIFF
--- a/cli-hub/cli_hub/cli.py
+++ b/cli-hub/cli_hub/cli.py
@@ -65,6 +65,23 @@ EXIT_USAGE = 2
 EXIT_PARTIAL = 3
 
 
+def _ensure_utf8_stdio() -> None:
+    """GBK 控制台/管道兼容：stdout/stderr 重配为 UTF-8（replace 兜底）。
+
+    中文 Windows（cp936）下，管道输出默认按 locale 编码（GBK），
+    ✓/✗/emoji 等字符会触发 UnicodeEncodeError 直接崩溃；
+    reconfig 后统一 UTF-8 输出，任何 locale 都不再崩。
+    """
+    for name in ("stdout", "stderr"):
+        stream = getattr(sys, name, None)
+        try:
+            if stream is not None and hasattr(stream, "reconfigure"):
+                stream.reconfigure(encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            # 控制台/只读流不支持 reconfigure 时静默跳过
+            pass
+
+
 def _invocation_command(ctx, version):
     """Return a compact label for the current invocation."""
     argv = sys.argv[1:]
@@ -84,6 +101,7 @@ def _invocation_command(ctx, version):
 @click.pass_context
 def main(ctx, version):
     """cli-hub — Download and manage CLI-Anything CLIs, public CLIs, and curated matrices."""
+    _ensure_utf8_stdio()
     track_first_run()
     track_visit(command=_invocation_command(ctx, version), detection=detect_invocation_context())
     if version:

--- a/cli-hub/tests/test_cli_hub.py
+++ b/cli-hub/tests/test_cli_hub.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -1508,6 +1509,24 @@ class TestCLI:
         assert "matrix" in result.output
         assert "previews" in result.output
         assert result.exit_code == 0
+
+    def test_gbk_console_utf8_stdio(self):
+        """中文 Windows（GBK 管道）下 ✓/✗ 输出不再 UnicodeEncodeError（回归）。"""
+        import contextlib
+        import io
+
+        import click
+
+        from cli_hub import cli as cli_mod
+
+        buf = io.BytesIO()
+        gbk = io.TextIOWrapper(buf, encoding="gbk", errors="strict")
+        with contextlib.redirect_stdout(gbk):
+            cli_mod._ensure_utf8_stdio()
+            assert sys.stdout.encoding == "utf-8"
+            click.secho("✓ Installed Obsidian CLI (obsidian-agent)", fg="green")
+        out = buf.getvalue().decode("utf-8", errors="replace")
+        assert "Installed Obsidian CLI" in out
 
     @patch("cli_hub.cli.track_first_run")
     @patch("cli_hub.cli.track_visit")


### PR DESCRIPTION
Fixes #418

## 改动

中文 Windows（cp936）下，`cli-hub` 打印 `✓`/`✗` 时 stdout 按 locale（GBK）编码会抛
`UnicodeEncodeError`，install/update/uninstall/matrix install 等成功路径在命令完成后崩溃。

- `cli_hub/cli.py`：新增 `_ensure_utf8_stdio()`，在 `main()` 入口把 stdout/stderr 重配为
  UTF-8（`errors="replace"` 兜底；控制台/只读流不支持 reconfigure 时静默跳过）。
- `tests/test_cli_hub.py`：新增 `TestCLI::test_gbk_console_utf8_stdio` 回归测试——
  GBK 流下 `✓` 输出不再抛异常，且字节为 UTF-8。

## 验证

- 修复前（GBK 管道）：`click.secho("✓ ...")` → `UnicodeEncodeError: 'gbk' codec can't encode character '\u2713'`
- 修复后（同一环境）：`stdout.encoding` 变为 `utf-8`，✓ 正常输出，无崩溃
- 上游测试套件：Windows 本机 `143 passed`；`21 failed` 与本 PR 无关（Windows 环境性问题：
  清空环境变量后 `Path.home()` 取不到家目录 + 联网用例），修复前后失败集合完全一致
- 新增回归测试单独通过

## 影响面

仅 CLI 入口做 stdio 编码兜底，不改变任何命令行为与输出内容。
