### PR TITLE
ci(harness): watchdog CI runs all harness unit suites and reports drift (#403)

### DIFF
--- a/.github/scripts/run_harness_unit_tests.py
+++ b/.github/scripts/run_harness_unit_tests.py
@@ -1,0 +1,94 @@
+"""本地/CI 共用的 harness 单元测试发现与运行脚本（#403）。
+
+发现 `*/agent-harness/cli_anything/*/tests/test_core.py`（后端无关的单测），
+逐个用 pytest 运行并输出汇总；供 GitHub Actions 矩阵生成与本地核对使用。
+"""
+
+import argparse
+import glob
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def discover(repo_root: Path) -> list[Path]:
+    return sorted(
+        Path(p)
+        for p in glob.glob(
+            str(repo_root / "*/agent-harness/cli_anything/*/tests/test_core.py")
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=str(Path(__file__).resolve().parents[2]))
+    parser.add_argument("--list", action="store_true", help="仅输出发现清单（JSON）")
+    parser.add_argument("--test", type=str, default="", help="只跑指定测试文件")
+    parser.add_argument("--out", type=str, default="", help="单测结果 JSON 输出路径")
+    args = parser.parse_args()
+
+    root = Path(args.repo_root)
+    tests = discover(root)
+    if args.test:
+        t = Path(args.test)
+        tests = [t if t.is_absolute() else (root / t)]
+    if args.list:
+        print(json.dumps([str(t.relative_to(root)) for t in tests], ensure_ascii=False))
+        return 0
+
+    results = []
+    failed = 0
+    for t in tests:
+        harness_dir = t.parents[3]  # .../agent-harness/cli_anything/<h>/tests/test_core.py
+        rel = t.relative_to(harness_dir)
+        rel_root = t.relative_to(root)
+        harness_name = rel_root.parts[0]
+        try:
+            out = subprocess.run(
+                [sys.executable, "-m", "pytest", str(rel), "-q", "--no-header"],
+                cwd=harness_dir,
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+            lines = (out.stdout or out.stderr).strip().splitlines()
+            tail = next(
+                (ln.strip() for ln in reversed(lines) if "passed" in ln or "failed" in ln),
+                (lines[-1].strip() if lines else ""),
+            )
+            ok = out.returncode == 0
+            if not ok:
+                failed += 1
+            results.append(
+                {
+                    "harness": harness_name,
+                    "test": str(rel),
+                    "ok": ok,
+                    "rc": out.returncode,
+                    "summary": tail,
+                }
+            )
+            print(f"{'PASS' if ok else 'FAIL'}  {rel}")
+            if args.out:
+                with open(args.out, "w", encoding="utf-8") as f:
+                    json.dump(results[0], f, ensure_ascii=False)
+        except subprocess.TimeoutExpired:
+            failed += 1
+            results.append({"harness": t.parts[0], "test": str(rel), "ok": False,
+                            "rc": "timeout", "summary": "timeout"})
+            print(f"TIMEOUT  {rel}")
+
+    print("\n== SUMMARY ==")
+    print(f"total={len(results)} failed={failed}")
+    for r in results:
+        if not r["ok"]:
+            print(f"  FAIL {r['test']} rc={r['rc']} {r['summary']}")
+    with open(root / ".harness-unit-report.json", "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=1)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/summarize_harness_tests.py
+++ b/.github/scripts/summarize_harness_tests.py
@@ -1,0 +1,39 @@
+"""把各 harness 单测结果 JSON 汇总为 Markdown 表（供 GITHUB_STEP_SUMMARY 输出）。"""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", nargs="+", help="单测结果 JSON 文件")
+    args = parser.parse_args()
+
+    rows = []
+    for f in args.files:
+        try:
+            data = json.loads(Path(f).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        rows.append(data)
+    rows.sort(key=lambda r: (r.get("test", ""), r.get("rc", "")))
+
+    lines = [
+        "## Harness 单元测试汇总",
+        "",
+        "| Harness | 测试文件 | 结果 | rc | 摘要 |",
+        "|---|---|---|---|---|",
+    ]
+    for r in rows:
+        status = "✅" if r.get("ok") else "❌"
+        lines.append(
+            f"| {r.get('harness', '-')} | {r.get('test', '-')} | {status} | "
+            f"{r.get('rc', '-')} | {str(r.get('summary', ''))[:60]} |"
+        )
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/harness-tests.yml
+++ b/.github/workflows/harness-tests.yml
@@ -1,0 +1,76 @@
+name: harness-unit-tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.list.outputs.tests }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: List harness unit test files
+        id: list
+        run: |
+          pip install --quiet pytest
+          python .github/scripts/run_harness_unit_tests.py --list > tests.json
+          echo "tests=$(cat tests.json)" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: discover
+    name: ${{ matrix.os }} / ${{ matrix.test }}
+    runs-on: ${{ matrix.os }}
+    # 看门狗模式（#403）：harness 单测存在已知漂移（blender/gimp/comfyui 等），
+    # 先不阻塞合并；每次运行把逐 harness 结果落到 artifact 与 job 日志，
+    # 让「2,461 passed」这类快照声明有 CI 可复核。漂移清零后可移除 continue-on-error。
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        test: ${{ fromJson(needs.discover.outputs.tests) }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install test deps
+        shell: bash
+        run: pip install --quiet pytest click requests
+      - name: Run unit tests
+        shell: bash
+        run: |
+          python .github/scripts/run_harness_unit_tests.py --test "${{ matrix.test }}" --out "${{ runner.temp }}/unit-result.json"
+      - name: Upload result
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-${{ matrix.os }}-${{ strategy.job-index }}
+          path: "${{ runner.temp }}/unit-result.json"
+          if-no-files-found: ignore
+
+  report:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: unit-*
+          path: unit-results
+          merge-multiple: true
+      - name: Write step summary
+        shell: bash
+        run: |
+          python .github/scripts/summarize_harness_tests.py unit-results/*.json \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/harness-tests.yml
+++ b/.github/workflows/harness-tests.yml
@@ -47,12 +47,15 @@ jobs:
       - name: Run unit tests
         shell: bash
         run: |
-          python .github/scripts/run_harness_unit_tests.py --test "${{ matrix.test }}" --out "${{ runner.temp }}/unit-result.json"
+          python .github/scripts/run_harness_unit_tests.py --test "${{ matrix.test }}" --out "${{ runner.temp }}/unit-result-${{ matrix.os }}-${{ strategy.job-index }}.json"
       - name: Upload result
+        # 看门狗核心：测试失败（退出码非 0）时也要把逐 harness 结果传上去，
+        # 否则恰好看不到失败集合。continue-on-error 只保工作流不红，不会让本步执行。
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: unit-${{ matrix.os }}-${{ strategy.job-index }}
-          path: "${{ runner.temp }}/unit-result.json"
+          path: "${{ runner.temp }}/unit-result-${{ matrix.os }}-${{ strategy.job-index }}.json"
           if-no-files-found: ignore
 
   report:


### PR DESCRIPTION
Closes #403

## 改动

新增 `harness-unit-tests` 工作流：发现并运行**所有** harness 的单元测试套件
（`*/agent-harness/cli_anything/*/tests/test_core.py`，后端无关），在
`ubuntu-latest` + `windows-latest`（Python 3.12）上逐 harness 执行，并生成汇总报告
（job step summary + artifact）。

- `.github/workflows/harness-tests.yml`：discover（生成矩阵）→ test（矩阵：os × 测试文件）→ report（汇总表）
- `.github/scripts/run_harness_unit_tests.py`：发现/单跑/批量跑 harness 单测；`--list` 输出矩阵，
  `--test` + `--out` 供 CI 逐项落盘结果
- `.github/scripts/summarize_harness_tests.py`：结果 JSON → Markdown 汇总表（GITHUB_STEP_SUMMARY）

## 设计说明（看门狗模式）

README 声称「2,461 passed / 100% pass rate」，但没有任何 CI 复现它。本机实测
（Windows / Python 3.13，仅装 pytest/click/requests）：

- 发现 66 个 harness 单测文件；**37 个全绿、29 个有失败**（含收集错误、缺后端用例、
  以及真实回归，如 openscreen 80 passed / 1 failed）

因此首个版本采用**不阻塞**的看门狗模式：`continue-on-error: true`，每次运行把逐
harness 结果写进日志 + artifact + step summary，让漂移显形；待存量失败清零后，
移除该开关即可转为硬性门禁。Windows 作业可直接暴露 #343 这类 `\U` 路径逃逸回归。

## 验证

- 工作流 YAML 语法校验通过（PyYAML）
- runner 本地实测：wavetone 24 passed（rc=0，结果 JSON 正确落盘）、
  openscreen 1 failed / 80 passed（rc=1 正确报告失败）
- 全量本地摸底（66 harness）见 PR 描述；CI 首次运行即为可复核基线

## 后续（不在本 PR）

- 存量 29 个失败 harness 逐个修复后，把看门狗升级为硬性门禁
- README 测试表改为由 CI 报告生成（#403 提到的第二个便宜方案）
