### PR TITLE
fix(codex-skill): ship references/ and vendored scripts in the skill bundle

### DIFF
--- a/codex-skill/references/HARNESS.md
+++ b/codex-skill/references/HARNESS.md
@@ -1,0 +1,1 @@
+../../cli-anything-plugin/HARNESS.md

--- a/codex-skill/references/commands
+++ b/codex-skill/references/commands
@@ -1,0 +1,1 @@
+../../cli-anything-plugin/commands

--- a/codex-skill/references/docs/PREVIEW_PROTOCOL.md
+++ b/codex-skill/references/docs/PREVIEW_PROTOCOL.md
@@ -1,0 +1,1 @@
+../../../docs/PREVIEW_PROTOCOL.md

--- a/codex-skill/references/guides
+++ b/codex-skill/references/guides
@@ -1,0 +1,1 @@
+../../cli-anything-plugin/guides

--- a/codex-skill/scripts/install.ps1
+++ b/codex-skill/scripts/install.ps1
@@ -37,6 +37,10 @@ try {
     New-Item -ItemType Directory -Path $stagingDir | Out-Null
     Get-ChildItem -LiteralPath $skillDir -Force | Copy-Item -Destination $stagingDir -Recurse -Force
 
+    # Drop repo-internal symlinks — the canonical copies below re-vendor the real
+    # files from cli-anything-plugin/ so the installed skill is fully self-contained.
+    Remove-Item -LiteralPath (Join-Path $stagingDir "references"), (Join-Path $stagingDir "scripts\templates"), (Join-Path $stagingDir "scripts\repl_skin.py"), (Join-Path $stagingDir "scripts\preview_bundle.py"), (Join-Path $stagingDir "scripts\skill_generator.py") -Recurse -Force -ErrorAction SilentlyContinue
+
     $referenceDir = Join-Path $stagingDir "references"
     $referenceCommands = Join-Path $referenceDir "commands"
     $referenceDocs = Join-Path $referenceDir "docs"

--- a/codex-skill/scripts/install.sh
+++ b/codex-skill/scripts/install.sh
@@ -40,6 +40,16 @@ trap cleanup EXIT
 
 STAGING_DIR="$(mktemp -d "${DEST_ROOT}/.cli-anything.tmp.XXXXXX")"
 cp -R "${SKILL_DIR}/." "${STAGING_DIR}/"
+
+# Drop repo-internal symlinks — the canonical copies below re-vendor the real
+# files from cli-anything-plugin/ so the installed skill is fully self-contained.
+rm -rf \
+  "${STAGING_DIR}/references" \
+  "${STAGING_DIR}/scripts/templates" \
+  "${STAGING_DIR}/scripts/repl_skin.py" \
+  "${STAGING_DIR}/scripts/preview_bundle.py" \
+  "${STAGING_DIR}/scripts/skill_generator.py"
+
 mkdir -p \
   "${STAGING_DIR}/references/commands" \
   "${STAGING_DIR}/references/docs" \

--- a/codex-skill/scripts/preview_bundle.py
+++ b/codex-skill/scripts/preview_bundle.py
@@ -1,0 +1,1 @@
+../../cli-anything-plugin/preview_bundle.py

--- a/codex-skill/scripts/repl_skin.py
+++ b/codex-skill/scripts/repl_skin.py
@@ -1,0 +1,1 @@
+../../cli-anything-plugin/repl_skin.py

--- a/codex-skill/scripts/skill_generator.py
+++ b/codex-skill/scripts/skill_generator.py
@@ -1,0 +1,1 @@
+../../cli-anything-plugin/skill_generator.py

--- a/codex-skill/scripts/templates
+++ b/codex-skill/scripts/templates
@@ -1,0 +1,1 @@
+../../cli-anything-plugin/templates

--- a/codex-skill/tests/test_install.sh
+++ b/codex-skill/tests/test_install.sh
@@ -79,6 +79,30 @@ fi
 grep -q 'references/HARNESS.md' "${INSTALLED_DIR}/SKILL.md" ||
   fail "installed SKILL.md does not point to vendored HARNESS.md"
 
+# Simulate `npx skills add HKUDS/CLI-Anything --skill cli-anything`, which copies
+# the skill directory resolving symlinks (fs.cp dereference:true) but does NOT run
+# install.sh. The vendored resources must be present in the repo checkout itself.
+NPX_STYLE_DIR="${TMP_DIR}/npx-style"
+mkdir -p "${NPX_STYLE_DIR}"
+cp -rL "${SKILL_DIR}/." "${NPX_STYLE_DIR}/"
+assert_file "${NPX_STYLE_DIR}/references/HARNESS.md"
+assert_file "${NPX_STYLE_DIR}/references/commands/cli-anything.md"
+assert_file "${NPX_STYLE_DIR}/references/commands/refine.md"
+assert_file "${NPX_STYLE_DIR}/references/commands/test.md"
+assert_file "${NPX_STYLE_DIR}/references/commands/validate.md"
+assert_file "${NPX_STYLE_DIR}/references/commands/list.md"
+assert_file "${NPX_STYLE_DIR}/references/guides/session-locking.md"
+assert_file "${NPX_STYLE_DIR}/scripts/repl_skin.py"
+assert_file "${NPX_STYLE_DIR}/scripts/preview_bundle.py"
+assert_file "${NPX_STYLE_DIR}/scripts/skill_generator.py"
+assert_file "${NPX_STYLE_DIR}/scripts/templates/SKILL.md.template"
+assert_file "${NPX_STYLE_DIR}/references/docs/PREVIEW_PROTOCOL.md"
+assert_same "${PLUGIN_DIR}/HARNESS.md" "${NPX_STYLE_DIR}/references/HARNESS.md"
+assert_same "${REPO_ROOT}/docs/PREVIEW_PROTOCOL.md" "${NPX_STYLE_DIR}/references/docs/PREVIEW_PROTOCOL.md"
+assert_tree_same "${PLUGIN_DIR}/commands" "${NPX_STYLE_DIR}/references/commands"
+[[ ! -L "${NPX_STYLE_DIR}/references/HARNESS.md" ]] ||
+  fail "npx-style copy left a symlink behind (dereference failed)"
+
 DETACHED_ROOT="${TMP_DIR}/detached"
 DETACHED_LOG="${TMP_DIR}/detached-install.log"
 mkdir -p "${DETACHED_ROOT}"


### PR DESCRIPTION
## Summary

Fixes #433 — `npx skills add HKUDS/CLI-Anything --skill cli-anything` installs a broken skill: `SKILL.md` tells agents to read `references/HARNESS.md` and `references/commands/`, but those files were never part of the installed bundle, so agents silently lost the full 7-phase methodology.

## Root cause

The `cli-anything` skill lives in `codex-skill/`. It is installed two ways:

1. **`install.sh` / `install.ps1`** (full repo checkout): the scripts vendor `HARNESS.md`, `commands/`, `guides/`, `templates/`, and the Python helpers from `cli-anything-plugin/` at install time. This path worked.
2. **`npx skills add`** (open agent skills ecosystem CLI, v1.5.x): copies the skill directory only, resolving symlinks (`fs.cp` with `dereference: true`), and **never runs `install.sh`**. This path shipped `SKILL.md` + `agents/` + `scripts/` + `tests/` with no `references/` — confirmed by reproducing the exact command from the issue.

## Fix

Add versioned symlinks inside `codex-skill/` pointing at the canonical resources in `cli-anything-plugin/` (and `docs/PREVIEW_PROTOCOL.md`):

- `references/HARNESS.md`, `references/commands/`, `references/guides/`, `references/docs/PREVIEW_PROTOCOL.md`
- `scripts/repl_skin.py`, `scripts/preview_bundle.py`, `scripts/skill_generator.py`, `scripts/templates/`

The skills CLI resolves symlinks when copying (`dereference: true`), so the installed bundle becomes self-contained, while the repo keeps a **single source of truth** in `cli-anything-plugin/` — no duplicated content to drift.

Both installers now drop those symlinks from the staging directory before re-vendoring the real files, so full-checkout installs behave exactly as before.

## Testing

- `bash codex-skill/tests/test_install.sh` → **PASS** (existing suite, unchanged expectations)
- New test section simulates the `npx skills add` copy semantics (`cp -rL`, symlink dereferencing) and asserts the full resource set lands in the bundle with content identical to the canonical sources
- End-to-end: `npx skills add yunaremaia/CLI-Anything#fix/skill-bundle-references --skill cli-anything -g -y` now installs `references/HARNESS.md`, `references/commands/*.md`, `references/guides/*.md`, `references/docs/PREVIEW_PROTOCOL.md`, `scripts/repl_skin.py`, `scripts/preview_bundle.py`, `scripts/skill_generator.py`, `scripts/templates/SKILL.md.template` — all real files, zero leftover symlinks, `sha256` identical to the canonical sources.

## Checklist

- [x] Fixes #433
- [x] Reproduction documented (issue + verified locally)
- [x] Test covers the fixed behavior (npx-style dereference copy)
- [x] Existing installer test still passes
- [x] No duplicated content — symlinks keep `cli-anything-plugin/` as the single source of truth
