### PR TITLE
fix(skill-generator): respect explicit --output paths

### DIFF
--- a/cli-anything-plugin/skill_generator.py
+++ b/cli-anything-plugin/skill_generator.py
@@ -536,8 +536,9 @@ def generate_skill_file(harness_path: str, output_path: Optional[str] = None,
 
     Args:
         harness_path: Path to the agent-harness directory
-        output_path: Optional output path for SKILL.md
-                     (default: skills/cli-anything-<software>/SKILL.md)
+        output_path: Optional explicit output path for SKILL.md. When provided,
+                     only this path is written. When omitted, writes the canonical
+                     skill and packaged compatibility copy.
         template_path: Optional path to custom Jinja2 template
 
     Returns:
@@ -552,6 +553,7 @@ def generate_skill_file(harness_path: str, output_path: Optional[str] = None,
     # Determine output path
     harness_path_obj = Path(harness_path)
     compatibility_path = harness_path_obj / "cli_anything" / metadata.software_name / "skills" / "SKILL.md"
+    write_compatibility_copy = output_path is None
     if output_path is None:
         repo_root = harness_path_obj.parent.parent
         output_path = repo_root / "skills" / metadata.skill_name / "SKILL.md"
@@ -563,7 +565,7 @@ def generate_skill_file(harness_path: str, output_path: Optional[str] = None,
 
     # Write file
     output_path.write_text(content, encoding="utf-8")
-    if compatibility_path != output_path:
+    if write_compatibility_copy and compatibility_path != output_path:
         compatibility_path.parent.mkdir(parents=True, exist_ok=True)
         compatibility_path.write_text(content, encoding="utf-8")
 

--- a/cli-anything-plugin/tests/test_skill_generator.py
+++ b/cli-anything-plugin/tests/test_skill_generator.py
@@ -542,6 +542,8 @@ class TestGenerateSkillFile:
         assert Path(output).exists()
         content = Path(output).read_text()
         assert "cli-anything-testapp" in content
+        compatibility_path = harness_dir / "cli_anything" / "testapp" / "skills" / "SKILL.md"
+        assert compatibility_path.read_text() == content
 
     def test_generates_file_at_custom_path(self, harness_dir, tmp_path):
         output_file = tmp_path / "custom" / "SKILL.md"
@@ -549,6 +551,16 @@ class TestGenerateSkillFile:
         assert Path(output).exists()
         content = Path(output).read_text()
         assert "testapp" in content.lower()
+
+    def test_custom_path_does_not_modify_compatibility_copy(self, harness_dir, tmp_path):
+        compatibility_path = harness_dir / "cli_anything" / "testapp" / "skills" / "SKILL.md"
+        compatibility_path.parent.mkdir(parents=True)
+        compatibility_path.write_text("# Existing packaged skill\n")
+
+        output_file = tmp_path / "custom" / "SKILL.md"
+        generate_skill_file(str(harness_dir), str(output_file))
+
+        assert compatibility_path.read_text() == "# Existing packaged skill\n"
 
     def test_creates_parent_directories(self, harness_dir, tmp_path):
         output_file = tmp_path / "deep" / "nested" / "dir" / "SKILL.md"

--- a/mubu/agent-harness/cli_anything/mubu/tests/test_agent_harness.py
+++ b/mubu/agent-harness/cli_anything/mubu/tests/test_agent_harness.py
@@ -1,5 +1,7 @@
+import shutil
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -100,17 +102,23 @@ class AgentHarnessPackagingTests(unittest.TestCase):
         self.assertIn("skin.print_goodbye()", repl_skin)
 
     def test_skill_generator_can_regenerate_skill_from_canonical_harness(self):
-        output_path = HARNESS_ROOT / "tmp-generated-SKILL.md"
-        try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            copied_harness = Path(tmp_dir) / "agent-harness"
+            shutil.copytree(HARNESS_ROOT, copied_harness)
+            output_path = Path(tmp_dir) / "generated-SKILL.md"
+            compatibility_path = copied_harness / "cli_anything" / "mubu" / "skills" / "SKILL.md"
+            existing_content = "# Existing packaged skill\n"
+            compatibility_path.write_text(existing_content, encoding="utf-8")
+
             result = subprocess.run(
                 [
                     sys.executable,
-                    str(HARNESS_ROOT / "skill_generator.py"),
-                    str(HARNESS_ROOT),
+                    str(copied_harness / "skill_generator.py"),
+                    str(copied_harness),
                     "--output",
                     str(output_path),
                 ],
-                cwd=HARNESS_ROOT,
+                cwd=copied_harness,
                 capture_output=True,
                 text=True,
             )
@@ -130,8 +138,7 @@ class AgentHarnessPackagingTests(unittest.TestCase):
             self.assertNotIn("Workspace/Daily tasks", content)
             self.assertNotIn("Daily tasks resolution", content)
             self.assertIn("## Version\n\n0.1.1", content)
-        finally:
-            output_path.unlink(missing_ok=True)
+            self.assertEqual(compatibility_path.read_text(encoding="utf-8"), existing_content)
 
 
 if __name__ == "__main__":

--- a/mubu/agent-harness/skill_generator.py
+++ b/mubu/agent-harness/skill_generator.py
@@ -406,6 +406,7 @@ def generate_skill_file(harness_path: str, output_path: Optional[str] = None, te
     content = generate_skill_md(metadata, template_path)
     harness_root = Path(harness_path)
     skill_id = f"cli-anything-{harness_root.parent.name.replace('_', '-')}"
+    write_mirror = output_path is None
     if output_path is None:
         output = harness_root.parent.parent / "skills" / skill_id / "SKILL.md"
     else:
@@ -413,7 +414,7 @@ def generate_skill_file(harness_path: str, output_path: Optional[str] = None, te
     mirror = harness_root / "cli_anything" / metadata.software_name / "skills" / "SKILL.md"
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(content, encoding="utf-8")
-    if mirror != output:
+    if write_mirror and mirror != output:
         mirror.parent.mkdir(parents=True, exist_ok=True)
         mirror.write_text(content, encoding="utf-8")
     return str(output)

--- a/zotero/agent-harness/cli_anything/zotero/tests/test_agent_harness.py
+++ b/zotero/agent-harness/cli_anything/zotero/tests/test_agent_harness.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -37,11 +39,17 @@ class AgentHarnessPackagingTests(unittest.TestCase):
         self.assertEqual(result.stdout.strip(), "0.1.0")
 
     def test_skill_generator_regenerates_skill(self):
-        output_path = HARNESS_ROOT / "tmp-SKILL.md"
-        try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            copied_harness = Path(tmp_dir) / "agent-harness"
+            shutil.copytree(HARNESS_ROOT, copied_harness)
+            output_path = Path(tmp_dir) / "generated-SKILL.md"
+            compatibility_path = copied_harness / "cli_anything" / "zotero" / "skills" / "SKILL.md"
+            existing_content = "# Existing packaged skill\n"
+            compatibility_path.write_text(existing_content, encoding="utf-8")
+
             result = subprocess.run(
-                [sys.executable, str(HARNESS_ROOT / "skill_generator.py"), str(HARNESS_ROOT), "--output", str(output_path)],
-                cwd=HARNESS_ROOT,
+                [sys.executable, str(copied_harness / "skill_generator.py"), str(copied_harness), "--output", str(output_path)],
+                cwd=copied_harness,
                 capture_output=True,
                 text=True,
             )
@@ -55,5 +63,4 @@ class AgentHarnessPackagingTests(unittest.TestCase):
             self.assertIn("### Item", content)
             self.assertIn("### Note", content)
             self.assertIn("| `add` |", content)
-        finally:
-            output_path.unlink(missing_ok=True)
+            self.assertEqual(compatibility_path.read_text(encoding="utf-8"), existing_content)

--- a/zotero/agent-harness/skill_generator.py
+++ b/zotero/agent-harness/skill_generator.py
@@ -273,11 +273,12 @@ def generate_skill_file(harness_path: str, output_path: Optional[str] = None, te
     content = generate_skill_md(metadata, template_path=template_path)
     harness_root = Path(harness_path)
     skill_id = f"cli-anything-{harness_root.parent.name.replace('_', '-')}"
-    output = Path(output_path) if output_path else harness_root.parent.parent / "skills" / skill_id / "SKILL.md"
+    write_mirror = output_path is None
+    output = Path(output_path) if output_path is not None else harness_root.parent.parent / "skills" / skill_id / "SKILL.md"
     mirror = harness_root / "cli_anything" / metadata.software_name / "skills" / "SKILL.md"
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(content, encoding="utf-8")
-    if mirror != output:
+    if write_mirror and mirror != output:
         mirror.parent.mkdir(parents=True, exist_ok=True)
         mirror.write_text(content, encoding="utf-8")
     return str(output)


### PR DESCRIPTION
## Description
Passing an explicit `--output` to `skill_generator.py` still rewrote the packaged compatibility `SKILL.md`. This caused generator tests to leave the working tree dirty even though their requested output was temporary.

This change:
- writes only the requested file when `--output` is provided;
- preserves canonical and compatibility generation when `--output` is omitted;
- applies the behavior consistently to the plugin, Mubu, and Zotero generators;
- runs the Mubu and Zotero regression tests against temporary harness copies and verifies that the packaged skill remains unchanged.

Fixes #441 

## Type of Change

- [ ] **New Software CLI (in-repo)** — adds a CLI harness inside this monorepo
- [ ] **New Software CLI (standalone repo)** — registry-only PR pointing to an external repo
- [ ] **New Feature** — adds new functionality to an existing harness or the plugin
- [x] **Bug Fix** — fixes incorrect behavior
- [ ] **Documentation** — updates docs only
- [ ] **Other** — please describe:

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands
- [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
- [x] I have tested my changes locally

## Test Results

```text
cli-anything-plugin/tests/test_skill_generator.py
42 passed

mubu/agent-harness/cli_anything/mubu/tests/test_agent_harness.py
11 passed

zotero/agent-harness/cli_anything/zotero/tests/test_agent_harness.py
4 passed

python3 .github/scripts/validate_root_skills.py
Root skills validation passed.

git diff --check
passed
```

The focused suites cover all three modified generator implementations. The working tree remained clean after running them.
No CLI runtime behavior is changed by this PR.