### PR TITLE
feat(registry): add Meta2d.js CLI registration

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -6,6 +6,25 @@
   },
   "clis": [
     {
+      "name": "meta2d",
+      "display_name": "Meta2d.js",
+      "version": "0.1.0",
+      "description": "Agent-Native CLI for Meta2d.js — create, edit and export Meta2dData diagrams headlessly in Node.js without a browser",
+      "requires": "Node.js 18+ with meta2d.js monorepo",
+      "homepage": "https://github.com/lixi523/meta2d.js",
+      "source_url": "https://github.com/lixi523/meta2d.js",
+      "install_cmd": "pnpm install && pnpm --filter @meta2d/cli build",
+      "entry_point": "meta2d",
+      "skill_md": "https://github.com/lixi523/meta2d.js/blob/main/packages/cli/SKILL.md",
+      "category": "diagrams",
+      "contributors": [
+        {
+          "name": "Tony Stark (Multica Agent)",
+          "url": "https://github.com/lixi523"
+        }
+      ]
+    },
+    {
       "name": "jumpserver",
       "display_name": "JumpServer",
       "version": "0.1.0",


### PR DESCRIPTION
## Summary

Register Meta2d.js CLI in the CLI-Anything public registry.

## Changes

- Added `meta2d` entry to `registry.json` at position 0 (top of list)
- `diagrams` category (same as drawio, mermaid)
- `source_url` points to https://github.com/lixi523/meta2d.js
- `skill_md` points to `packages/cli/SKILL.md` in the meta2d.js repo

## Meta2d.js CLI Overview

10 agent-native commands covering full diagram lifecycle:

| Command | Description |
|---------|-------------|
| `init` | Create new empty Meta2dData diagram |
| `open` | Load and validate diagram file |
| `add` | Add shapes (single or batch) |
| `update` | Update shape properties |
| `remove` | Remove shapes by id |
| `save` | Validate and write back normalized JSON |
| `set-data` | Batch set global properties (networks, grid) |
| `connect` | Declarative network connection config |
| `export` | Export to PNG (napi-canvas) or SVG |
| `serve` | Express HTTP server with JWT auth + persistence |

- 102 Jest tests passing, 92%+ coverage
- SSRF whitelist protection on `connect`
- Structured JSON error envelope conforming to CLI-Anything spec
- Ajv schema validation against Meta2dData schema

## Testing

```bash
pnpm --filter @meta2d/cli test
# Test Suites: 8 passed, 8 total
# Tests:       102 passed, 102 total
```

## Related

- PR on meta2d.js: https://github.com/lixi523/meta2d.js/pull/1 (merged)