### PR TITLE
fix(inkscape): autosave new documents to project path

### DIFF
--- a/inkscape/agent-harness/cli_anything/inkscape/inkscape_cli.py
+++ b/inkscape/agent-harness/cli_anything/inkscape/inkscape_cli.py
@@ -207,9 +207,12 @@ def document_new(width, height, units, background, name, profile, output):
         background=background, name=name, profile=profile,
     )
     sess = get_session()
-    sess.set_project(proj, output)
+    auto_save_path = sess.project_path if _auto_save and not _dry_run else None
+    sess.set_project(proj, output or auto_save_path)
     if output:
         doc_mod.save_document(proj, output)
+    elif auto_save_path:
+        sess.save_session()
     output_data = doc_mod.get_document_info(proj)
     globals()["output"](output_data, f"Created document: {name}")
 

--- a/inkscape/agent-harness/cli_anything/inkscape/tests/test_full_e2e.py
+++ b/inkscape/agent-harness/cli_anything/inkscape/tests/test_full_e2e.py
@@ -729,6 +729,29 @@ class TestCLISubprocess:
         assert result.returncode == 0
         assert os.path.exists(out)
 
+    def test_document_new_autosaves_to_project_path(self, tmp_dir):
+        out = os.path.join(tmp_dir, "autosaved.json")
+        result = self._run([
+            "--project", out, "--save", "document", "new",
+            "--name", "autosaved", "--width", "720", "--height", "960",
+        ])
+
+        assert result.returncode == 0
+        with open(out, encoding="utf-8") as project_file:
+            project = json.load(project_file)
+        assert project["name"] == "autosaved"
+        assert project["document"]["width"] == 720
+        assert project["document"]["height"] == 960
+
+    def test_document_new_autosave_respects_dry_run(self, tmp_dir):
+        out = os.path.join(tmp_dir, "dry-run.json")
+        result = self._run([
+            "--project", out, "--save", "--dry-run", "document", "new",
+        ])
+
+        assert result.returncode == 0
+        assert not os.path.exists(out)
+
     def test_document_new_json_output(self, tmp_dir):
         out = os.path.join(tmp_dir, "test.json")
         result = self._run(["--json", "document", "new", "-o", out])


### PR DESCRIPTION
## Description

`document new` discarded the path supplied through the top-level `--project`
option. Because `Session.set_project()` also resets the modified flag, the
`--save` close callback had neither a path nor a pending mutation to persist.

This change reuses the current session project path only when `--save` is
enabled and the command is not a dry run. Explicit `document new -o ...`
continues to use its existing save path and behavior.

Fixes #404

## Type of Change

- [ ] **New Software CLI (in-repo)**
- [ ] **New Software CLI (standalone repo)**
- [ ] **New Feature**
- [x] **Bug Fix**
- [ ] **Documentation**
- [ ] **Other**

---

### For Existing CLI Modifications

- [x] All unit tests pass: `153 passed`
- [x] All backend-independent harness tests pass: `204 passed, 5 backend tests deselected`
- [x] No previously passing tests were removed or weakened
- [x] `registry.json` does not require an update because version, description, and requirements are unchanged

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] No new command or JSON output contract was introduced
- [x] Commit message follows the repository's conventional format
- [x] Tested locally

## Test Results

```text
pytest cli_anything/inkscape/tests/test_core.py -q
153 passed

pytest cli_anything/inkscape/tests/test_full_e2e.py -q -k "TestCLISubprocess"
15 passed, 41 deselected

pytest cli_anything/inkscape/tests -q \
  -k "not TestInkscapeBackend and not TestInkscapeExportE2E"
204 passed, 5 deselected

python -m compileall -q cli_anything/inkscape
passed

git diff --check
passed
```

The five deselected tests invoke the external Inkscape executable, which is not
installed in the local Windows environment. The changed behavior and both new
regressions execute through the real CLI subprocess path without requiring the
GUI/backend.

## Boundary

- Preserves the existing no-save behavior when `--save` is absent.
- Preserves `--dry-run` by not creating the project file.
- Does not change session storage, other mutation commands, or registry data.
