### PR TITLE
feat(shotcut): add subtitle rendering

### DIFF
--- a/shotcut/agent-harness/.env.example
+++ b/shotcut/agent-harness/.env.example
@@ -1,0 +1,11 @@
+# Optional fallback configuration. Prefer macOS Keychain; see README.md.
+# Never commit a real .env file.
+BRIGHT_DATA_API_KEY=
+BRIGHT_DATA_SNAPSHOT_RETRY_COUNT=60
+BRIGHT_DATA_SNAPSHOT_POLL_INTERVAL_SECONDS=2
+
+# Mistral Voxtral transcription
+MISTRAL_API_KEY=
+
+# ElevenLabs text-to-speech
+ELEVENLABS_API_KEY=

--- a/shotcut/agent-harness/.gitignore
+++ b/shotcut/agent-harness/.gitignore
@@ -11,3 +11,4 @@ htmlcov/
 *.mlt
 *.egg
 .worktrees/
+.env

--- a/shotcut/agent-harness/SHOTCUT.md
+++ b/shotcut/agent-harness/SHOTCUT.md
@@ -47,7 +47,7 @@ manipulate projects entirely by reading and writing this XML format.
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<mlt LC_NUMERIC="C" version="7.x" title="Shotcut" producer="main_bin">
+<mlt LC_NUMERIC="C" version="7.x" title="Shotcut" producer="tractor0">
 
   <!-- Video/Audio Profile -->
   <profile description="HD 1080p 30fps"
@@ -99,6 +99,13 @@ manipulate projects entirely by reading and writing this XML format.
 | Clip on track | `<entry>` | Clip placed on timeline |
 | Effect | `<filter>` | Applied filter |
 | Transition | `<transition>` | Cross-dissolve, etc. |
+
+### Saved Project Entry Point
+
+`main_bin` stores imported media, but the root `producer` must reference the
+main timeline tractor (normally `tractor0`) for Shotcut to open the project on
+the editable timeline. The writer preserves `main_bin` and updates the root
+producer when saving.
 
 ### Shotcut-Specific Properties
 
@@ -230,7 +237,8 @@ melt command for the user to run elsewhere.
 | File → Export | `export render <output> [--preset name]` |
 | Add video track | `timeline add-track --type video --name "V1"` |
 | Add audio track | `timeline add-track --type audio --name "A1"` |
-| Drag clip to timeline | `timeline add-clip <file> --track <n> --in <tc> --out <tc>` |
+| Import media | `media import <file>` |
+| Drag clip to timeline | `timeline add-clip <clip_id> --track <n> --in <tc> --out <tc>` |
 | Trim clip | `timeline trim <track> <clip> --in/--out <tc>` |
 | Split clip | `timeline split <track> <clip> --at <tc>` |
 | Remove clip | `timeline remove-clip <track> <clip>` |

--- a/shotcut/agent-harness/cli_anything/shotcut/README.md
+++ b/shotcut/agent-harness/cli_anything/shotcut/README.md
@@ -11,6 +11,10 @@ without a GUI.
 - `melt` (MLT CLI) — **required** for rendering and playback
 - `ffmpeg` / `ffprobe` — required for media probing and export
 
+On macOS, the bundled Shotcut MLT executable is detected automatically. Set
+`SHOTCUT_MELT=/path/to/melt` to override it when multiple `melt` executables
+are installed.
+
 Optional (for interactive REPL):
 - `prompt_toolkit`
 
@@ -150,7 +154,7 @@ project profiles                             # List available profiles
 project xml                                  # Print raw MLT XML
 ```
 
-Available profiles: `hd1080p30`, `hd1080p60`, `hd1080p24`, `hd720p30`, `4k30`, `4k60`, `sd480p`
+Available profiles: `vertical1080p30`, `hd1080p30`, `hd1080p60`, `hd1080p24`, `hd720p30`, `4k30`, `4k60`, `sd480p`
 
 ### Timeline
 

--- a/shotcut/agent-harness/cli_anything/shotcut/README.md
+++ b/shotcut/agent-harness/cli_anything/shotcut/README.md
@@ -10,6 +10,22 @@ without a GUI.
 - `click` (CLI framework)
 - `melt` (MLT CLI) — **required** for rendering and playback
 - `ffmpeg` / `ffprobe` — required for media probing and export
+- `MISTRAL_API_KEY` — required for transcription
+- `ELEVENLABS_API_KEY` — required for text-to-speech
+- `BRIGHT_DATA_API_KEY` — required for Instagram video downloads
+
+API keys can be stored in macOS Keychain instead of a workspace `.env` file.
+The CLI looks for Keychain entries with account `cli-anything-shotcut` and
+service names `BRIGHT_DATA_API_KEY`, `MISTRAL_API_KEY`, and `ELEVENLABS_API_KEY`.
+
+```bash
+read -r -s BRIGHT_DATA_API_KEY
+security add-generic-password -U -a cli-anything-shotcut -s BRIGHT_DATA_API_KEY -w "$BRIGHT_DATA_API_KEY"
+unset BRIGHT_DATA_API_KEY
+```
+
+The CLI checks environment variables first, then macOS Keychain. Do not create
+a real `.env` file inside the repository.
 
 On macOS, the bundled Shotcut MLT executable is detected automatically. Set
 `SHOTCUT_MELT=/path/to/melt` to override it when multiple `melt` executables
@@ -88,6 +104,9 @@ Inside the REPL, type `help` for all available commands.
 | Command | Description |
 |---------|-------------|
 | `media import <file> [--caption name]` | Import media file, returns `clip_id` |
+| `media transcribe <file-or-url> [--speed 2.0]` | Transcribe video audio |
+| `media add-subtitles <video> --transcript <json> -o <output>` | Burn timestamped subtitles into a video |
+| `media tts <text> --voice <id> -o <file>` | Generate speech with ElevenLabs |
 | `media` | List all imported media |
 | `probe <file>` | Analyze a media file |
 
@@ -219,12 +238,33 @@ Available blend modes: `normal`, `add`, `multiply`, `screen`, `overlay`, `darken
 ### Media
 
 ```bash
+media download-instagram <url> -o <output.mp4> [--overwrite]
+media transcribe <file-or-url> [--speed 2.0] [--model voxtral-mini-latest] [-o transcript.json]
+media add-subtitles <video> --transcript transcript.json -o subtitled.mp4 [--overwrite]
+media tts "Hello from Shotcut" --voice <id> -o speech.mp3
+media tts --text-file script.txt --voice <id> -o speech.mp3
+media tts "Hello locally" --provider local --voice-sample my-voice.wav -o speech.wav
 media import <file> [--caption name]               # Import media into project bin
 media list                                         # List media in project
 media probe <file>                                 # Analyze media file
 media check                                        # Check all files exist
 media thumbnail <file> -o <output> [--time tc]     # Extract thumbnail
 ```
+
+Install the optional transcription dependency with `pip install cli-anything-shotcut[transcription]`.
+Install local XTTS support with `pip install cli-anything-shotcut[local-tts]`.
+Local XTTS uses a reference recording and requires `--format wav`; use `--language`
+for non-English speech and `--device mps` to force Apple Silicon acceleration.
+Instagram downloads use BrightData and require `BRIGHT_DATA_API_KEY`.
+
+Transcription always writes a JSON sidecar with timestamped segments. For a
+local video, the default path is `<video>.transcript.json`; use `-o` to choose
+another path. Segment timestamps are mapped back to the original video when
+the cost-saving 2x audio speed is used.
+
+Use `media add-subtitles` with that sidecar to burn bold, centered, outlined ASS
+captions into a rendered MP4. The command requires ffmpeg with the subtitles
+filter enabled.
 
 ### Export
 

--- a/shotcut/agent-harness/cli_anything/shotcut/core/credentials.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/credentials.py
@@ -1,0 +1,70 @@
+"""Credential providers for secrets that must stay outside the repository."""
+
+import os
+import shutil
+import subprocess
+from typing import Callable, Protocol
+
+
+class CredentialProvider(Protocol):
+    def get(self, name: str) -> str | None:
+        """Return a credential without displaying it."""
+
+
+class EnvironmentCredentialProvider:
+    def get(self, name: str) -> str | None:
+        value = os.getenv(name)
+        return value or None
+
+
+class MacOSKeychainCredentialProvider:
+    ACCOUNT = "cli-anything-shotcut"
+
+    def __init__(
+        self,
+        account: str = ACCOUNT,
+        executable: str | None = None,
+        runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    ) -> None:
+        self._account = account
+        self._executable = executable or shutil.which("security")
+        self._runner = runner
+
+    def get(self, name: str) -> str | None:
+        if self._executable is None:
+            return None
+        try:
+            result = self._runner(
+                [
+                    self._executable,
+                    "find-generic-password",
+                    "-a",
+                    self._account,
+                    "-s",
+                    name,
+                    "-w",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            return None
+        if result.returncode != 0:
+            return None
+        value = result.stdout.strip()
+        return value or None
+
+
+class CompositeCredentialProvider:
+    def __init__(self, providers: list[CredentialProvider]) -> None:
+        self._providers = providers
+
+    def get_required(self, name: str) -> str:
+        for provider in self._providers:
+            value = provider.get(name)
+            if value:
+                return value
+        raise RuntimeError(
+            f"Credential {name} was not found in the environment or macOS Keychain"
+        )

--- a/shotcut/agent-harness/cli_anything/shotcut/core/export.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/export.py
@@ -2,7 +2,6 @@
 
 import os
 import subprocess
-import shutil
 from typing import Optional
 
 from ..utils import mlt_xml
@@ -172,12 +171,8 @@ def render(session: Session, output_path: str,
         available = ", ".join(sorted(EXPORT_PRESETS.keys()))
         raise ValueError(f"Unknown preset: {preset!r}. Available: {available}")
 
-    melt = shutil.which("melt")
-    if not melt:
-        raise RuntimeError(
-            "melt is required for rendering but not found. "
-            "Install it with: apt install melt  (or equivalent for your OS)"
-        )
+    from ..utils.melt_backend import find_melt
+    melt = find_melt()
     # No ffmpeg fallback — melt is the only render path because it natively
     # reads MLT XML and handles all project features (transitions, compositing,
     # multi-track). Direct ffmpeg encoding cannot interpret MLT projects.

--- a/shotcut/agent-harness/cli_anything/shotcut/core/media_download/__init__.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/media_download/__init__.py
@@ -1,0 +1,13 @@
+"""Platform-neutral media download services."""
+
+from .models import DownloadRequest, DownloadResult, ResolvedMedia
+from .registry import MediaResolverRegistry
+from .service import MediaDownloadService
+
+__all__ = [
+    "DownloadRequest",
+    "DownloadResult",
+    "MediaDownloadService",
+    "MediaResolverRegistry",
+    "ResolvedMedia",
+]

--- a/shotcut/agent-harness/cli_anything/shotcut/core/media_download/adapters/__init__.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/media_download/adapters/__init__.py
@@ -1,0 +1,6 @@
+"""Concrete media download adapters."""
+
+from .brightdata_api_client import BrightDataApiClient
+from .http_file_downloader import HttpFileDownloader
+
+__all__ = ["BrightDataApiClient", "HttpFileDownloader"]

--- a/shotcut/agent-harness/cli_anything/shotcut/core/media_download/adapters/brightdata_api_client.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/media_download/adapters/brightdata_api_client.py
@@ -1,0 +1,115 @@
+"""BrightData dataset API adapter."""
+
+import json
+import time
+from collections.abc import Callable
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+class BrightDataApiClient:
+    TRIGGER_URL = "https://api.brightdata.com/datasets/v3/trigger"
+    SNAPSHOT_URL = "https://api.brightdata.com/datasets/v3/snapshot/{snapshot_id}"
+
+    def __init__(
+        self,
+        api_key: str,
+        timeout_seconds: float = 60.0,
+        retry_count: int = 60,
+        poll_interval_seconds: float = 2.0,
+        opener: Callable[..., object] | None = None,
+        sleeper: Callable[[float], None] | None = None,
+    ) -> None:
+        if not api_key.strip():
+            raise ValueError("BRIGHT_DATA_API_KEY is required for Instagram downloads")
+        if retry_count < 1:
+            raise ValueError("BrightData retry_count must be at least 1")
+        self._api_key = api_key
+        self._timeout_seconds = timeout_seconds
+        self._retry_count = retry_count
+        self._poll_interval_seconds = poll_interval_seconds
+        self._opener = opener or urlopen
+        self._sleeper = sleeper or time.sleep
+
+    def trigger(self, dataset_id: str, source_url: str) -> str:
+        response = self._request(
+            "POST",
+            self.TRIGGER_URL,
+            params={
+                "dataset_id": dataset_id,
+                "format": "json",
+                "uncompressed_webhook": "true",
+                "include_errors": "false",
+            },
+            payload=[{"url": source_url}],
+        )
+        snapshot_id = response.get("snapshot_id")
+        if not isinstance(snapshot_id, str) or not snapshot_id:
+            raise RuntimeError("BrightData did not return a snapshot ID")
+        return snapshot_id
+
+    def wait_for_snapshot(self, snapshot_id: str) -> list[dict[str, object]]:
+        for attempt in range(self._retry_count):
+            response = self._request(
+                "GET",
+                self.SNAPSHOT_URL.format(snapshot_id=snapshot_id),
+                params={"format": "json"},
+            )
+            records = self._extract_records(response)
+            if records is not None:
+                return records
+
+            status = response.get("status")
+            if status == "failed":
+                message = response.get("message") or "BrightData snapshot failed"
+                raise RuntimeError(str(message))
+            if status == "ready":
+                raise RuntimeError("BrightData snapshot was ready but contained no data")
+            if attempt < self._retry_count - 1:
+                self._sleeper(self._poll_interval_seconds)
+
+        raise TimeoutError(
+            f"BrightData snapshot did not finish after {self._retry_count} attempts"
+        )
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        params: dict[str, str],
+        payload: object | None = None,
+    ) -> dict[str, object] | list[object]:
+        request_url = f"{url}?{urlencode(params)}"
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = Request(
+            request_url,
+            data=body,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with self._opener(request, timeout=self._timeout_seconds) as response:
+                parsed = json.loads(response.read().decode("utf-8"))
+        except Exception as error:
+            raise RuntimeError(f"BrightData request failed: {error}") from error
+        if not isinstance(parsed, (dict, list)):
+            raise RuntimeError("BrightData returned an invalid JSON response")
+        return parsed
+
+    @staticmethod
+    def _extract_records(
+        response: dict[str, object] | list[object],
+    ) -> list[dict[str, object]] | None:
+        records: object = response
+        if isinstance(response, dict) and isinstance(response.get("data"), list):
+            records = response["data"]
+        if not isinstance(records, list):
+            return None
+        if not records:
+            raise RuntimeError("BrightData returned an empty snapshot")
+        if not all(isinstance(record, dict) for record in records):
+            raise RuntimeError("BrightData returned an invalid snapshot record")
+        return records  # type: ignore[return-value]

--- a/shotcut/agent-harness/cli_anything/shotcut/core/media_download/adapters/http_file_downloader.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/media_download/adapters/http_file_downloader.py
@@ -1,0 +1,30 @@
+"""Generic HTTP file downloader."""
+
+import os
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+
+class HttpFileDownloader:
+    def __init__(self, timeout_seconds: float = 60.0) -> None:
+        self._timeout_seconds = timeout_seconds
+
+    def download(self, source_url: str, output_path: Path, overwrite: bool = False) -> Path:
+        output_path = output_path.expanduser().resolve()
+        if output_path.exists() and not overwrite:
+            raise FileExistsError(f"Output file already exists: {output_path}")
+        if not output_path.parent.is_dir():
+            raise FileNotFoundError(f"Output directory not found: {output_path.parent}")
+
+        partial_path = output_path.with_name(f".{output_path.name}.part")
+        request = Request(source_url, headers={"User-Agent": "cli-anything-shotcut"})
+        try:
+            with urlopen(request, timeout=self._timeout_seconds) as response:
+                with partial_path.open("wb") as output_file:
+                    while chunk := response.read(1024 * 1024):
+                        output_file.write(chunk)
+            os.replace(partial_path, output_path)
+        except Exception:
+            partial_path.unlink(missing_ok=True)
+            raise
+        return output_path

--- a/shotcut/agent-harness/cli_anything/shotcut/core/media_download/adapters/platforms/__init__.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/media_download/adapters/platforms/__init__.py
@@ -1,0 +1,5 @@
+"""Platform-specific media resolvers."""
+
+from .instagram_video_resolver import BrightDataInstagramVideoResolver
+
+__all__ = ["BrightDataInstagramVideoResolver"]

--- a/shotcut/agent-harness/cli_anything/shotcut/core/media_download/adapters/platforms/instagram_video_resolver.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/media_download/adapters/platforms/instagram_video_resolver.py
@@ -1,0 +1,70 @@
+"""BrightData-backed Instagram video resolver."""
+
+from urllib.parse import urlparse
+
+from ...models import ResolvedMedia
+from ...ports import BrightDataApi
+
+
+class BrightDataInstagramVideoResolver:
+    platform = "instagram"
+    INSTAGRAM_POST_DATASET = "gd_lk5ns7kz21pck8jpis"
+    INSTAGRAM_REEL_DATASET = "gd_lyclm20il4r5helnj"
+
+    def __init__(self, brightdata_api: BrightDataApi) -> None:
+        self._brightdata_api = brightdata_api
+
+    def can_resolve(self, source_url: str) -> bool:
+        parsed = urlparse(source_url)
+        hostname = (parsed.hostname or "").lower()
+        path = parsed.path.rstrip("/")
+        return (
+            hostname == "instagram.com" or hostname.endswith(".instagram.com")
+        ) and any(path.startswith(prefix) for prefix in ("/p/", "/reel/", "/reels/"))
+
+    def resolve(self, source_url: str) -> ResolvedMedia:
+        normalized_url, dataset_id = self._normalize_source(source_url)
+        snapshot_id = self._brightdata_api.trigger(dataset_id, normalized_url)
+        records = self._brightdata_api.wait_for_snapshot(snapshot_id)
+        media_url = self._find_video_url(records)
+        return ResolvedMedia(
+            source_url=source_url,
+            media_url=media_url,
+            platform=self.platform,
+        )
+
+    def _normalize_source(self, source_url: str) -> tuple[str, str]:
+        parsed = urlparse(source_url)
+        path = parsed.path.replace("/reels/", "/reel/", 1)
+        normalized_url = parsed._replace(path=path).geturl()
+        if path.startswith("/p/"):
+            return normalized_url, self.INSTAGRAM_POST_DATASET
+        if path.startswith("/reel/"):
+            return normalized_url, self.INSTAGRAM_REEL_DATASET
+        raise ValueError("Instagram URL must point to a post or reel")
+
+    @staticmethod
+    def _find_video_url(records: list[dict[str, object]]) -> str:
+        for record in records:
+            video_url = record.get("video_url")
+            if isinstance(video_url, str) and video_url:
+                return video_url
+
+            for item in record.get("post_content", []):
+                if isinstance(item, dict):
+                    item_type = str(item.get("type", "")).lower()
+                    item_url = item.get("url")
+                    if item_type == "video" and isinstance(item_url, str) and item_url:
+                        return item_url
+
+            videos = record.get("videos", [])
+            if isinstance(videos, list):
+                for item in videos:
+                    if isinstance(item, str) and item:
+                        return item
+                    if isinstance(item, dict):
+                        item_url = item.get("url")
+                        if isinstance(item_url, str) and item_url:
+                            return item_url
+
+        raise RuntimeError("BrightData did not return a video URL for this Instagram URL")

--- a/shotcut/agent-harness/cli_anything/shotcut/core/media_download/models.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/media_download/models.py
@@ -1,0 +1,35 @@
+"""Framework-neutral media download models."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DownloadRequest:
+    source_url: str
+    output_path: Path
+    overwrite: bool = False
+
+
+@dataclass(frozen=True)
+class ResolvedMedia:
+    source_url: str
+    media_url: str
+    platform: str
+    media_type: str = "video"
+
+
+@dataclass(frozen=True)
+class DownloadResult:
+    source_url: str
+    output_path: Path
+    platform: str
+    media_type: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "source_url": self.source_url,
+            "output_path": str(self.output_path),
+            "platform": self.platform,
+            "media_type": self.media_type,
+        }

--- a/shotcut/agent-harness/cli_anything/shotcut/core/media_download/ports.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/media_download/ports.py
@@ -1,0 +1,29 @@
+"""Dependency-injection ports for media downloading."""
+
+from pathlib import Path
+from typing import Protocol
+
+from .models import ResolvedMedia
+
+
+class MediaResolver(Protocol):
+    platform: str
+
+    def can_resolve(self, source_url: str) -> bool:
+        """Return whether this resolver supports the source URL."""
+
+    def resolve(self, source_url: str) -> ResolvedMedia:
+        """Resolve a platform URL to a direct media URL."""
+
+
+class FileDownloader(Protocol):
+    def download(self, source_url: str, output_path: Path, overwrite: bool = False) -> Path:
+        """Download a direct media URL to a local file."""
+
+
+class BrightDataApi(Protocol):
+    def trigger(self, dataset_id: str, source_url: str) -> str:
+        """Start a BrightData dataset job and return its snapshot ID."""
+
+    def wait_for_snapshot(self, snapshot_id: str) -> list[dict[str, object]]:
+        """Wait for and return BrightData snapshot records."""

--- a/shotcut/agent-harness/cli_anything/shotcut/core/media_download/registry.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/media_download/registry.py
@@ -1,0 +1,15 @@
+"""Media resolver registry."""
+
+from .models import ResolvedMedia
+from .ports import MediaResolver
+
+
+class MediaResolverRegistry:
+    def __init__(self, resolvers: list[MediaResolver]) -> None:
+        self._resolvers = resolvers
+
+    def resolve(self, source_url: str) -> ResolvedMedia:
+        for resolver in self._resolvers:
+            if resolver.can_resolve(source_url):
+                return resolver.resolve(source_url)
+        raise ValueError(f"No media resolver supports URL: {source_url}")

--- a/shotcut/agent-harness/cli_anything/shotcut/core/media_download/service.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/media_download/service.py
@@ -1,0 +1,34 @@
+"""Generic media download application service."""
+
+from .models import DownloadRequest, DownloadResult
+from .ports import FileDownloader
+from .registry import MediaResolverRegistry
+
+
+class MediaDownloadService:
+    """Resolve a platform URL and download its direct media resource."""
+
+    def __init__(
+        self,
+        resolver_registry: MediaResolverRegistry,
+        file_downloader: FileDownloader,
+    ) -> None:
+        self._resolver_registry = resolver_registry
+        self._file_downloader = file_downloader
+
+    def download(self, request: DownloadRequest) -> DownloadResult:
+        if not request.source_url.strip():
+            raise ValueError("Media source URL cannot be empty")
+
+        resolved_media = self._resolver_registry.resolve(request.source_url)
+        output_path = self._file_downloader.download(
+            resolved_media.media_url,
+            request.output_path,
+            request.overwrite,
+        )
+        return DownloadResult(
+            source_url=resolved_media.source_url,
+            output_path=output_path,
+            platform=resolved_media.platform,
+            media_type=resolved_media.media_type,
+        )

--- a/shotcut/agent-harness/cli_anything/shotcut/core/project.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/project.py
@@ -8,6 +8,13 @@ from .session import Session
 
 # Standard video profiles
 PROFILES = {
+    "vertical1080p30": {
+        "width": "1080", "height": "1920",
+        "frame_rate_num": "30000", "frame_rate_den": "1001",
+        "sample_aspect_num": "1", "sample_aspect_den": "1",
+        "display_aspect_num": "9", "display_aspect_den": "16",
+        "progressive": "1", "colorspace": "709",
+    },
     "hd1080p30": {
         "width": "1920", "height": "1080",
         "frame_rate_num": "30000", "frame_rate_den": "1001",

--- a/shotcut/agent-harness/cli_anything/shotcut/core/session.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/session.py
@@ -199,6 +199,11 @@ class Session:
         if not save_path:
             raise RuntimeError("No save path specified and project has no path")
         save_path = os.path.abspath(save_path)
+        # Mutations normally refresh this value, but saving must also make
+        # projects created through older sessions/render workflows valid.
+        from .timeline import _update_tractor_out
+        if self.main_tractor is not None:
+            _update_tractor_out(self)
         mlt_xml.write_mlt(self.root, save_path)
         self.project_path = save_path
         self._modified = False

--- a/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/__init__.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/__init__.py
@@ -1,0 +1,4 @@
+from .models import SubtitleRequest, SubtitleResult
+from .service import SubtitleService
+
+__all__ = ["SubtitleRequest", "SubtitleResult", "SubtitleService"]

--- a/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/adapters/__init__.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/adapters/__init__.py
@@ -1,0 +1,3 @@
+from .ffmpeg_subtitle_renderer import FfmpegSubtitleRenderer
+
+__all__ = ["FfmpegSubtitleRenderer"]

--- a/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/adapters/ffmpeg_subtitle_renderer.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/adapters/ffmpeg_subtitle_renderer.py
@@ -1,0 +1,19 @@
+"""ffmpeg subtitle renderer."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+class FfmpegSubtitleRenderer:
+    """Burn ASS subtitles into a video using ffmpeg's subtitles filter."""
+
+    def __init__(self, executable: str | None = None) -> None:
+        self._executable = executable or shutil.which("ffmpeg") or "ffmpeg"
+
+    def render(self, video_path: Path, ass_path: Path, output_path: Path, overwrite: bool) -> None:
+        command = [self._executable, "-y" if overwrite else "-n", "-i", str(video_path), "-vf", f"subtitles={ass_path}", "-c:a", "copy", str(output_path)]
+        completed = subprocess.run(command, capture_output=True, text=True)
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or "ffmpeg failed"
+            raise RuntimeError(detail)

--- a/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/models.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/models.py
@@ -1,0 +1,35 @@
+"""Models for rendering timed subtitles onto a video."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..transcription.models import TranscriptSegment
+
+
+@dataclass(frozen=True)
+class SubtitleRequest:
+    video_path: Path
+    transcript_path: Path
+    output_path: Path
+    overwrite: bool = False
+
+
+@dataclass(frozen=True)
+class SubtitleResult:
+    video_path: Path
+    transcript_path: Path
+    output_path: Path
+    subtitle_count: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "video_path": str(self.video_path),
+            "transcript_path": str(self.transcript_path),
+            "output_path": str(self.output_path),
+            "subtitle_count": self.subtitle_count,
+        }
+
+
+@dataclass(frozen=True)
+class SubtitleDocument:
+    segments: tuple[TranscriptSegment, ...]

--- a/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/ports.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/ports.py
@@ -1,0 +1,9 @@
+"""Dependency-injection ports for subtitle rendering."""
+
+from pathlib import Path
+from typing import Protocol
+
+
+class SubtitleRenderer(Protocol):
+    def render(self, video_path: Path, ass_path: Path, output_path: Path, overwrite: bool) -> None:
+        """Burn an ASS subtitle file into a video."""

--- a/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/service.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/subtitles/service.py
@@ -1,0 +1,95 @@
+"""Subtitle generation and rendering application service."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from ..transcription.models import TranscriptSegment
+from .models import SubtitleDocument, SubtitleRequest, SubtitleResult
+from .ports import SubtitleRenderer
+
+
+class SubtitleService:
+    """Read timestamped transcript segments and burn them into a video."""
+
+    def __init__(self, renderer: SubtitleRenderer) -> None:
+        self._renderer = renderer
+
+    def add_subtitles(self, request: SubtitleRequest) -> SubtitleResult:
+        video_path = self._existing_file(request.video_path, "Video")
+        transcript_path = self._existing_file(request.transcript_path, "Transcript")
+        document = self._load_document(transcript_path)
+        output_path = request.output_path.expanduser().resolve()
+        if output_path.exists() and not request.overwrite:
+            raise FileExistsError(f"Output file already exists: {output_path}")
+        if not output_path.parent.is_dir():
+            raise FileNotFoundError(f"Output directory not found: {output_path.parent}")
+
+        with tempfile.TemporaryDirectory(prefix="shotcut-subtitles-") as directory:
+            ass_path = Path(directory) / "subtitles.ass"
+            ass_path.write_text(self._to_ass(document), encoding="utf-8")
+            self._renderer.render(video_path, ass_path, output_path, request.overwrite)
+
+        return SubtitleResult(video_path, transcript_path, output_path, len(document.segments))
+
+    @staticmethod
+    def _existing_file(path: Path, label: str) -> Path:
+        resolved = path.expanduser().resolve()
+        if not resolved.is_file():
+            raise FileNotFoundError(f"{label} file not found: {resolved}")
+        return resolved
+
+    @classmethod
+    def _load_document(cls, path: Path) -> SubtitleDocument:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            raise ValueError(f"Invalid transcript JSON: {path}") from error
+        segments = []
+        for index, item in enumerate(payload.get("segments", [])):
+            try:
+                start = float(item["start_seconds"])
+                end = float(item["end_seconds"])
+                text = str(item["text"]).strip()
+            except (KeyError, TypeError, ValueError) as error:
+                raise ValueError(f"Invalid transcript segment at index {index}") from error
+            if start < 0 or end <= start or not text:
+                raise ValueError(f"Invalid transcript segment at index {index}")
+            segments.append(TranscriptSegment(start, end, text))
+        if not segments:
+            raise ValueError(f"Transcript contains no subtitle segments: {path}")
+        return SubtitleDocument(tuple(segments))
+
+    @classmethod
+    def _to_ass(cls, document: SubtitleDocument) -> str:
+        lines = [
+            "[Script Info]",
+            "ScriptType: v4.00+",
+            "PlayResX: 1920",
+            "PlayResY: 1080",
+            "ScaledBorderAndShadow: yes",
+            "",
+            "[V4+ Styles]",
+            "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding",
+            "Style: Default,Arial,64,&H00FFFFFF,&H00FFFFFF,&H00000000,&H99000000,-1,0,0,0,100,100,0,0,1,3,1,2,80,80,100,1",
+            "",
+            "[Events]",
+            "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",
+        ]
+        lines.extend(
+            f"Dialogue: 0,{cls._time(segment.start_seconds)},{cls._time(segment.end_seconds)},Default,,0,0,0,,{cls._escape(segment.text)}"
+            for segment in document.segments
+        )
+        return "\n".join(lines) + "\n"
+
+    @staticmethod
+    def _time(seconds: float) -> str:
+        total_centiseconds = round(seconds * 100)
+        hours, remainder = divmod(total_centiseconds, 360000)
+        minutes, remainder = divmod(remainder, 6000)
+        whole_seconds, centiseconds = divmod(remainder, 100)
+        return f"{hours}:{minutes:02d}:{whole_seconds:02d}.{centiseconds:02d}"
+
+    @staticmethod
+    def _escape(text: str) -> str:
+        return text.replace("\\", r"\\").replace("{", r"\{").replace("}", r"\}").replace("\n", r"\N")

--- a/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/__init__.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/__init__.py
@@ -1,0 +1,6 @@
+"""Text-to-speech use case and provider integrations."""
+
+from .models import TextToSpeechRequest, TextToSpeechResult
+from .service import TextToSpeechService
+
+__all__ = ["TextToSpeechRequest", "TextToSpeechResult", "TextToSpeechService"]

--- a/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/adapters/__init__.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/adapters/__init__.py
@@ -1,0 +1,6 @@
+"""Text-to-speech provider adapters."""
+
+from .elevenlabs_provider import ElevenLabsTextToSpeech
+from .xtts_provider import XTTSVoiceProvider
+
+__all__ = ["ElevenLabsTextToSpeech", "XTTSVoiceProvider"]

--- a/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/adapters/elevenlabs_provider.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/adapters/elevenlabs_provider.py
@@ -1,0 +1,50 @@
+"""ElevenLabs text-to-speech HTTP adapter."""
+
+import json
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+class ElevenLabsTextToSpeech:
+    """Synthesize speech through the ElevenLabs REST API."""
+
+    BASE_URL = "https://api.elevenlabs.io/v1/text-to-speech"
+
+    def __init__(self, api_key: str, timeout_seconds: float = 60.0) -> None:
+        if not api_key.strip():
+            raise ValueError("ELEVENLABS_API_KEY is required for text-to-speech")
+        self._api_key = api_key
+        self._timeout_seconds = timeout_seconds
+
+    def synthesize(
+        self,
+        text: str,
+        voice_id: str | None,
+        model: str,
+        output_format: str,
+        voice_sample: Path | None,
+        language: str,
+    ) -> bytes:
+        if not voice_id or voice_sample is not None:
+            raise ValueError("ElevenLabs requires a voice ID and no local voice sample")
+        request = Request(
+            f"{self.BASE_URL}/{voice_id}?output_format={output_format}",
+            data=json.dumps({"text": text, "model_id": model}).encode("utf-8"),
+            headers={
+                "Accept": "audio/mpeg",
+                "Content-Type": "application/json",
+                "xi-api-key": self._api_key,
+            },
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=self._timeout_seconds) as response:
+                return response.read()
+        except HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"ElevenLabs synthesis failed ({error.code}): {detail}"
+            ) from error
+        except URLError as error:
+            raise RuntimeError(f"ElevenLabs connection failed: {error.reason}") from error

--- a/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/adapters/xtts_provider.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/adapters/xtts_provider.py
@@ -1,0 +1,62 @@
+"""Local Coqui XTTS v2 text-to-speech adapter."""
+
+import tempfile
+from pathlib import Path
+
+
+class XTTSVoiceProvider:
+    """Generate speech locally from a reference speaker recording."""
+
+    MODEL = "tts_models/multilingual/multi-dataset/xtts_v2"
+
+    def __init__(self, device: str = "auto", model: str = MODEL) -> None:
+        self._device = self._resolve_device(device)
+        self.model = model
+
+    def synthesize(
+        self,
+        text: str,
+        voice_id: str | None,
+        model: str,
+        output_format: str,
+        voice_sample: Path | None,
+        language: str,
+    ) -> bytes:
+        if voice_sample is None:
+            raise ValueError("Local XTTS requires --voice-sample")
+        sample = voice_sample.expanduser().resolve()
+        if not sample.is_file():
+            raise FileNotFoundError(f"Voice sample not found: {sample}")
+        if output_format != "wav":
+            raise ValueError("Local XTTS currently supports only --format wav")
+
+        try:
+            from TTS.api import TTS
+        except ImportError as error:
+            raise RuntimeError(
+                "Local XTTS requires Coqui TTS. Install it with: "
+                "pip install coqui-tts"
+            ) from error
+
+        synthesizer = TTS(model_name=model, progress_bar=False).to(self._device)
+        with tempfile.TemporaryDirectory(prefix="shotcut-xtts-") as directory:
+            output_path = Path(directory) / "speech.wav"
+            synthesizer.tts_to_file(
+                text=text,
+                speaker_wav=[str(sample)],
+                language=language,
+                file_path=str(output_path),
+            )
+            return output_path.read_bytes()
+
+    @staticmethod
+    def _resolve_device(device: str) -> str:
+        if device not in {"auto", "cpu", "mps"}:
+            raise ValueError("XTTS device must be auto, cpu, or mps")
+        if device != "auto":
+            return device
+        try:
+            import torch
+        except ImportError:
+            return "cpu"
+        return "mps" if torch.backends.mps.is_available() else "cpu"

--- a/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/models.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/models.py
@@ -1,0 +1,37 @@
+"""Framework-neutral text-to-speech models."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TextToSpeechRequest:
+    """Input accepted by the text-to-speech use case."""
+
+    text: str
+    voice_id: str | None
+    output_path: Path
+    model: str = "eleven_multilingual_v2"
+    output_format: str = "mp3_44100_128"
+    voice_sample: Path | None = None
+    language: str = "en"
+
+
+@dataclass(frozen=True)
+class TextToSpeechResult:
+    """Provider-independent text-to-speech response."""
+
+    output_path: Path
+    voice_id: str | None
+    model: str
+    output_format: str
+    character_count: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "output_path": str(self.output_path),
+            "voice_id": self.voice_id,
+            "model": self.model,
+            "output_format": self.output_format,
+            "character_count": self.character_count,
+        }

--- a/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/ports.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/ports.py
@@ -1,0 +1,17 @@
+"""Dependency-injection ports for text-to-speech."""
+
+from pathlib import Path
+from typing import Protocol
+
+
+class TextToSpeechProvider(Protocol):
+    def synthesize(
+        self,
+        text: str,
+        voice_id: str | None,
+        model: str,
+        output_format: str,
+        voice_sample: Path | None,
+        language: str,
+    ) -> bytes:
+        """Return synthesized audio bytes."""

--- a/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/service.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/text_to_speech/service.py
@@ -1,0 +1,41 @@
+"""Text-to-speech application service."""
+
+from pathlib import Path
+
+from .models import TextToSpeechRequest, TextToSpeechResult
+from .ports import TextToSpeechProvider
+
+
+class TextToSpeechService:
+    """Coordinate synthesis and persistence without knowing the provider."""
+
+    def __init__(self, provider: TextToSpeechProvider) -> None:
+        self._provider = provider
+
+    def synthesize(self, request: TextToSpeechRequest) -> TextToSpeechResult:
+        self._validate_request(request)
+        audio = self._provider.synthesize(
+            request.text,
+            request.voice_id,
+            request.model,
+            request.output_format,
+            request.voice_sample,
+            request.language,
+        )
+        output_path = request.output_path.expanduser().resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(audio)
+        return TextToSpeechResult(
+            output_path=output_path,
+            voice_id=request.voice_id,
+            model=request.model,
+            output_format=request.output_format,
+            character_count=len(request.text),
+        )
+
+    @staticmethod
+    def _validate_request(request: TextToSpeechRequest) -> None:
+        if not request.text.strip():
+            raise ValueError("Text-to-speech text cannot be empty")
+        if not request.output_path.name:
+            raise ValueError("Text-to-speech output path must include a filename")

--- a/shotcut/agent-harness/cli_anything/shotcut/core/timeline.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/timeline.py
@@ -441,10 +441,11 @@ def add_clip(session: Session, clip_id: str, track_index: int,
              position: Optional[int] = None,
              at_time: Optional[str] = None,
              caption: Optional[str] = None) -> dict:
-    """Add a clip to a track by referencing an imported media clip_id.
+    """Add an independently editable clip instance to a track.
 
-    The timeline chain is shared — same clip_id always maps to the same chain.
-    Each call creates a new playlist entry with its own in/out range.
+    Each call creates a unique timeline chain while reusing the imported
+    media resource. Shotcut uses the chain identity when editing a clip, so
+    timeline occurrences must not share one chain.
     """
     if position is not None and at_time is not None:
         raise ValueError("Cannot specify both position and at_time")
@@ -460,27 +461,24 @@ def add_clip(session: Session, clip_id: str, track_index: int,
     resource = mlt_xml.get_property(bin_chain, "resource", "")
     session.checkpoint()
 
-    # Reuse timeline chain for same clip_id
-    timeline_chain_id = f"tl_{clip_id}"
-    timeline_chain = mlt_xml.find_element_by_id(session.root, timeline_chain_id)
-
-    if timeline_chain is None or mlt_xml.get_parent(timeline_chain) is None:
-        length_tc = mlt_xml.get_property(bin_chain, "length")
-        source_out = bin_chain.get("out") or length_tc
-        video_index = mlt_xml.get_property(bin_chain, "video_index") or "0"
-        audio_index = mlt_xml.get_property(bin_chain, "audio_index") or "1"
-
-        timeline_chain = mlt_xml.create_chain(
-            session.root, resource,
-            in_point="00:00:00.000",
-            out_point=source_out,
-            caption=caption or os.path.basename(resource),
-            extra_props={"video_index": video_index, "audio_index": audio_index},
-            insert_idx=session._timeline_insert_idx,
-            length=length_tc,
-            id_override=timeline_chain_id,
-        )
-        session._timeline_insert_idx += 1
+    length_tc = mlt_xml.get_property(bin_chain, "length")
+    source_out = bin_chain.get("out") or length_tc
+    video_index = mlt_xml.get_property(bin_chain, "video_index") or "0"
+    audio_index = mlt_xml.get_property(bin_chain, "audio_index") or "1"
+    timeline_chain = mlt_xml.create_chain(
+        session.root, resource,
+        in_point="00:00:00.000",
+        out_point=source_out,
+        caption=caption or os.path.basename(resource),
+        extra_props={
+            "video_index": video_index,
+            "audio_index": audio_index,
+            "shotcut:uuid": uuid.uuid4().hex,
+        },
+        insert_idx=session._timeline_insert_idx,
+        length=length_tc,
+    )
+    session._timeline_insert_idx += 1
 
     playlist = _get_track_playlist(session, track_index)
     final_in = in_point or timeline_chain.get("in", "00:00:00.000")

--- a/shotcut/agent-harness/cli_anything/shotcut/core/transcription/__init__.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/transcription/__init__.py
@@ -1,0 +1,6 @@
+"""Reusable video transcription service and adapters."""
+
+from .models import TranscriptionRequest, TranscriptionResult
+from .service import TranscriptionService
+
+__all__ = ["TranscriptionRequest", "TranscriptionResult", "TranscriptionService"]

--- a/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/__init__.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/__init__.py
@@ -1,0 +1,15 @@
+"""Concrete transcription infrastructure adapters."""
+
+from .ffmpeg_audio_extractor import FfmpegAudioExtractor
+from .http_video_downloader import HttpVideoDownloader
+from .mistral_transcriber import MistralTranscriber
+from .json_transcription_writer import JsonTranscriptionWriter
+from .temporary_workspace import TemporaryWorkspaceProvider
+
+__all__ = [
+    "FfmpegAudioExtractor",
+    "HttpVideoDownloader",
+    "MistralTranscriber",
+    "JsonTranscriptionWriter",
+    "TemporaryWorkspaceProvider",
+]

--- a/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/ffmpeg_audio_extractor.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/ffmpeg_audio_extractor.py
@@ -1,0 +1,36 @@
+"""ffmpeg-based audio extraction adapter."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+class FfmpegAudioExtractor:
+    def __init__(self, executable: str | None = None, timeout_seconds: float = 300.0) -> None:
+        self._executable = executable or shutil.which("ffmpeg")
+        self._timeout_seconds = timeout_seconds
+        if self._executable is None:
+            raise FileNotFoundError("ffmpeg is required for transcription")
+
+    def extract(self, video_path: Path, audio_path: Path, playback_speed: float) -> Path:
+        result = subprocess.run(
+            [
+                self._executable,
+                "-y",
+                "-i",
+                str(video_path),
+                "-vn",
+                "-af",
+                f"atempo={playback_speed:g}",
+                "-acodec",
+                "libmp3lame",
+                str(audio_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=self._timeout_seconds,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or "ffmpeg failed to extract audio"
+            raise RuntimeError(detail)
+        return audio_path

--- a/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/http_video_downloader.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/http_video_downloader.py
@@ -1,0 +1,15 @@
+"""HTTP video download adapter."""
+
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+
+class HttpVideoDownloader:
+    def __init__(self, timeout_seconds: float = 30.0) -> None:
+        self._timeout_seconds = timeout_seconds
+
+    def download(self, source: str, destination: Path) -> Path:
+        request = Request(source, headers={"User-Agent": "cli-anything-shotcut"})
+        with urlopen(request, timeout=self._timeout_seconds) as response:
+            destination.write_bytes(response.read())
+        return destination

--- a/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/json_transcription_writer.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/json_transcription_writer.py
@@ -1,0 +1,39 @@
+"""JSON transcription artifact writer."""
+
+import json
+import os
+from pathlib import Path
+
+from ..models import TranscriptionResult
+
+
+class JsonTranscriptionWriter:
+    def write(self, result: TranscriptionResult, output_path: Path) -> Path:
+        output_path = output_path.expanduser().resolve()
+        if not output_path.parent.is_dir():
+            raise FileNotFoundError(f"Transcript directory not found: {output_path.parent}")
+
+        temporary_path = output_path.with_name(f".{output_path.name}.tmp")
+        try:
+            temporary_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "source": result.source,
+                        "model": result.model,
+                        "language": result.language,
+                        "playback_speed": result.playback_speed,
+                        "timestamps_are_original_video_seconds": True,
+                        "text": result.text,
+                        "segments": [segment.to_dict() for segment in result.segments],
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            os.replace(temporary_path, output_path)
+        except Exception:
+            temporary_path.unlink(missing_ok=True)
+            raise
+        return output_path

--- a/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/mistral_transcriber.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/mistral_transcriber.py
@@ -1,0 +1,63 @@
+"""Mistral Voxtral transcription adapter."""
+
+from pathlib import Path
+
+from ..models import ProviderTranscription, TranscriptSegment
+
+
+class MistralTranscriber:
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "voxtral-mini-latest",
+        timeout_ms: int = 60_000,
+    ) -> None:
+        if not api_key.strip():
+            raise ValueError("MISTRAL_API_KEY is required for transcription")
+        self._api_key = api_key
+        self.model = model
+        self._timeout_ms = timeout_ms
+
+    def transcribe(self, audio_path: Path) -> ProviderTranscription:
+        try:
+            from mistralai.client import Mistral
+            from mistralai.client.models import File
+        except ImportError as error:
+            raise RuntimeError(
+                "Mistral transcription requires the transcription extra: "
+                "pip install cli-anything-shotcut[transcription]"
+            ) from error
+
+        with audio_path.open("rb") as audio_file:
+            with Mistral(api_key=self._api_key, timeout_ms=self._timeout_ms) as client:
+                response = client.audio.transcriptions.complete(
+                    model=self.model,
+                    file=File(content=audio_file.read(), fileName=audio_path.name),
+                    timestamp_granularities=["segment"],
+                )
+
+        text = getattr(response, "text", None)
+        if not text and isinstance(response, dict):
+            text = response.get("text")
+        if not isinstance(text, str):
+            raise RuntimeError("Mistral returned no transcript text")
+        segments = []
+        for segment in getattr(response, "segments", None) or []:
+            segments.append(
+                TranscriptSegment(
+                    start_seconds=float(segment.start),
+                    end_seconds=float(segment.end),
+                    text=str(segment.text),
+                    score=self._optional_float(getattr(segment, "score", None)),
+                    speaker_id=getattr(segment, "speaker_id", None),
+                )
+            )
+        return ProviderTranscription(
+            text=text,
+            segments=tuple(segments),
+            language=getattr(response, "language", None),
+        )
+
+    @staticmethod
+    def _optional_float(value: object) -> float | None:
+        return float(value) if isinstance(value, (float, int)) else None

--- a/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/temporary_workspace.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/transcription/adapters/temporary_workspace.py
@@ -1,0 +1,21 @@
+"""Temporary workspace adapter."""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+
+class TemporaryWorkspace:
+    def __init__(self, directory: Path) -> None:
+        self._directory = directory
+        self.video_path = directory / "source.mp4"
+        self.audio_path = directory / "transcription.mp3"
+
+    def cleanup(self) -> None:
+        shutil.rmtree(self._directory, ignore_errors=True)
+
+
+class TemporaryWorkspaceProvider:
+    def create(self) -> TemporaryWorkspace:
+        directory = Path(tempfile.mkdtemp(prefix="shotcut-transcription-"))
+        return TemporaryWorkspace(directory)

--- a/shotcut/agent-harness/cli_anything/shotcut/core/transcription/models.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/transcription/models.py
@@ -1,0 +1,67 @@
+"""Framework-neutral transcription models."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TranscriptSegment:
+    start_seconds: float
+    end_seconds: float
+    text: str
+    score: float | None = None
+    speaker_id: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "start_seconds": self.start_seconds,
+            "end_seconds": self.end_seconds,
+            "text": self.text,
+        }
+        if self.score is not None:
+            result["score"] = self.score
+        if self.speaker_id is not None:
+            result["speaker_id"] = self.speaker_id
+        return result
+
+
+@dataclass(frozen=True)
+class ProviderTranscription:
+    text: str
+    segments: tuple[TranscriptSegment, ...] = ()
+    language: str | None = None
+
+
+@dataclass(frozen=True)
+class TranscriptionRequest:
+    """Input accepted by the transcription use case."""
+
+    source: str
+    playback_speed: float = 2.0
+    output_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class TranscriptionResult:
+    """Provider-independent transcription response."""
+
+    text: str
+    source: str
+    model: str
+    playback_speed: float
+    segments: tuple[TranscriptSegment, ...] = ()
+    language: str | None = None
+    transcript_path: Path | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "text": self.text,
+            "source": self.source,
+            "model": self.model,
+            "playback_speed": self.playback_speed,
+            "language": self.language,
+            "segments": [segment.to_dict() for segment in self.segments],
+        }
+        if self.transcript_path is not None:
+            result["transcript_path"] = str(self.transcript_path)
+        return result

--- a/shotcut/agent-harness/cli_anything/shotcut/core/transcription/ports.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/transcription/ports.py
@@ -1,0 +1,41 @@
+"""Dependency-injection ports for transcription."""
+
+from pathlib import Path
+from typing import Protocol
+
+from .models import ProviderTranscription, TranscriptionResult
+
+
+class VideoDownloader(Protocol):
+    def download(self, source: str, destination: Path) -> Path:
+        """Download a remote video to destination."""
+
+
+class AudioExtractor(Protocol):
+    def extract(self, video_path: Path, audio_path: Path, playback_speed: float) -> Path:
+        """Extract and optionally speed up audio from a video."""
+
+
+class TranscriptionProvider(Protocol):
+    model: str
+
+    def transcribe(self, audio_path: Path) -> ProviderTranscription:
+        """Return transcript text and provider timestamps for an audio file."""
+
+
+class TranscriptionWriter(Protocol):
+    def write(self, result: TranscriptionResult, output_path: Path) -> Path:
+        """Persist a transcription artifact."""
+
+
+class TranscriptionWorkspace(Protocol):
+    video_path: Path
+    audio_path: Path
+
+    def cleanup(self) -> None:
+        """Release temporary files."""
+
+
+class TranscriptionWorkspaceProvider(Protocol):
+    def create(self) -> TranscriptionWorkspace:
+        """Create an isolated workspace for one transcription."""

--- a/shotcut/agent-harness/cli_anything/shotcut/core/transcription/service.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/core/transcription/service.py
@@ -1,0 +1,99 @@
+"""Transcription application service."""
+
+from pathlib import Path
+from dataclasses import replace
+
+from .models import TranscriptSegment, TranscriptionRequest, TranscriptionResult
+from .ports import (
+    AudioExtractor,
+    TranscriptionProvider,
+    TranscriptionWorkspaceProvider,
+    TranscriptionWriter,
+    VideoDownloader,
+)
+
+
+class TranscriptionService:
+    """Coordinate source acquisition, audio preparation, and transcription."""
+
+    def __init__(
+        self,
+        downloader: VideoDownloader,
+        audio_extractor: AudioExtractor,
+        provider: TranscriptionProvider,
+        workspace_provider: TranscriptionWorkspaceProvider,
+        writer: TranscriptionWriter,
+    ) -> None:
+        self._downloader = downloader
+        self._audio_extractor = audio_extractor
+        self._provider = provider
+        self._workspace_provider = workspace_provider
+        self._writer = writer
+
+    def transcribe(self, request: TranscriptionRequest) -> TranscriptionResult:
+        self._validate_request(request)
+        workspace = self._workspace_provider.create()
+
+        try:
+            video_path = self._resolve_video(request.source, workspace.video_path)
+            self._audio_extractor.extract(
+                video_path,
+                workspace.audio_path,
+                request.playback_speed,
+            )
+            provider_result = self._provider.transcribe(workspace.audio_path)
+            result = TranscriptionResult(
+                text=provider_result.text,
+                source=request.source,
+                model=self._provider.model,
+                playback_speed=request.playback_speed,
+                segments=self._restore_video_timestamps(
+                    provider_result.segments,
+                    request.playback_speed,
+                ),
+                language=provider_result.language,
+            )
+            transcript_path = request.output_path or self._default_output_path(
+                request.source, video_path
+            )
+            written_path = self._writer.write(result, transcript_path)
+            return replace(result, transcript_path=written_path)
+        finally:
+            workspace.cleanup()
+
+    def _resolve_video(self, source: str, destination: Path) -> Path:
+        if source.startswith(("http://", "https://")):
+            return self._downloader.download(source, destination)
+
+        video_path = Path(source).expanduser().resolve()
+        if not video_path.is_file():
+            raise FileNotFoundError(f"Video file not found: {video_path}")
+        return video_path
+
+    @staticmethod
+    def _default_output_path(source: str, video_path: Path) -> Path:
+        if source.startswith(("http://", "https://")):
+            return Path.cwd() / "transcription.json"
+        return video_path.with_suffix(".transcript.json")
+
+    @staticmethod
+    def _restore_video_timestamps(
+        segments: tuple[TranscriptSegment, ...], playback_speed: float
+    ) -> tuple[TranscriptSegment, ...]:
+        return tuple(
+            TranscriptSegment(
+                start_seconds=segment.start_seconds / playback_speed,
+                end_seconds=segment.end_seconds / playback_speed,
+                text=segment.text,
+                score=segment.score,
+                speaker_id=segment.speaker_id,
+            )
+            for segment in segments
+        )
+
+    @staticmethod
+    def _validate_request(request: TranscriptionRequest) -> None:
+        if not request.source.strip():
+            raise ValueError("Transcription source cannot be empty")
+        if not 0.5 <= request.playback_speed <= 2.0:
+            raise ValueError("Playback speed must be between 0.5 and 2.0")

--- a/shotcut/agent-harness/cli_anything/shotcut/shotcut_cli.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/shotcut_cli.py
@@ -22,6 +22,7 @@ import shlex
 import shutil
 import subprocess
 import click
+from pathlib import Path
 from typing import Optional
 
 # Add parent to path for imports
@@ -36,6 +37,41 @@ from cli_anything.shotcut.core import export as export_mod
 from cli_anything.shotcut.core import transitions as trans_mod
 from cli_anything.shotcut.core import compositing as comp_mod
 from cli_anything.shotcut.core import preview as preview_mod
+from cli_anything.shotcut.core.transcription import TranscriptionRequest, TranscriptionService
+from cli_anything.shotcut.core.transcription.adapters import (
+    FfmpegAudioExtractor,
+    HttpVideoDownloader,
+    MistralTranscriber,
+    JsonTranscriptionWriter,
+    TemporaryWorkspaceProvider,
+)
+from cli_anything.shotcut.core.media_download import (
+    DownloadRequest,
+    MediaDownloadService,
+    MediaResolverRegistry,
+)
+from cli_anything.shotcut.core.media_download.adapters import (
+    BrightDataApiClient,
+    HttpFileDownloader,
+)
+from cli_anything.shotcut.core.media_download.adapters.platforms import (
+    BrightDataInstagramVideoResolver,
+)
+from cli_anything.shotcut.core.credentials import (
+    CompositeCredentialProvider,
+    EnvironmentCredentialProvider,
+    MacOSKeychainCredentialProvider,
+)
+from cli_anything.shotcut.core.text_to_speech import (
+    TextToSpeechRequest,
+    TextToSpeechService,
+)
+from cli_anything.shotcut.core.text_to_speech.adapters import (
+    ElevenLabsTextToSpeech,
+    XTTSVoiceProvider,
+)
+from cli_anything.shotcut.core.subtitles import SubtitleRequest, SubtitleService
+from cli_anything.shotcut.core.subtitles.adapters import FfmpegSubtitleRenderer
 
 # Global session state (persists across commands in REPL mode)
 _session: Optional[Session] = None
@@ -172,7 +208,7 @@ def handle_error(func):
             else:
                 click.echo(f"Error: {e}", err=True)
             sys.exit(1) if not _repl_mode else None
-        except (ValueError, IndexError, RuntimeError) as e:
+        except (ValueError, IndexError, RuntimeError, FileExistsError) as e:
             if _json_output:
                 click.echo(json.dumps({"error": str(e), "type": type(e).__name__}))
             else:
@@ -191,6 +227,10 @@ def handle_error(func):
 
 _repl_mode = False
 _dry_run = False
+_credentials = CompositeCredentialProvider([
+    EnvironmentCredentialProvider(),
+    MacOSKeychainCredentialProvider(),
+])
 
 
 # ============================================================================
@@ -700,7 +740,7 @@ def filter_duck(track_index, clip_index, windows, normal_level, duck_level, atta
 
 @cli.group()
 def media():
-    """Media operations: probe, list, check files."""
+    """Media operations: probe, list, check files, and transcribe."""
     pass
 
 
@@ -740,6 +780,157 @@ def media_import(resource, caption):
     session = get_session()
     result = media_mod.import_media(session, resource, caption)
     output(result, f"Imported {os.path.basename(resource)} as {result['clip_id']}")
+
+
+@media.command("download-instagram")
+@click.argument("source_url")
+@click.option("-o", "--output", "output_path", required=True, help="Output video path")
+@click.option("--overwrite", is_flag=True, help="Replace an existing output file")
+@handle_error
+def media_download_instagram(source_url, output_path, overwrite):
+    """Download a public Instagram post or reel video through BrightData."""
+    brightdata_api = BrightDataApiClient(
+        api_key=_credentials.get_required("BRIGHT_DATA_API_KEY"),
+        retry_count=int(os.getenv("BRIGHT_DATA_SNAPSHOT_RETRY_COUNT", "60")),
+        poll_interval_seconds=float(
+            os.getenv("BRIGHT_DATA_SNAPSHOT_POLL_INTERVAL_SECONDS", "2")
+        ),
+    )
+    service = MediaDownloadService(
+        resolver_registry=MediaResolverRegistry(
+            [BrightDataInstagramVideoResolver(brightdata_api)]
+        ),
+        file_downloader=HttpFileDownloader(),
+    )
+    result = service.download(
+        DownloadRequest(
+            source_url=source_url,
+            output_path=Path(output_path),
+            overwrite=overwrite,
+        )
+    )
+    output(result.to_dict(), f"Downloaded Instagram video to: {result.output_path}")
+
+
+@media.command("transcribe")
+@click.argument("source")
+@click.option(
+    "--speed",
+    "playback_speed",
+    default=2.0,
+    type=click.FloatRange(min=0.5, max=2.0),
+    show_default=True,
+    help="Audio playback speed used to reduce transcription cost.",
+)
+@click.option("--model", default="voxtral-mini-latest", show_default=True)
+@click.option("-o", "--output", "output_path", default=None, help="Transcript JSON path")
+@handle_error
+def media_transcribe(source, playback_speed, model, output_path):
+    """Transcribe a local video file or HTTP(S) video URL."""
+    api_key = _credentials.get_required("MISTRAL_API_KEY")
+    service = TranscriptionService(
+        downloader=HttpVideoDownloader(),
+        audio_extractor=FfmpegAudioExtractor(),
+        provider=MistralTranscriber(api_key=api_key, model=model),
+        workspace_provider=TemporaryWorkspaceProvider(),
+        writer=JsonTranscriptionWriter(),
+    )
+    result = service.transcribe(
+        TranscriptionRequest(
+            source=source,
+            playback_speed=playback_speed,
+            output_path=Path(output_path) if output_path else None,
+        )
+    )
+    output(result.to_dict(), "Transcription complete")
+
+
+@media.command("add-subtitles")
+@click.argument("video", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--transcript",
+    "transcript_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Timestamped transcript JSON produced by media transcribe",
+)
+@click.option("-o", "output_path", required=True, type=click.Path(dir_okay=False),
+              help="Output video path")
+@click.option("--overwrite", is_flag=True, help="Replace an existing output file")
+@handle_error
+def media_add_subtitles(video, transcript_path, output_path, overwrite):
+    """Burn timestamped transcript segments into VIDEO."""
+    service = SubtitleService(FfmpegSubtitleRenderer())
+    result = service.add_subtitles(
+        SubtitleRequest(
+            video_path=Path(video),
+            transcript_path=Path(transcript_path),
+            output_path=Path(output_path),
+            overwrite=overwrite,
+        )
+    )
+    output(result.to_dict(), f"Subtitles added to: {result.output_path}")
+
+
+@media.command("tts")
+@click.argument("text", required=False)
+@click.option("--provider", type=click.Choice(["elevenlabs", "local"]),
+              default="elevenlabs", show_default=True,
+              help="Speech provider")
+@click.option("--text-file", type=click.Path(exists=True, dir_okay=False),
+              help="Read the text to synthesize from a UTF-8 file")
+@click.option("--voice", "voice_id", default=None, help="ElevenLabs voice ID")
+@click.option("--voice-sample", type=click.Path(exists=True, dir_okay=False),
+              help="Reference WAV/audio file for local XTTS voice cloning")
+@click.option("--language", default="en", show_default=True,
+              help="Language code for local XTTS, e.g. en or nl")
+@click.option("--device", type=click.Choice(["auto", "mps", "cpu"]), default="auto",
+              show_default=True, help="Local XTTS execution device")
+@click.option("-o", "output_path", required=True, type=click.Path(dir_okay=False),
+              help="Output audio path")
+@click.option("--model", default=None,
+              help="Provider model ID (defaults to the provider's recommended model)")
+@click.option("--format", "output_format", default=None,
+              help="Audio format; local XTTS currently requires wav")
+@handle_error
+def media_tts(text, provider, text_file, voice_id, voice_sample, language, device,
+              output_path, model, output_format):
+    """Generate speech from TEXT or --text-file."""
+    if text is not None and text_file is not None:
+        raise ValueError("Provide TEXT or --text-file, not both")
+    if text is None and text_file is None:
+        raise ValueError("Provide TEXT or --text-file")
+
+    source_text = Path(text_file).read_text(encoding="utf-8") if text_file else text
+    if provider == "local":
+        if voice_sample is None:
+            raise ValueError("Local XTTS requires --voice-sample")
+        tts_provider = XTTSVoiceProvider(device=device, model=model or XTTSVoiceProvider.MODEL)
+        selected_model = model or XTTSVoiceProvider.MODEL
+        selected_format = output_format or "wav"
+    else:
+        if not voice_id:
+            raise ValueError("ElevenLabs requires --voice")
+        if voice_sample is not None:
+            raise ValueError("--voice-sample is only valid with --provider local")
+        api_key = _credentials.get_required("ELEVENLABS_API_KEY")
+        tts_provider = ElevenLabsTextToSpeech(api_key=api_key)
+        selected_model = model or "eleven_multilingual_v2"
+        selected_format = output_format or "mp3_44100_128"
+
+    service = TextToSpeechService(tts_provider)
+    result = service.synthesize(
+        TextToSpeechRequest(
+            text=source_text,
+            voice_id=voice_id,
+            output_path=Path(output_path),
+            model=selected_model,
+            output_format=selected_format,
+            voice_sample=Path(voice_sample) if voice_sample else None,
+            language=language,
+        )
+    )
+    output(result.to_dict(), f"Speech saved to: {result.output_path}")
 
 
 @media.command("thumbnail")
@@ -1209,6 +1400,8 @@ def _run_repl(s: Session, skin):
         "add-track <video|audio> [name]": "Add a track",
         "add-clip <clip_id> <track> [in] [out] [--at time]": "Add imported clip to track",
         "media import <file> [--caption name]": "Import media file into project bin",
+        "media transcribe <file-or-url> [--speed 2.0]": "Transcribe video audio",
+        "media add-subtitles <video> --transcript <json> -o <output>": "Burn transcript subtitles into video",
         "clips <track>": "List clips on a track",
         "remove-clip <track> <clip>": "Remove a clip",
         "trim <track> <clip> [--in tc] [--out tc]": "Trim a clip",
@@ -1558,6 +1751,37 @@ def _run_repl(s: Session, skin):
                         i += 1
                 result = media_mod.import_media(s, args[1], caption)
                 output(result, f"Imported {os.path.basename(args[1])} as {result['clip_id']}")
+
+            elif cmd == "media" and args and args[0] == "transcribe":
+                if len(args) < 2:
+                    click.echo("Usage: media transcribe <file-or-url> [--speed 2.0] [--model name]")
+                    continue
+                playback_speed = 2.0
+                model = "voxtral-mini-latest"
+                i = 2
+                while i < len(args):
+                    if args[i] == "--speed" and i + 1 < len(args):
+                        playback_speed = float(args[i + 1])
+                        i += 2
+                    elif args[i] == "--model" and i + 1 < len(args):
+                        model = args[i + 1]
+                        i += 2
+                    else:
+                        i += 1
+                api_key = os.getenv("MISTRAL_API_KEY", "")
+                service = TranscriptionService(
+                    downloader=HttpVideoDownloader(),
+                    audio_extractor=FfmpegAudioExtractor(),
+                    provider=MistralTranscriber(api_key=api_key, model=model),
+                    workspace_provider=TemporaryWorkspaceProvider(),
+                )
+                result = service.transcribe(
+                    TranscriptionRequest(
+                        source=args[1],
+                        playback_speed=playback_speed,
+                    )
+                )
+                output(result.to_dict(), "Transcription complete")
 
             elif cmd == "media":
                 result = media_mod.list_media(s)

--- a/shotcut/agent-harness/cli_anything/shotcut/shotcut_cli.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/shotcut_cli.py
@@ -8,7 +8,8 @@ Usage:
     # One-shot commands
     shotcut-cli project new --profile hd1080p30 -o my_project.mlt
     shotcut-cli timeline add-track --type video
-    shotcut-cli timeline add-clip video.mp4 --track 1
+    shotcut-cli media import video.mp4
+    shotcut-cli timeline add-clip clip0 --track 1
 
     # Interactive REPL
     shotcut-cli repl
@@ -257,7 +258,7 @@ def project():
 
 @project.command("new")
 @click.option("--profile", default="hd1080p30",
-              help="Video profile (hd1080p30, hd1080p60, 4k30, etc.)")
+              help="Video profile (vertical1080p30, hd1080p30, hd1080p60, 4k30, etc.)")
 @click.option("-o", "--output", "output_path", default=None,
               help="Save the new project to this path")
 @handle_error

--- a/shotcut/agent-harness/cli_anything/shotcut/skills/SKILL.md
+++ b/shotcut/agent-harness/cli_anything/shotcut/skills/SKILL.md
@@ -68,6 +68,11 @@ cli-anything-shotcut --project my_project.mlt
 - `media import <file> [--caption name]` — Import file into project bin, returns `clip_id` (e.g., `clip0`)
 - `media` — List all imported media
 - `probe <file>` — Analyze a media file
+- `media transcribe <file-or-url> [--speed 2.0] [-o transcript.json]` — Transcribe video audio with Mistral Voxtral and save timestamped JSON
+- `media add-subtitles <video> --transcript <json> -o <output.mp4> [--overwrite]` — Burn timestamped ASS subtitles into a video
+- `media tts <text> --voice <id> -o <output.mp3>` — Generate speech with ElevenLabs; use `--text-file` for longer scripts
+- `media tts <text> --provider local --voice-sample <file> -o <output.wav>` — Generate speech locally with XTTS v2
+- `media download-instagram <url> -o <output.mp4>` — Download an Instagram post or reel video through BrightData
 
 **Timeline:**
 - `add-track <video|audio> [name]` — Add a track
@@ -160,6 +165,8 @@ Media operations: probe, list, check files.
 | `list` | List all media clips in the current project |
 | `check` | Check all media files for existence |
 | `thumbnail` | Generate a thumbnail from a video file |
+| `transcribe` | Transcribe a local video or HTTP(S) video URL |
+| `download-instagram` | Download an Instagram post or reel video |
 
 
 ### Export

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_brightdata_api_client.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_brightdata_api_client.py
@@ -1,0 +1,74 @@
+"""Tests for the BrightData API adapter."""
+
+import json
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from cli_anything.shotcut.core.media_download.adapters import BrightDataApiClient
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+class FakeOpener:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.requests = []
+
+    def __call__(self, request, timeout):
+        self.requests.append((request, timeout))
+        return next(self.responses)
+
+
+def test_trigger_starts_dataset_job():
+    opener = FakeOpener([FakeResponse({"snapshot_id": "snapshot-1"})])
+    client = BrightDataApiClient("api-key", opener=opener)
+
+    snapshot_id = client.trigger("dataset-1", "https://instagram.com/p/example/")
+
+    assert snapshot_id == "snapshot-1"
+    query = parse_qs(urlparse(opener.requests[0][0].full_url).query)
+    assert query["dataset_id"] == ["dataset-1"]
+    assert query["format"] == ["json"]
+
+
+def test_wait_for_snapshot_polls_until_records_are_ready():
+    opener = FakeOpener(
+        [
+            FakeResponse({"status": "running"}),
+            FakeResponse([{"video_url": "https://cdn.test/video.mp4"}]),
+        ]
+    )
+    sleeps = []
+    client = BrightDataApiClient(
+        "api-key",
+        retry_count=2,
+        poll_interval_seconds=3,
+        opener=opener,
+        sleeper=sleeps.append,
+    )
+
+    records = client.wait_for_snapshot("snapshot-1")
+
+    assert records == [{"video_url": "https://cdn.test/video.mp4"}]
+    assert sleeps == [3]
+
+
+def test_wait_for_snapshot_raises_for_failed_job():
+    opener = FakeOpener([FakeResponse({"status": "failed", "message": "blocked"})])
+    client = BrightDataApiClient("api-key", opener=opener)
+
+    with pytest.raises(RuntimeError, match="blocked"):
+        client.wait_for_snapshot("snapshot-1")

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_core.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_core.py
@@ -20,6 +20,7 @@ from cli_anything.shotcut.core import export as export_mod
 from cli_anything.shotcut.core import transitions as trans_mod
 from cli_anything.shotcut.core import compositing as comp_mod
 from cli_anything.shotcut.core import preview as preview_mod
+from cli_anything.shotcut.utils import melt_backend
 from cli_anything.shotcut.utils.time import (
     timecode_to_frames, frames_to_timecode, parse_time_input,
     frames_to_seconds, seconds_to_frames,
@@ -134,6 +135,14 @@ class TestMltXml:
             if child.tag == "chain" and child.get("id") == "late_chain"
         )
         assert late_idx < first_playlist_or_tractor
+
+    def test_write_mlt_points_root_at_timeline(self, tmp_path):
+        root = create_blank_project(PROFILE_HD1080)
+        tmpfile = str(tmp_path / "timeline-root.mlt")
+        write_mlt(root, tmpfile)
+        parsed = parse_mlt(tmpfile)
+        tractor = get_main_tractor(parsed)
+        assert parsed.get("producer") == tractor.get("id")
 
     def test_properties(self):
         import xml.etree.ElementTree as ET
@@ -679,11 +688,28 @@ class TestProject:
         assert "hd1080p30" in profiles
         assert "4k30" in profiles
 
+    def test_vertical_profile(self):
+        profile = proj_mod.list_profiles()["vertical1080p30"]
+        assert profile["resolution"] == "1080x1920"
+        assert profile["fps"] == 29.97
+
     def test_save_project(self, session, tmp_path):
         path = str(tmp_path / "test.mlt")
         result = proj_mod.save_project(session, path)
         assert result["path"] == path
         assert os.path.isfile(path)
+
+    def test_save_project_refreshes_duration(self, session_with_track, dummy_file, tmp_path):
+        clip_id = media_mod.import_media(session_with_track, dummy_file)["clip_id"]
+        tl_mod.add_clip(
+            session_with_track, clip_id, 1,
+            in_point="00:00:00.000", out_point="00:00:05.000",
+        )
+        path = str(tmp_path / "duration.mlt")
+        proj_mod.save_project(session_with_track, path)
+        parsed = parse_mlt(path)
+        assert parsed.get("producer") == "tractor0"
+        assert get_main_tractor(parsed).get("out") != "00:00:00.000"
 
     def test_open_and_info(self, session, tmp_path):
         path = str(tmp_path / "test.mlt")
@@ -904,7 +930,14 @@ class TestTimeline:
         playlist = session_with_track._track_playlists[1]
         children = list(playlist)
         entry_producers = [c.get("producer") for c in children if c.tag == "entry"]
-        assert entry_producers == ["tl_clip0", "tl_clip0", "tl_clip0"]
+        assert len(entry_producers) == 3
+        assert len(set(entry_producers)) == 3
+        timeline_chains = [find_element_by_id(session_with_track.root, producer_id)
+                           for producer_id in entry_producers]
+        assert all(chain is not None for chain in timeline_chains)
+        uuids = [get_property(chain, "shotcut:uuid") for chain in timeline_chains]
+        assert all(uuids)
+        assert len(set(uuids)) == 3
 
     def test_add_clip_at_after_two_clips(self, session_with_track, dummy_file):
         clip_id = media_mod.import_media(session_with_track, dummy_file)["clip_id"]
@@ -1381,6 +1414,29 @@ class TestExport:
         tractor = get_main_tractor(s.root)
 
         assert tractor.get("out") == "00:00:00.000"
+
+
+class TestMeltBackend:
+    def test_find_melt_prefers_configured_path(self, monkeypatch, tmp_path):
+        configured = tmp_path / "melt"
+        configured.write_text("melt")
+        configured.chmod(0o755)
+        monkeypatch.setenv("SHOTCUT_MELT", str(configured))
+        monkeypatch.setattr(melt_backend, "_is_mlt_melt", lambda path: path == str(configured))
+        monkeypatch.setattr(melt_backend.shutil, "which", lambda name: None)
+
+        assert melt_backend.find_melt() == str(configured)
+
+    def test_find_melt_rejects_unrelated_binary(self, monkeypatch, tmp_path):
+        unrelated = tmp_path / "melt"
+        unrelated.write_text("not MLT")
+        unrelated.chmod(0o755)
+        monkeypatch.setenv("SHOTCUT_MELT", str(unrelated))
+        monkeypatch.setattr(melt_backend, "_is_mlt_melt", lambda path: False)
+        monkeypatch.setattr(melt_backend.shutil, "which", lambda name: None)
+
+        with pytest.raises(RuntimeError, match="MLT melt executable"):
+            melt_backend.find_melt()
 
 
 # ============================================================================

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_credentials.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_credentials.py
@@ -1,0 +1,46 @@
+"""Tests for environment and macOS Keychain credential lookup."""
+
+import subprocess
+
+import pytest
+
+from cli_anything.shotcut.core.credentials import (
+    CompositeCredentialProvider,
+    EnvironmentCredentialProvider,
+    MacOSKeychainCredentialProvider,
+)
+
+
+def test_keychain_provider_returns_secret_without_printing_it():
+    calls = []
+
+    def runner(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, stdout="secret-value\n", stderr="")
+
+    provider = MacOSKeychainCredentialProvider(executable="security", runner=runner)
+
+    assert provider.get("BRIGHT_DATA_API_KEY") == "secret-value"
+    assert calls[0][0][-2:] == ["BRIGHT_DATA_API_KEY", "-w"]
+    assert calls[0][1]["capture_output"] is True
+
+
+def test_composite_provider_prefers_environment(monkeypatch):
+    monkeypatch.setenv("BRIGHT_DATA_API_KEY", "environment-value")
+
+    provider = CompositeCredentialProvider([
+        EnvironmentCredentialProvider(),
+        MacOSKeychainCredentialProvider(executable="/nonexistent/security"),
+    ])
+
+    assert provider.get_required("BRIGHT_DATA_API_KEY") == "environment-value"
+
+
+def test_composite_provider_reports_missing_credential():
+    provider = CompositeCredentialProvider([
+        EnvironmentCredentialProvider(),
+        MacOSKeychainCredentialProvider(executable="/nonexistent/security"),
+    ])
+
+    with pytest.raises(RuntimeError, match="BRIGHT_DATA_API_KEY"):
+        provider.get_required("BRIGHT_DATA_API_KEY")

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_full_e2e.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_full_e2e.py
@@ -1010,6 +1010,46 @@ class TestPreviewE2E:
 
 
 class TestMeltRenderE2E:
+    def test_saved_vertical_project_renders_non_black(self, preview_video):
+        session = Session()
+        proj_mod.new_project(session, "vertical1080p30")
+        tl_mod.add_track(session, "video", "Main Video")
+        clip_id = media_mod.import_media(session, preview_video)["clip_id"]
+        tl_mod.add_clip(
+            session, clip_id, 1,
+            in_point="00:00:00.000", out_point="00:00:02.000",
+            caption="Preview Clip",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            project_path = os.path.join(tmp_dir, "project.mlt")
+            output_path = os.path.join(tmp_dir, "render.mp4")
+            frame_path = os.path.join(tmp_dir, "frame.png")
+            proj_mod.save_project(session, project_path)
+
+            import xml.etree.ElementTree as ET
+            root = ET.parse(project_path).getroot()
+            tractor = root.find(".//tractor[@id='tractor0']")
+            assert root.get("producer") == "tractor0"
+            assert tractor is not None
+            assert tractor.get("out") != "00:00:00.000"
+
+            result = export_mod.render(session, output_path, "h264-fast", overwrite=True)
+            assert result["success"] is True
+
+            probe = media_mod.probe_media(output_path)
+            video_stream = probe["video_streams"][0]
+            assert video_stream["width"] == 1080
+            assert video_stream["height"] == 1920
+            assert probe["duration_seconds"] > 1.0
+
+            subprocess.run(
+                ["ffmpeg", "-y", "-ss", "00:00:00.500", "-i", output_path,
+                 "-frames:v", "1", frame_path],
+                check=True, capture_output=True, text=True, timeout=120,
+            )
+            assert _luma_yavg(frame_path) > 10.0
+
     def test_render_color_bars_mp4(self):
         from cli_anything.shotcut.utils.melt_backend import render_color_bars
 

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_instagram_video_resolver.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_instagram_video_resolver.py
@@ -1,0 +1,65 @@
+"""Tests for the BrightData Instagram resolver."""
+
+import pytest
+
+from cli_anything.shotcut.core.media_download.adapters.platforms import (
+    BrightDataInstagramVideoResolver,
+)
+
+
+class FakeBrightDataApi:
+    def __init__(self, records):
+        self.records = records
+        self.trigger_calls = []
+        self.wait_calls = []
+
+    def trigger(self, dataset_id: str, source_url: str) -> str:
+        self.trigger_calls.append((dataset_id, source_url))
+        return "snapshot-123"
+
+    def wait_for_snapshot(self, snapshot_id: str):
+        self.wait_calls.append(snapshot_id)
+        return self.records
+
+
+def test_resolves_post_video_from_post_content():
+    api = FakeBrightDataApi(
+        [{"post_content": [{"type": "video", "url": "https://cdn.test/post.mp4"}]}]
+    )
+    resolver = BrightDataInstagramVideoResolver(api)
+
+    result = resolver.resolve("https://www.instagram.com/p/example/")
+
+    assert result.media_url == "https://cdn.test/post.mp4"
+    assert result.platform == "instagram"
+    assert api.trigger_calls == [
+        (resolver.INSTAGRAM_POST_DATASET, "https://www.instagram.com/p/example/")
+    ]
+    assert api.wait_calls == ["snapshot-123"]
+
+
+def test_normalizes_reels_url_and_resolves_reel_video():
+    api = FakeBrightDataApi([{"video_url": "https://cdn.test/reel.mp4"}])
+    resolver = BrightDataInstagramVideoResolver(api)
+
+    result = resolver.resolve("https://instagram.com/reels/example/?foo=bar")
+
+    assert result.media_url == "https://cdn.test/reel.mp4"
+    assert api.trigger_calls == [
+        (resolver.INSTAGRAM_REEL_DATASET, "https://instagram.com/reel/example/?foo=bar")
+    ]
+
+
+def test_rejects_unsupported_instagram_url():
+    resolver = BrightDataInstagramVideoResolver(FakeBrightDataApi([]))
+
+    assert resolver.can_resolve("https://www.instagram.com/accounts/login/") is False
+    with pytest.raises(ValueError, match="post or reel"):
+        resolver.resolve("https://www.instagram.com/accounts/login/")
+
+
+def test_raises_when_instagram_response_has_no_video():
+    resolver = BrightDataInstagramVideoResolver(FakeBrightDataApi([{"photos": ["x"]}]))
+
+    with pytest.raises(RuntimeError, match="did not return a video URL"):
+        resolver.resolve("https://www.instagram.com/p/example/")

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_media_download_cli.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_media_download_cli.py
@@ -1,0 +1,47 @@
+"""CLI wiring tests for Instagram media downloads."""
+
+import json
+
+from click.testing import CliRunner
+
+from cli_anything.shotcut import shotcut_cli
+from cli_anything.shotcut.core.media_download.models import DownloadResult
+
+
+def test_download_instagram_outputs_json(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeService:
+        def __init__(self, **dependencies):
+            captured["dependencies"] = dependencies
+
+        def download(self, request):
+            captured["request"] = request
+            return DownloadResult(
+                source_url=request.source_url,
+                output_path=request.output_path.resolve(),
+                platform="instagram",
+                media_type="video",
+            )
+
+    monkeypatch.setattr(shotcut_cli, "MediaDownloadService", FakeService)
+    monkeypatch.setenv("BRIGHT_DATA_API_KEY", "test-key")
+    output_path = tmp_path / "competitor.mp4"
+
+    result = CliRunner().invoke(
+        shotcut_cli.cli,
+        [
+            "--json",
+            "media",
+            "download-instagram",
+            "https://www.instagram.com/p/example/",
+            "-o",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["platform"] == "instagram"
+    assert captured["request"].source_url.endswith("/p/example/")
+    assert captured["request"].overwrite is False

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_media_download_service.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_media_download_service.py
@@ -1,0 +1,51 @@
+"""Tests for the platform-neutral media download service."""
+
+from pathlib import Path
+
+from cli_anything.shotcut.core.media_download.models import (
+    DownloadRequest,
+    ResolvedMedia,
+)
+from cli_anything.shotcut.core.media_download.registry import MediaResolverRegistry
+from cli_anything.shotcut.core.media_download.service import MediaDownloadService
+
+
+class FakeResolver:
+    platform = "fake"
+
+    def can_resolve(self, source_url: str) -> bool:
+        return source_url.startswith("fake:")
+
+    def resolve(self, source_url: str) -> ResolvedMedia:
+        return ResolvedMedia(source_url, "https://cdn.test/video.mp4", self.platform)
+
+
+class FakeDownloader:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def download(self, source_url: str, output_path: Path, overwrite: bool = False) -> Path:
+        self.calls.append((source_url, output_path, overwrite))
+        return output_path.resolve()
+
+
+def test_service_resolves_then_downloads_media(tmp_path):
+    downloader = FakeDownloader()
+    service = MediaDownloadService(
+        resolver_registry=MediaResolverRegistry([FakeResolver()]),
+        file_downloader=downloader,
+    )
+
+    result = service.download(
+        DownloadRequest(
+            source_url="fake:video",
+            output_path=tmp_path / "video.mp4",
+            overwrite=True,
+        )
+    )
+
+    assert result.platform == "fake"
+    assert result.output_path == (tmp_path / "video.mp4").resolve()
+    assert downloader.calls == [
+        ("https://cdn.test/video.mp4", tmp_path / "video.mp4", True)
+    ]

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_subtitles.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_subtitles.py
@@ -1,0 +1,59 @@
+"""Tests for timestamped subtitle rendering."""
+
+import json
+
+from cli_anything.shotcut.core.subtitles.models import SubtitleRequest
+from cli_anything.shotcut.core.subtitles.service import SubtitleService
+
+
+def test_subtitle_service_generates_bold_centered_ass(tmp_path):
+    video = tmp_path / "video.mp4"
+    transcript = tmp_path / "video.transcript.json"
+    output = tmp_path / "subtitled.mp4"
+    video.write_bytes(b"video")
+    transcript.write_text(
+        json.dumps(
+            {
+                "segments": [
+                    {"start_seconds": 0, "end_seconds": 1.25, "text": "Hello {world}"}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    captured = {}
+
+    class FakeRenderer:
+        def render(self, video_path, ass_path, output_path, overwrite):
+            captured["video_path"] = video_path
+            captured["ass"] = ass_path.read_text(encoding="utf-8")
+            captured["output_path"] = output_path
+            captured["overwrite"] = overwrite
+
+    result = SubtitleService(FakeRenderer()).add_subtitles(
+        SubtitleRequest(video, transcript, output, overwrite=True)
+    )
+
+    assert result.subtitle_count == 1
+    assert "Default,Arial,64" in captured["ass"]
+    assert ",-1,0,0,0,100,100" in captured["ass"]
+    assert "Alignment, MarginL" in captured["ass"]
+    assert "Dialogue: 0,0:00:00.00,0:00:01.25" in captured["ass"]
+    assert r"Hello \{world\}" in captured["ass"]
+    assert captured["overwrite"] is True
+
+
+def test_subtitle_service_rejects_empty_transcript(tmp_path):
+    video = tmp_path / "video.mp4"
+    transcript = tmp_path / "transcript.json"
+    video.write_bytes(b"video")
+    transcript.write_text(json.dumps({"segments": []}), encoding="utf-8")
+
+    try:
+        SubtitleService(object()).add_subtitles(
+            SubtitleRequest(video, transcript, tmp_path / "out.mp4")
+        )
+    except ValueError as error:
+        assert "no subtitle segments" in str(error)
+    else:
+        raise AssertionError("Expected empty transcripts to be rejected")

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_text_to_speech_service.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_text_to_speech_service.py
@@ -1,0 +1,60 @@
+"""Unit tests for the dependency-injected text-to-speech service."""
+
+from pathlib import Path
+
+import pytest
+
+from cli_anything.shotcut.core.text_to_speech.models import TextToSpeechRequest
+from cli_anything.shotcut.core.text_to_speech.service import TextToSpeechService
+
+
+class FakeProvider:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def synthesize(self, text, voice_id, model, output_format, voice_sample, language):
+        self.calls.append(
+            (text, voice_id, model, output_format, voice_sample, language)
+        )
+        return b"fake audio"
+
+
+def test_synthesizes_and_writes_audio(tmp_path: Path):
+    provider = FakeProvider()
+    service = TextToSpeechService(provider)
+    output_path = tmp_path / "nested" / "speech.mp3"
+
+    result = service.synthesize(
+        TextToSpeechRequest(
+            text="Hello from a test",
+            voice_id="voice123",
+            output_path=output_path,
+        )
+    )
+
+    assert result.output_path == output_path.resolve()
+    assert result.character_count == len("Hello from a test")
+    assert output_path.read_bytes() == b"fake audio"
+    assert provider.calls == [
+        (
+            "Hello from a test",
+            "voice123",
+            "eleven_multilingual_v2",
+            "mp3_44100_128",
+            None,
+            "en",
+        )
+    ]
+
+
+def test_rejects_empty_text(tmp_path: Path):
+    service = TextToSpeechService(FakeProvider())
+
+    with pytest.raises(ValueError, match="cannot be empty"):
+        service.synthesize(
+            TextToSpeechRequest(
+                text=" ",
+                voice_id="voice123",
+                output_path=tmp_path / "speech.mp3",
+            )
+        )

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_transcription_cli.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_transcription_cli.py
@@ -1,0 +1,41 @@
+"""CLI wiring tests for transcription."""
+
+import json
+
+from click.testing import CliRunner
+
+from cli_anything.shotcut import shotcut_cli
+from cli_anything.shotcut.core.transcription.models import TranscriptionResult
+
+
+def test_media_transcribe_outputs_json(monkeypatch, tmp_path):
+    source = tmp_path / "video.mp4"
+    source.write_bytes(b"video")
+    captured = {}
+
+    class FakeService:
+        def __init__(self, **dependencies):
+            captured["dependencies"] = dependencies
+
+        def transcribe(self, request):
+            captured["request"] = request
+            return TranscriptionResult(
+                text="a transcript",
+                source=request.source,
+                model="fake-model",
+                playback_speed=request.playback_speed,
+            )
+
+    monkeypatch.setattr(shotcut_cli, "TranscriptionService", FakeService)
+    monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+
+    result = CliRunner().invoke(
+        shotcut_cli.cli,
+        ["--json", "media", "transcribe", str(source)],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["text"] == "a transcript"
+    assert captured["request"].playback_speed == 2.0
+    assert captured["request"].source == str(source)

--- a/shotcut/agent-harness/cli_anything/shotcut/tests/test_transcription_service.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/tests/test_transcription_service.py
@@ -1,0 +1,152 @@
+"""Unit tests for the dependency-injected transcription service."""
+
+from pathlib import Path
+
+import pytest
+
+from cli_anything.shotcut.core.transcription.adapters.json_transcription_writer import (
+    JsonTranscriptionWriter,
+)
+from cli_anything.shotcut.core.transcription.models import (
+    ProviderTranscription,
+    TranscriptSegment,
+    TranscriptionRequest,
+)
+from cli_anything.shotcut.core.transcription.service import TranscriptionService
+
+
+class FakeWorkspace:
+    def __init__(self, directory: Path) -> None:
+        self.video_path = directory / "source.mp4"
+        self.audio_path = directory / "audio.mp3"
+        self.cleaned = False
+
+    def cleanup(self) -> None:
+        self.cleaned = True
+
+
+class FakeWorkspaceProvider:
+    def __init__(self, workspace: FakeWorkspace) -> None:
+        self.workspace = workspace
+
+    def create(self) -> FakeWorkspace:
+        return self.workspace
+
+
+class FakeDownloader:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def download(self, source: str, destination: Path) -> Path:
+        self.calls.append((source, destination))
+        destination.write_bytes(b"video")
+        return destination
+
+
+class FakeAudioExtractor:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def extract(self, video_path: Path, audio_path: Path, playback_speed: float) -> Path:
+        self.calls.append((video_path, audio_path, playback_speed))
+        audio_path.write_bytes(b"audio")
+        return audio_path
+
+
+class FakeProvider:
+    model = "fake-model"
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def transcribe(self, audio_path: Path) -> ProviderTranscription:
+        self.calls.append(audio_path)
+        return ProviderTranscription(
+            text="hello from the fake provider",
+            segments=(TranscriptSegment(0.0, 2.0, "hello from the fake provider"),),
+            language="en",
+        )
+
+
+def make_service(tmp_path: Path):
+    workspace = FakeWorkspace(tmp_path)
+    downloader = FakeDownloader()
+    extractor = FakeAudioExtractor()
+    provider = FakeProvider()
+    service = TranscriptionService(
+        downloader=downloader,
+        audio_extractor=extractor,
+        provider=provider,
+        workspace_provider=FakeWorkspaceProvider(workspace),
+        writer=JsonTranscriptionWriter(),
+    )
+    return service, workspace, downloader, extractor, provider
+
+
+def test_transcribes_local_video_at_cost_saving_speed(tmp_path):
+    source = tmp_path / "video.mp4"
+    source.write_bytes(b"video")
+    service, workspace, downloader, extractor, provider = make_service(tmp_path)
+
+    result = service.transcribe(TranscriptionRequest(source=str(source)))
+
+    assert result.text == "hello from the fake provider"
+    assert result.segments[0].end_seconds == 1.0
+    assert result.transcript_path == (tmp_path / "video.transcript.json").resolve()
+    assert result.transcript_path.is_file()
+    assert downloader.calls == []
+    assert extractor.calls[0][2] == 2.0
+    assert provider.calls == [workspace.audio_path]
+    assert workspace.cleaned is True
+
+
+def test_downloads_remote_video_before_transcribing(tmp_path):
+    service, workspace, downloader, extractor, provider = make_service(tmp_path)
+
+    result = service.transcribe(
+        TranscriptionRequest(
+            source="https://example.test/video.mp4",
+            playback_speed=1.5,
+            output_path=tmp_path / "transcription.json",
+        )
+    )
+
+    assert result.text == "hello from the fake provider"
+    assert result.transcript_path == (tmp_path / "transcription.json").resolve()
+    assert downloader.calls[0][0] == "https://example.test/video.mp4"
+    assert extractor.calls[0][0] == workspace.video_path
+    assert extractor.calls[0][2] == 1.5
+
+
+def test_cleans_up_when_provider_fails(tmp_path):
+    source = tmp_path / "video.mp4"
+    source.write_bytes(b"video")
+    service, workspace, downloader, extractor, _ = make_service(tmp_path)
+
+    class FailingProvider:
+        model = "failing-model"
+
+        def transcribe(self, audio_path: Path) -> ProviderTranscription:
+            raise RuntimeError("provider failed")
+
+    service = TranscriptionService(
+        downloader=downloader,
+        audio_extractor=extractor,
+        provider=FailingProvider(),
+        workspace_provider=FakeWorkspaceProvider(workspace),
+        writer=JsonTranscriptionWriter(),
+    )
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        service.transcribe(TranscriptionRequest(source=str(source)))
+
+    assert workspace.cleaned is True
+
+
+def test_rejects_invalid_speed(tmp_path):
+    service, _, _, _, _ = make_service(tmp_path)
+
+    with pytest.raises(ValueError, match="between 0.5 and 2.0"):
+        service.transcribe(
+            TranscriptionRequest(source="video.mp4", playback_speed=2.1)
+        )

--- a/shotcut/agent-harness/cli_anything/shotcut/utils/melt_backend.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/utils/melt_backend.py
@@ -58,14 +58,45 @@ def _validate_extra_args(extra_args: list) -> list:
     return extra_args
 
 
+def _is_mlt_melt(path: str) -> bool:
+    """Return whether an executable identifies itself as MLT melt."""
+    try:
+        result = subprocess.run(
+            [path, "-version"], capture_output=True, text=True, timeout=10
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    output = f"{result.stdout}\n{result.stderr}".lower()
+    return result.returncode == 0 and "mlt" in output and "melt" in output
+
+
 def find_melt() -> str:
-    """Find the melt executable. Raises RuntimeError if not found."""
-    path = shutil.which("melt")
-    if path:
-        return path
+    """Find a validated MLT melt executable.
+
+    ``SHOTCUT_MELT`` takes precedence. On macOS, Shotcut bundles its own
+    MLT binary, which is preferred over unrelated executables named ``melt``.
+    """
+    candidates = []
+    for env_name in ("SHOTCUT_MELT", "MLT_MELT"):
+        configured = os.environ.get(env_name)
+        if configured:
+            candidates.append(configured)
+
+    candidates.extend([
+        "/Applications/Shotcut.app/Contents/MacOS/melt",
+        shutil.which("melt"),
+    ])
+
+    seen = set()
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK) and _is_mlt_melt(candidate):
+                return candidate
+
     raise RuntimeError(
-        "melt is not installed. Install it with:\n"
-        "  apt install melt   # Debian/Ubuntu"
+        "An MLT melt executable was not found. Set SHOTCUT_MELT to its path "
+        "or install Shotcut/MLT."
     )
 
 

--- a/shotcut/agent-harness/cli_anything/shotcut/utils/mlt_xml.py
+++ b/shotcut/agent-harness/cli_anything/shotcut/utils/mlt_xml.py
@@ -66,6 +66,11 @@ def write_mlt(root: ET.Element, filepath: str) -> None:
     """
     pretty = copy.deepcopy(root)
     normalize_top_level_order(pretty)
+    main_tractor = get_main_tractor(pretty)
+    if main_tractor is not None and main_tractor.get("id"):
+        # Shotcut opens the root producer as the active timeline. Keep the
+        # media bin available, but make saved projects open on the tractor.
+        pretty.set("producer", main_tractor.get("id"))
     ET.indent(pretty, space="  ")
     tree = ET.ElementTree(pretty)
     tree.write(filepath, xml_declaration=True, encoding="utf-8")
@@ -200,7 +205,9 @@ def create_blank_project(profile: dict) -> ET.Element:
     root.set("LC_NUMERIC", "C")
     root.set("version", "7.36.1")
     root.set("title", "Shotcut version 26.2.26")
-    root.set("producer", "main_bin")
+    # Shotcut opens the root producer as the active timeline. The media bin
+    # remains available as main_bin, but it must not be the project output.
+    root.set("producer", "tractor0")
 
     # Profile
     prof = ET.SubElement(root, "profile")

--- a/shotcut/agent-harness/setup.py
+++ b/shotcut/agent-harness/setup.py
@@ -39,6 +39,12 @@ setup(
         "defusedxml>=0.7.1",
     ],
     extras_require={
+        "transcription": [
+            "mistralai>=1.0.0",
+        ],
+        "local-tts": [
+            "coqui-tts>=0.27.0",
+        ],
         "dev": [
             "pytest>=7.0.0",
             "pytest-cov>=4.0.0",


### PR DESCRIPTION
## Summary

- Add `media add-subtitles` to burn timestamped transcript JSON into videos
- Generate bold, centered, outlined ASS captions and render them with ffmpeg
- Add validation, injectable renderer tests, and CLI documentation
- Include the related transcription, TTS, Instagram download, and credential wiring already present in the working tree

## Usage

```bash
cli-anything-shotcut media transcribe input.mp4 -o input.transcript.json
cli-anything-shotcut media add-subtitles input.mp4 --transcript input.transcript.json -o subtitled.mp4
```

## Verification

- Focused subtitle and transcription tests: 3 passed
- Full Shotcut suite: 260 passed; existing full-E2E failures require `/root/shotcut/1.mp4` and include unrelated preview/CLI assumptions