### PR TITLE
fix(audacity): render generator effects on empty tracks

### DIFF
--- a/audacity/agent-harness/cli_anything/audacity/core/export.py
+++ b/audacity/agent-harness/cli_anything/audacity/core/export.py
@@ -13,6 +13,7 @@ import math
 import struct
 from typing import Dict, Any, Optional, List, Tuple
 
+from cli_anything.audacity.core.effects import EFFECT_REGISTRY
 from cli_anything.audacity.utils.audio_utils import (
     generate_sine_wave,
     generate_silence,
@@ -167,16 +168,22 @@ def render_mix(
             continue
 
         track_audio = _render_track(track, sample_rate, out_channels)
+        track_effects = track.get("effects", [])
+        has_generator = any(
+            EFFECT_REGISTRY.get(effect.get("name"), {}).get("category") == "generate"
+            for effect in track_effects
+        )
 
-        if track_audio:
+        if track_audio or has_generator:
             # Apply track-level effects
             track_audio = _apply_track_effects(
-                track_audio, track.get("effects", []),
+                track_audio or [], track_effects,
                 sample_rate, out_channels,
             )
-            rendered_tracks.append(track_audio)
-            track_volumes.append(track.get("volume", 1.0))
-            track_pans.append(track.get("pan", 0.0))
+            if track_audio:
+                rendered_tracks.append(track_audio)
+                track_volumes.append(track.get("volume", 1.0))
+                track_pans.append(track.get("pan", 0.0))
 
     # Mix all tracks together
     if rendered_tracks:

--- a/audacity/agent-harness/cli_anything/audacity/tests/test_full_e2e.py
+++ b/audacity/agent-harness/cli_anything/audacity/tests/test_full_e2e.py
@@ -288,6 +288,40 @@ class TestRenderPipeline:
         assert result["format"] == "WAV"
         assert result["tracks_rendered"] == 0
 
+    def test_render_tone_without_source_clip(self, tmp_dir):
+        proj = create_project(channels=1)
+        add_track(proj, name="Tone")
+        add_effect(
+            proj,
+            "tone",
+            0,
+            {"frequency": 220.0, "duration": 3.0, "amplitude": 0.5},
+        )
+
+        out = os.path.join(tmp_dir, "tone.wav")
+        result = render_mix(proj, out, preset="wav")
+
+        with wave.open(out, "rb") as wav_file:
+            assert wav_file.getnframes() == 3 * wav_file.getframerate()
+            frames = wav_file.readframes(wav_file.getnframes())
+
+        assert result["duration"] == 3.0
+        assert result["tracks_rendered"] == 1
+        assert any(frames)
+
+    def test_non_generator_effect_on_empty_track_stays_empty(self, tmp_dir):
+        proj = create_project(channels=1)
+        add_track(proj, name="Echo")
+        add_effect(proj, "echo", 0, {"delay_ms": 200.0, "decay": 0.5})
+
+        out = os.path.join(tmp_dir, "empty_with_echo.wav")
+        result = render_mix(proj, out, preset="wav")
+
+        with wave.open(out, "rb") as wav_file:
+            assert wav_file.getnframes() == wav_file.getframerate()
+
+        assert result["tracks_rendered"] == 0
+
     def test_render_single_track(self, tmp_dir, sine_wav):
         proj = create_project()
         add_track(proj, name="Voice")


### PR DESCRIPTION
## Description

Audacity's render pipeline skipped the entire effect chain when a track had no source clip. As a result, a configured `tone` generator was saved correctly but never rendered, and export fell back to the default one-second silent WAV.

This change:

- lets an empty track enter the effect chain only when it contains a registered `generate` effect;
- preserves the existing effect order and appends the track only when the chain produces samples;
- keeps ordinary empty tracks and non-generator-only chains (such as echo on an empty track) unrendered;
- adds regression coverage for both the requested three-second tone and the non-generator boundary.

Fixes #407

## Type of Change

- [x] **Bug Fix** — fixes incorrect behavior

### For Existing CLI Modifications

- [x] All unit tests pass
- [ ] All E2E tests pass — seven SoX-backed cases cannot run in this environment because SoX is not installed; the same seven failures occur on the unmodified base
- [x] No test regressions — no previously passing tests were removed or weakened
- [x] `registry.json` does not require an update because version, description, and requirements are unchanged

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] No new command or `--json` behavior was introduced
- [x] Commit message follows the conventional format
- [x] Changes were tested locally

## Test Results

```text
Focused regressions:
2 passed

Audacity harness, unmodified base:
159 passed, 7 failed (all seven require unavailable SoX)

Audacity harness, this branch:
161 passed, 7 failed (the same seven SoX-dependent cases)

Audacity harness excluding the two SoX-dependent test classes:
161 passed, 7 deselected

Additional checks:
- issue-path WAV: 3.0 seconds, 132300 frames at 44100 Hz, non-silent
- python -m compileall: passed
- critical Ruff rules: passed
- git diff --check: passed
```
