### PR TITLE
fix: add __main__ guards to the remaining four CLI modules

### DIFF
--- a/eth2-quickstart/agent-harness/cli_anything/eth2_quickstart/eth2_quickstart_cli.py
+++ b/eth2-quickstart/agent-harness/cli_anything/eth2_quickstart/eth2_quickstart_cli.py
@@ -282,3 +282,7 @@ def health_check_cmd(ctx):
     backend = backend_from_context(ctx)
     result = health_check(backend)
     emit(result, ctx.obj["as_json"])
+
+
+if __name__ == "__main__":
+    main()

--- a/mubu/agent-harness/cli_anything/mubu/mubu_cli.py
+++ b/mubu/agent-harness/cli_anything/mubu/mubu_cli.py
@@ -765,3 +765,7 @@ __all__ = [
     "session_state_dir",
     "session_state_path",
 ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(entrypoint())

--- a/siyuan/agent-harness/cli_anything/siyuan/siyuan_cli.py
+++ b/siyuan/agent-harness/cli_anything/siyuan/siyuan_cli.py
@@ -800,3 +800,7 @@ def tag_list(ctx: SiYuanContext):
         click.echo(json.dumps(tags, ensure_ascii=False))
     else:
         _print_tags(tags)
+
+
+if __name__ == "__main__":
+    cli()

--- a/zotero/agent-harness/cli_anything/zotero/zotero_cli.py
+++ b/zotero/agent-harness/cli_anything/zotero/zotero_cli.py
@@ -1083,3 +1083,7 @@ def dispatch(argv: list[str] | None = None, prog_name: str | None = None) -> int
 
 def entrypoint(argv: list[str] | None = None) -> int:
     return dispatch(argv, prog_name=sys.argv[0])
+
+
+if __name__ == "__main__":
+    raise SystemExit(entrypoint())


### PR DESCRIPTION
## Description

Follow-up to #438, as offered there. Four CLI modules define their entry point but never invoke it
under an `if __name__ == "__main__":` guard, so `python -m cli_anything.<pkg>.<pkg>_cli` exits 0 with
no output at all. 63 of the 68 CLI modules in the repo already have the guard; this adds it to the
remaining four.

Each guard calls exactly the callable that harness's console script points at, so a module run
behaves like an installed run:

| Harness | `console_scripts` target | guard added |
|---|---|---|
| eth2-quickstart | `eth2_quickstart_cli:main` | `main()` |
| mubu | `mubu_cli:entrypoint` | `raise SystemExit(entrypoint())` |
| siyuan | `siyuan_cli:cli` | `cli()` |
| zotero | `zotero_cli:entrypoint` | `raise SystemExit(entrypoint())` |

`entrypoint()` returns an exit code in mubu and zotero, so `SystemExit` propagates it the way
setuptools' console-script wrapper does.

**Scope note, so this is not oversold:** unlike #438, none of these four have a broken test suite
today. Their tests either do not use the `_resolve_cli()` fallback at all, or — in siyuan's case —
resolve to `cli_anything.siyuan`, the package path, which works because `__main__.py` carries the
guard. This PR is a consistency fix that removes a silent no-op, not a test fix.

Refs #436

## Type of Change

- [x] **Bug Fix** — fixes incorrect behavior

---

### For Existing CLI Modifications

- [x] All unit tests pass — see below; the failures listed are pre-existing on `main` and unrelated
- [x] No test regressions — verified by running each suite before and after the change
- [ ] `registry.json` entry is updated if version, description, or requirements changed — no version
      bump included, since this changes no documented behaviour of the installed CLIs. Happy to add
      bumps for all four if you prefer.

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands (no new commands in this PR)
- [x] Commit messages follow the conventional format (`fix:`)
- [x] I have tested my changes locally

## Test Results

Each module now produces its help output instead of exiting silently:

```console
$ PYTHONPATH=. python -m cli_anything.eth2_quickstart.eth2_quickstart_cli --help   # rc=0, 749 bytes
$ PYTHONPATH=. python -m cli_anything.mubu.mubu_cli --help                         # rc=0, 1843 bytes
$ PYTHONPATH=. python -m cli_anything.siyuan.siyuan_cli --help                     # rc=0, 757 bytes
$ PYTHONPATH=. python -m cli_anything.zotero.zotero_cli --help                     # rc=0, 1140 bytes
```

Suites, run per harness with `PYTHONPATH=. python -m pytest cli_anything/<pkg>/tests/ -q`:

```
eth2-quickstart   18 passed,  3 skipped
mubu               1 failed, 93 passed, 12 skipped
siyuan            41 passed,  5 skipped
zotero             6 failed, 69 passed, 13 skipped
```

The mubu and zotero failures are identical on unmodified `main` (verified by stashing this change and
re-running), so they are pre-existing and not caused here:

```
mubu     test_cli_entrypoint.py::CliEntrypointTests::test_default_entrypoint_banner_includes_skill_path
zotero   test_core.py::ImportCoreTests::test_import_json_url_attachment_uses_delay_and_default_timeout  (+5 more)
```

Two side observations while testing, both left untouched here — say the word if you want either as a
separate issue:

- running mubu's suite rewrites the tracked file `cli_anything/mubu/skills/SKILL.md`, leaving the
  working tree dirty after a test run;
- zotero's usage line under `python -m` shows the full module path, because `entrypoint()` passes
  `prog_name=sys.argv[0]`.

Environment: Linux aarch64, Python 3.13.5, pytest 9.0.3, click 8.4.2.
