### PR TITLE
Add Vivideo CLI to public registry

### DIFF
--- a/public_registry.json
+++ b/public_registry.json
@@ -492,6 +492,28 @@
           "url": "https://github.com/goddardoven110907"
         }
       ]
+    },
+    {
+      "name": "vivideo",
+      "display_name": "Vivideo CLI",
+      "version": "1.0.2",
+      "description": "Vivideo AI video generation CLI — create avatar and text-to-video content from the terminal, scripts, CI, or agents. Supports auto and manual modes, model/avatar/voice/brand-kit listing, credit estimates, and status/wait polling.",
+      "category": "ai",
+      "requires": "Node.js >= 18.17, VIVIDEO_API_KEY",
+      "homepage": "https://vivideo.ai",
+      "source_url": null,
+      "package_manager": "npm",
+      "npm_package": "@vivideo/cli",
+      "install_cmd": "npm install -g @vivideo/cli",
+      "npx_cmd": "npx @vivideo/cli",
+      "skill_md": "https://vivideo.ai",
+      "entry_point": "vivideo",
+      "contributors": [
+        {
+          "name": "Vivideo",
+          "url": "https://vivideo.ai"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds **Vivideo CLI** (`@vivideo/cli`) to `public_registry.json` so it shows up on CLI-Hub alongside the other third-party/official npm CLIs (e.g. MiniMax CLI).

Vivideo is an AI video generation platform ([vivideo.ai](https://vivideo.ai)). The CLI lets agents, scripts, and CI create videos directly from the terminal.

## Registry entry

- **Package:** [`@vivideo/cli`](https://www.npmjs.com/package/@vivideo/cli) (npm, v1.0.2)
- **Install:** `npm install -g @vivideo/cli` / `npx @vivideo/cli`
- **Entry point:** `vivideo`
- **Requires:** Node.js >= 18.17, `VIVIDEO_API_KEY`
- **Category:** `ai`
- **Homepage:** https://vivideo.ai

## Capabilities

Structured, agent-friendly subcommands: `account`, `models`, `avatars`, `voices`, `brand-kits`, `estimate`, `create` (`auto` / `manual`), `status <id>`, `wait <id>`, `videos`, `render <id>`, plus `configure`/`config` for secure API-key storage.

## Notes

- `source_url` is `null` (closed-source, official CLI — same pattern as the existing `minimax-cli` entry).
- JSON validated locally; entry appended to the `clis` array.

Made with [Cursor](https://cursor.com)