### PR TITLE
fix(preview): select latest bundle across recipes

### DIFF
--- a/cli-anything-plugin/preview_bundle.py
+++ b/cli-anything-plugin/preview_bundle.py
@@ -146,6 +146,7 @@ def find_latest_manifest(
         search_root = Path.home() / ".cli-anything" / "previews" / _slug(software)
     if recipe:
         search_root = search_root / _slug(recipe)
+    latest: Optional[tuple[str, str, Path, Dict[str, Any]]] = None
     for manifest_path in _iter_manifests(search_root):
         try:
             manifest = _load_json(manifest_path)
@@ -159,13 +160,23 @@ def find_latest_manifest(
             continue
         if manifest.get("status") not in {"ok", "partial"}:
             continue
-        manifest["_manifest_path"] = str(manifest_path.resolve())
-        manifest["_bundle_dir"] = str(manifest_path.parent.resolve())
-        manifest["_summary_path"] = str(
-            (manifest_path.parent / manifest.get("summary_path", "summary.json")).resolve()
+        candidate = (
+            str(manifest.get("created_at") or ""),
+            str(manifest.get("bundle_id") or ""),
+            manifest_path,
+            manifest,
         )
-        return manifest
-    return None
+        if latest is None or candidate[:2] > latest[:2]:
+            latest = candidate
+    if latest is None:
+        return None
+    _, _, manifest_path, manifest = latest
+    manifest["_manifest_path"] = str(manifest_path.resolve())
+    manifest["_bundle_dir"] = str(manifest_path.parent.resolve())
+    manifest["_summary_path"] = str(
+        (manifest_path.parent / manifest.get("summary_path", "summary.json")).resolve()
+    )
+    return manifest
 
 
 def prepare_bundle(

--- a/cli-anything-plugin/tests/test_preview_bundle.py
+++ b/cli-anything-plugin/tests/test_preview_bundle.py
@@ -1,0 +1,53 @@
+"""Tests for shared preview bundle helpers."""
+
+import json
+import sys
+from pathlib import Path
+
+
+_PLUGIN_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PLUGIN_DIR))
+
+from preview_bundle import PROTOCOL_VERSION, find_latest_manifest
+
+
+def _write_manifest(
+    root: Path,
+    *,
+    recipe: str,
+    bundle_id: str,
+    created_at: str,
+) -> None:
+    bundle_dir = root / "test-app" / recipe / bundle_id
+    bundle_dir.mkdir(parents=True)
+    manifest = {
+        "protocol_version": PROTOCOL_VERSION,
+        "bundle_id": bundle_id,
+        "bundle_kind": "capture",
+        "software": "test-app",
+        "recipe": recipe,
+        "status": "ok",
+        "created_at": created_at,
+    }
+    (bundle_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
+def test_find_latest_manifest_compares_created_at_across_recipes(tmp_path):
+    preview_root = tmp_path / "previews"
+    _write_manifest(
+        preview_root,
+        recipe="z-last-alphabetically",
+        bundle_id="20260101T000000Z_old",
+        created_at="2026-01-01T00:00:00Z",
+    )
+    _write_manifest(
+        preview_root,
+        recipe="a-first-alphabetically",
+        bundle_id="20260201T000000Z_new",
+        created_at="2026-02-01T00:00:00Z",
+    )
+
+    latest = find_latest_manifest("test-app", root_dir=str(preview_root))
+
+    assert latest is not None
+    assert latest["bundle_id"] == "20260201T000000Z_new"


### PR DESCRIPTION
## Description

When preview latest is called without a recipe filter, manifest paths are currently sorted as full strings. The recipe directory therefore takes precedence over the timestamped bundle directory, so an older bundle under a lexicographically later recipe can be returned as the latest preview.

This scans the valid candidates and selects the maximum created_at value, using bundle_id as a deterministic tie-breaker. A regression test covers bundles whose recipe-name order conflicts with creation order.

## Type of Change

- [x] **Bug Fix** — fixes incorrect behavior

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] No new CLI commands are introduced
- [x] Commit message follows the conventional format
- [x] Changes tested locally

## Test Results

    python3 -m pytest tests/test_preview_bundle.py tests/test_skill_generator.py -q
    42 passed in 2.34s

Additional checks: Python compilation and git diff --check passed.