### PR TITLE
fix(adguardhome): add __main__ guard so the test dev fallback invokes the CLI

### DIFF
--- a/adguardhome/agent-harness/cli_anything/adguardhome/adguardhome_cli.py
+++ b/adguardhome/agent-harness/cli_anything/adguardhome/adguardhome_cli.py
@@ -674,3 +674,7 @@ def tls_(ctx: click.Context):
 def tls_status(ctx: click.Context):
     client = make_client(ctx)
     output(server_core.get_tls_status(client), ctx.obj["as_json"])
+
+
+if __name__ == "__main__":
+    main()

--- a/adguardhome/agent-harness/cli_anything/adguardhome/tests/test_full_e2e.py
+++ b/adguardhome/agent-harness/cli_anything/adguardhome/tests/test_full_e2e.py
@@ -186,10 +186,12 @@ class TestCLISubprocess:
     def test_rewrite_help(self):
         result = self._run(["rewrite", "--help"])
         assert result.returncode == 0
+        assert "list" in result.stdout
 
     def test_blocking_help(self):
         result = self._run(["blocking", "--help"])
         assert result.returncode == 0
+        assert "parental" in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/adguardhome/agent-harness/setup.py
+++ b/adguardhome/agent-harness/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name="cli-anything-adguardhome",
-    version="1.0.0",
+    version="1.0.1",
     description="CLI harness for AdGuardHome - control your ad blocker from the command line",
     packages=find_namespace_packages(include=["cli_anything.*"]),
     install_requires=[

--- a/registry.json
+++ b/registry.json
@@ -122,7 +122,7 @@
     {
       "name": "adguardhome",
       "display_name": "AdGuardHome",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "DNS ad-blocking and network infrastructure management via AdGuardHome REST API",
       "requires": "AdGuardHome instance running",
       "homepage": "https://adguard.com/adguard-home/overview.html",


### PR DESCRIPTION
## Description

`cli_anything/adguardhome/adguardhome_cli.py` defines `main()` but never calls it under an
`if __name__ == "__main__":` guard. Running that module directly therefore exits 0 with empty stdout
— and that is exactly the module path `_resolve_cli()` in `tests/test_full_e2e.py` falls back to when
the console script is not on `PATH`, so five of the seven subprocess tests fail on a plain checkout.
Two further tests (`test_rewrite_help`, `test_blocking_help`) asserted only the exit code and stayed
green throughout, which is why the pair could not surface it.

This PR adds the guard, brings those two tests in line with their siblings by asserting
command-specific stdout, and bumps the harness patch version.

Scope note: 63 of 68 CLI modules in the repo already have the guard. The others without it are
eth2-quickstart, mubu, siyuan and zotero, but their console-script targets differ
(`:main`, `:entrypoint`, `:cli`), so they are deliberately not touched here. Happy to follow up on
them in a separate PR if you want.

Fixes #436

## Type of Change

- [x] **Bug Fix** — fixes incorrect behavior

---

### For Existing CLI Modifications

- [x] All unit tests pass: `python3 -m pytest cli_anything/adguardhome/tests/test_core.py -v`
- [x] All E2E tests pass: `python3 -m pytest cli_anything/adguardhome/tests/test_full_e2e.py -v`
      (the `TestDockerE2E` class is deselected below — no Docker access on my machine; the seven
      `TestCLISubprocess` tests do run and pass)
- [x] No test regressions — no previously passing tests were removed or weakened; the two changed
      tests gained an assertion, they did not lose one
- [x] `registry.json` entry is updated (`version` 1.0.0 → 1.0.1, matching `setup.py`)

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands (no new commands in this PR)
- [x] Commit messages follow the conventional format (`fix:`)
- [x] I have tested my changes locally

## Test Results

Before the fix, on a plain checkout with no console script on `PATH`:

```
$ env -u AGH_HOST -u AGH_PORT -u AGH_USERNAME -u AGH_PASSWORD PYTHONPATH=. \
    python3 -m pytest cli_anything/adguardhome/tests/test_full_e2e.py::TestCLISubprocess -q -s
[_resolve_cli] Falling back to: /usr/bin/python3 -m cli_anything.adguardhome.adguardhome_cli
5 failed, 2 passed in 2.78s
```

After the fix, same command, same conditions:

```
$ env -u AGH_HOST -u AGH_PORT -u AGH_USERNAME -u AGH_PASSWORD PYTHONPATH=. \
    python3 -m pytest cli_anything/adguardhome/tests/test_full_e2e.py::TestCLISubprocess -q -s
[_resolve_cli] Falling back to: /usr/bin/python3 -m cli_anything.adguardhome.adguardhome_cli
7 passed in 2.51s
```

Full non-Docker set after the fix:

```
$ env -u AGH_HOST -u AGH_PORT -u AGH_USERNAME -u AGH_PASSWORD PYTHONPATH=. \
    python3 -m pytest cli_anything/adguardhome/tests/ -q \
    --deselect cli_anything/adguardhome/tests/test_full_e2e.py::TestDockerE2E
...............................                                          [100%]
31 passed, 5 deselected in 2.54s
```

Environment: Linux aarch64, Python 3.13.5, pytest 9.0.3, click 8.3.3.
