### PR TITLE
fix(inkscape): render stars as standard SVG paths

### DIFF
--- a/inkscape/agent-harness/cli_anything/inkscape/core/document.py
+++ b/inkscape/agent-harness/cli_anything/inkscape/core/document.py
@@ -12,7 +12,7 @@ from typing import Optional, Dict, Any, List
 
 from cli_anything.inkscape.utils.svg_utils import (
     create_svg_element, serialize_svg, write_svg_file, parse_svg_file,
-    SVG_NS, INKSCAPE_NS, SODIPODI_NS, find_all_shapes, _ns,
+    SVG_NS, INKSCAPE_NS, find_all_shapes, _ns,
 )
 
 # Document profiles (common canvas presets)
@@ -414,7 +414,6 @@ def _object_to_svg_element(obj: Dict[str, Any]):
         tag = f"{{{SVG_NS}}}path"
         if "d" in obj:
             attribs["d"] = obj["d"]
-        attribs[_ns("sodipodi", "type")] = "star"
 
     else:
         return None

--- a/inkscape/agent-harness/cli_anything/inkscape/inkscape_cli.py
+++ b/inkscape/agent-harness/cli_anything/inkscape/inkscape_cli.py
@@ -1023,7 +1023,7 @@ def repl(project_path):
     global _repl_mode
     _repl_mode = True
 
-    skin = ReplSkin("inkscape", version="1.0.0")
+    skin = ReplSkin("inkscape", version="1.0.1")
 
     if project_path:
         _load_or_seed_project(project_path)

--- a/inkscape/agent-harness/cli_anything/inkscape/skills/SKILL.md
+++ b/inkscape/agent-harness/cli_anything/inkscape/skills/SKILL.md
@@ -299,4 +299,4 @@ When using this CLI programmatically:
 
 ## Version
 
-1.0.0
+1.0.1

--- a/inkscape/agent-harness/cli_anything/inkscape/tests/test_core.py
+++ b/inkscape/agent-harness/cli_anything/inkscape/tests/test_core.py
@@ -16,7 +16,7 @@ from cli_anything.inkscape.utils.svg_utils import (
     parse_style, serialize_style, validate_color, generate_id,
     reset_id_counter, create_svg_element, serialize_svg,
     find_defs, find_element_by_id, remove_element_by_id,
-    SVG_NS, INKSCAPE_NS,
+    SVG_NS, INKSCAPE_NS, SODIPODI_NS,
 )
 from cli_anything.inkscape.core.document import (
     create_document, open_document, save_document, get_document_info,
@@ -254,6 +254,17 @@ class TestDocument:
         assert len(text_nodes) == 1
         tspans = list(text_nodes[0].iter(f"{{{SVG_NS}}}tspan"))
         assert len(tspans) > 1
+
+    def test_project_to_svg_star_uses_standard_path_only(self):
+        proj = create_document(name="svg_star", background="none")
+        add_star(proj, cx=100, cy=100, points_count=5, outer_r=50, inner_r=25)
+
+        svg = project_to_svg(proj)
+        star_paths = list(svg.iter(f"{{{SVG_NS}}}path"))
+
+        assert len(star_paths) == 1
+        assert star_paths[0].get("d")
+        assert f"{{{SODIPODI_NS}}}type" not in star_paths[0].attrib
 
 
 class TestCliBootstrap:

--- a/inkscape/agent-harness/setup.py
+++ b/inkscape/agent-harness/setup.py
@@ -13,7 +13,7 @@ with open("cli_anything/inkscape/README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="cli-anything-inkscape",
-    version="1.0.0",
+    version="1.0.1",
     author="cli-anything contributors",
     author_email="",
     description="CLI harness for Inkscape - SVG vector graphics with export via inkscape --export-filename. Requires: inkscape (apt install inkscape)",

--- a/registry.json
+++ b/registry.json
@@ -350,7 +350,7 @@
     {
       "name": "inkscape",
       "display_name": "Inkscape",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "SVG vector graphics with export via inkscape --export-filename",
       "requires": "inkscape (apt install inkscape)",
       "homepage": "https://inkscape.org",

--- a/skills/cli-anything-inkscape/SKILL.md
+++ b/skills/cli-anything-inkscape/SKILL.md
@@ -298,4 +298,4 @@ When using this CLI programmatically:
 
 ## Version
 
-1.0.0
+1.0.1


### PR DESCRIPTION
## Summary

- serialize generated stars as standard SVG paths
- remove the incomplete `sodipodi:type="star"` marker
- add a regression test and bump the Inkscape harness registry version to 1.0.1

## Root cause

The exporter emitted valid path geometry together with a live-star marker but none of the required Sodipodi star parameters. Inkscape therefore ignored the path geometry and rendered nothing.

## Validation

- `python3 -m pytest cli_anything/inkscape/tests/test_core.py -q` — 154 passed
- `python3 -m compileall -q cli_anything/inkscape/core/document.py cli_anything/inkscape/tests/test_core.py`
- `git diff --check`

This intentionally favors portable rendered SVG geometry over preserving the star as an editable Inkscape live primitive.

Fixes #405

