### PR TITLE
fix(adguardhome): keep --json parsable on connection errors and fix the Docker port hint

### DIFF
--- a/adguardhome/agent-harness/cli_anything/adguardhome/adguardhome_cli.py
+++ b/adguardhome/agent-harness/cli_anything/adguardhome/adguardhome_cli.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import click
+import requests
 
 from cli_anything.adguardhome.core import blocking as blocking_core
 from cli_anything.adguardhome.core import clients as clients_core
@@ -84,7 +85,17 @@ def cli(ctx: click.Context, host, port, username, password, config_path, use_htt
 
 
 def main():
-    cli(obj={})
+    try:
+        cli(obj={})
+    except (RuntimeError, requests.exceptions.RequestException) as exc:
+        # Backend failures reach this point as exceptions; without this handler they
+        # surface as a chained traceback and --json produces nothing parsable.
+        # sys.argv is used because the Click context is already unwound here.
+        if "--json" in sys.argv:
+            click.echo(json.dumps({"error": str(exc)}, default=str))
+        else:
+            click.echo(str(exc), err=True)
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/adguardhome/agent-harness/cli_anything/adguardhome/tests/test_core.py
+++ b/adguardhome/agent-harness/cli_anything/adguardhome/tests/test_core.py
@@ -93,6 +93,11 @@ class TestAdGuardHomeClient:
             assert result == {}
             mock_post.assert_called_once()
 
+    def test_connection_error_docker_hint_maps_to_container_port(self):
+        client = AdGuardHomeClient(host="localhost", port=3001)
+        message = str(client._connection_error(Exception("refused")))
+        assert "-p 3001:3000" in message
+
     def test_connection_error_raises_runtime(self):
         c = make_client()
         with patch.object(c.session, "get", side_effect=requests.exceptions.ConnectionError("refused")):

--- a/adguardhome/agent-harness/cli_anything/adguardhome/tests/test_full_e2e.py
+++ b/adguardhome/agent-harness/cli_anything/adguardhome/tests/test_full_e2e.py
@@ -191,6 +191,27 @@ class TestCLISubprocess:
         result = self._run(["blocking", "--help"])
         assert result.returncode == 0
 
+    def test_connection_error_json_is_parsable(self):
+        """--json must stay machine-readable when the server is unreachable."""
+        result = self._run(
+            ["--json", "--host", "127.0.0.1", "--port", "1", "server", "status"],
+            check=False,
+        )
+        assert result.returncode != 0
+        data = json.loads(result.stdout)
+        assert "Cannot connect to AdGuardHome" in data["error"]
+        assert "Traceback" not in result.stderr
+
+    def test_connection_error_human_message(self):
+        """Without --json the message goes to stderr, without a traceback."""
+        result = self._run(
+            ["--host", "127.0.0.1", "--port", "1", "server", "status"],
+            check=False,
+        )
+        assert result.returncode != 0
+        assert "Cannot connect to AdGuardHome" in result.stderr
+        assert "Traceback" not in result.stderr
+
 
 # ---------------------------------------------------------------------------
 # Docker E2E tests

--- a/adguardhome/agent-harness/cli_anything/adguardhome/utils/adguardhome_backend.py
+++ b/adguardhome/agent-harness/cli_anything/adguardhome/utils/adguardhome_backend.py
@@ -38,7 +38,8 @@ class AdGuardHomeClient:
             f"Cannot connect to AdGuardHome at {self.base_url}.\n"
             f"Ensure AdGuardHome is running and accessible.\n"
             f"Install: curl -s -S -L https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/master/scripts/install.sh | sh -s -- -v\n"
-            f"Or Docker: docker run --name adguardhome -p {self.port}:{self.port} adguard/adguardhome\n"
+            f"Or Docker: docker run --name adguardhome -p {self.port}:3000 adguard/adguardhome\n"
+            f"(the container serves its web interface on port 3000 - keep that port in the setup wizard)\n"
             f"Error: {e}"
         )
 


### PR DESCRIPTION
## Description

Two fixes on the connection-error path of the adguardhome harness.

**1. `main()` had no error handling.** It was just `cli(obj={})`, so a `RuntimeError` from
`AdGuardHomeClient._connection_error()` reached the terminal behind a chained
urllib3 → requests → click traceback. With `--json`, stdout stayed empty (0 bytes) — an agent calling
the CLI got nothing parsable at all. `main()` now catches `RuntimeError` and
`requests.exceptions.RequestException` (so HTTP status errors and timeouts are covered too, not just
the connection path), prints `{"error": ...}` on stdout in `--json` mode and the plain message on
stderr otherwise, and exits 1 either way.

The handler reads `--json` from `sys.argv`, because the Click context is already unwound by the time
the exception surfaces in `main()`. If you would rather see this solved inside the Click layer — or
in the harness template, since other harnesses have the same bare `main()` — I am happy to rework it.

**2. The Docker hint in that message could not work.** It rendered
`-p {self.port}:{self.port}`, mapping the host port onto itself, so with `--port 3001` it printed
`-p 3001:3001`. The image serves its web interface on container port 3000 — which the harness already
assumes elsewhere: the E2E fixture maps `-p {AGH_TEST_PORT}:3000` and pins `web.port` to 3000 through
the install API, and `README.md` shows `-p 3000:3000`. The hint now maps to `:3000` and adds a line
telling the user to keep the web interface on 3000 in the setup wizard, since the wizard's own
default for the admin interface is port 80.

Fixes #437

Merge order: on a plain checkout the subprocess tests can only exercise this once #438 lands (without
that `__main__` guard the fallback module is inert). The test results below therefore come from the
documented procedure, `pip install -e .` first. This PR does not touch `registry.json` — #438 already
bumps the same version line, and I did not want two open PRs editing it.

## Type of Change

- [x] **Bug Fix** — fixes incorrect behavior

---

### For Existing CLI Modifications

- [x] All unit tests pass: `python3 -m pytest cli_anything/adguardhome/tests/test_core.py -v`
- [x] All E2E tests pass: `python3 -m pytest cli_anything/adguardhome/tests/test_full_e2e.py -v`
      (`TestDockerE2E` deselected — no Docker access on my machine)
- [x] No test regressions — three tests added, none removed or weakened
- [ ] `registry.json` entry is updated if version, description, or requirements changed — see the
      merge-order note above; happy to add the bump here if you prefer it in this PR

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands (no new commands in this PR)
- [x] Commit messages follow the conventional format (`fix:`)
- [x] I have tested my changes locally

## Test Results

```
$ env -u AGH_HOST -u AGH_PORT -u AGH_USERNAME -u AGH_PASSWORD CLI_ANYTHING_FORCE_INSTALLED=1 \
    python -m pytest cli_anything/adguardhome/tests/ -q \
    --deselect cli_anything/adguardhome/tests/test_full_e2e.py::TestDockerE2E
..................................                                       [100%]
34 passed, 5 deselected in 2.74s
```

Behaviour before and after, against a port with nothing listening:

```console
# before
$ cli-anything-adguardhome --json --host 127.0.0.1 --port 1 server status
# stdout: 0 bytes; stderr: long chained traceback; rc=1

# after
$ cli-anything-adguardhome --json --host 127.0.0.1 --port 1 server status
{"error": "Cannot connect to AdGuardHome at http://127.0.0.1:1/control.\nEnsure AdGuardHome is running and accessible.\n..."}
# rc=1, stderr empty

$ cli-anything-adguardhome --host 127.0.0.1 --port 1 server status
Cannot connect to AdGuardHome at http://127.0.0.1:1/control.
Ensure AdGuardHome is running and accessible.
Install: curl -s -S -L https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/master/scripts/install.sh | sh -s -- -v
Or Docker: docker run --name adguardhome -p 1:3000 adguard/adguardhome
(the container serves its web interface on port 3000 - keep that port in the setup wizard)
Error: HTTPConnectionPool(host='127.0.0.1', port=1): Max retries exceeded with url: /control/status ...
# rc=1, stdout empty
```

Environment: Linux aarch64, Python 3.13.5, pytest 9.0.3, click 8.4.2, requests 2.34.2.
