### PR TITLE
fix: normalize PyPI requirements in registry date updater

### DIFF
--- a/.github/scripts/tests/test_update_registry_dates.py
+++ b/.github/scripts/tests/test_update_registry_dates.py
@@ -81,3 +81,9 @@ def test_extract_pypi_package_returns_none_for_editable_only_install():
     install_cmd = "pip install -e ."
 
     assert MODULE._extract_pypi_package(install_cmd) is None
+
+
+def test_extract_pypi_package_strips_extras_and_version_specifier():
+    install_cmd = "pip install 'requests[socks]>=2.32'"
+
+    assert MODULE._extract_pypi_package(install_cmd) == "requests"

--- a/.github/scripts/update_registry_dates.py
+++ b/.github/scripts/update_registry_dates.py
@@ -19,6 +19,12 @@ USER_AGENT = "CLI-Anything registry date updater"
 GITHUB_REPO_RE = re.compile(r"https://github\.com/([^/]+/[^/#?]+?)(?:\.git)?(?:[/?#].*)?$")
 GIT_URL_RE = re.compile(r"https://github\.com/[^\s#]+")
 SUBDIRECTORY_RE = re.compile(r"#subdirectory=([^\s]+)")
+PYPI_REQUIREMENT_RE = re.compile(
+    r"^(?P<name>[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)"
+    r"(?:\[[A-Za-z0-9._,-]+\])?"
+    r"(?:[<>=!~].*)?"
+    r"(?:;.*)?$"
+)
 PIP_OPTIONS_WITH_VALUES = {
     "-c",
     "--constraint",
@@ -165,7 +171,8 @@ def _extract_pypi_package(install_cmd: str) -> str | None:
             continue
         if "://" in token or token.startswith("git+"):
             return None
-        return token
+        requirement = PYPI_REQUIREMENT_RE.fullmatch(token)
+        return requirement.group("name") if requirement else None
     return None
 
 


### PR DESCRIPTION
## Description

The registry date updater passed complete pip requirement strings such as requests[socks]>=2.32 to the PyPI JSON endpoint. Extras and version specifiers are valid in pip install commands, but they are not part of the PyPI project name, so those lookups returned no release date.

This extracts and validates the distribution name before querying PyPI while preserving the existing handling for command options and non-PyPI sources. A regression test covers a requirement containing both extras and a minimum version.

## Type of Change

- [x] **Bug Fix** — fixes incorrect behavior

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] No CLI command behavior is changed
- [x] Commit message follows the conventional format
- [x] Changes tested locally

## Test Results

    python3 -m pytest .github/scripts/tests/test_update_registry_dates.py -q
    9 passed in 2.27s

Additional checks: Python compilation and git diff validation passed.