### PR TITLE
feat(opencti): add OpenCTI agent harness — read/write GraphQL v7 CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -345,3 +345,7 @@ assets/gen_typing_gif.py
 !/jumpserver/
 !/jumpserver/agent-harness/
 !/cli_anything/jumpserver/
+!/opencti/
+/opencti/*
+/opencti/.*
+!/opencti/agent-harness/

--- a/README.md
+++ b/README.md
@@ -1140,6 +1140,13 @@ Each application received complete, production-ready CLI interfaces — not demo
 <td align="center">✅ <a href="n8n/agent-harness/">55+ cmds</a></td>
 </tr>
 <tr>
+<td align="center"><strong>🛡️ <a href="opencti/agent-harness/">OpenCTI</a></strong></td>
+<td>Threat Intelligence</td>
+<td><code>cli-anything-opencti</code></td>
+<td>OpenCTI GraphQL API v7</td>
+<td align="center">✅ <a href="opencti/agent-harness/">20+ cmds</a></td>
+</tr>
+<tr>
 <td align="center"><strong>📧 <a href="mailchimp/agent-harness/">Mailchimp</a></strong></td>
 <td>Email Marketing &amp; Automation</td>
 <td><code>cli-anything-mailchimp</code></td>

--- a/opencti/agent-harness/OPENCTI.md
+++ b/opencti/agent-harness/OPENCTI.md
@@ -1,0 +1,121 @@
+# OpenCTI: Project-Specific Analysis & SOP
+
+## Architecture Summary
+
+OpenCTI is an open-source threat intelligence platform built on a GraphQL API
+(Node.js) over Elasticsearch, with a React frontend. Intelligence objects
+(indicators, observables, reports, cases, threat actors, malware) follow the
+STIX 2.1 standard and are stored as entities connected by STIX relationships.
+
+```
++----------------------------------------------------------+
+|                    OpenCTI Platform                       |
+|  +--------------------+   +---------------------------+  |
+|  |   GraphQL API      |   |      React Frontend       |  |
+|  |   (single /graphql |   +---------------------------+  |
+|  |    endpoint)       |                                  |
+|  +---------+----------+                                  |
+|            |                                             |
+|  +---------v-------------------------------------+       |
+|  | Elasticsearch (objects) | RabbitMQ (queueing)  |      |
+|  | MinIO (files)           | Redis (pubsub/cache) |      |
+|  +-----------------------------------------------+       |
++----------------------------------------------------------+
+              |
+     Connectors ingest from MISP, CVE feeds, etc.
+```
+
+## CLI Strategy: GraphQL over HTTP
+
+Unlike file-format tools, OpenCTI is network-native. The harness is a thin
+client over one endpoint:
+
+1. **Single POST** to `{base_url}/graphql` per operation; auth via
+   `Authorization: Bearer <token>`.
+2. **Relay pagination** (`edges` / `pageInfo {endCursor hasNextPage}`) is
+   normalized by a shared `paginated()` helper so every list command returns a
+   flat list of nodes.
+3. **Retry policy**: 429/5xx/connection errors retried up to 4 times with
+   exponential backoff + jitter; server `Retry-After` honored.
+4. **Writes with guardrails**: create mutations for observables, indicators,
+   reports, cases, entities, and relationships; deletion requires an explicit
+   `--force` flag (without it, `delete` is a dry-run). Status messages go to
+   stderr so stdout stays machine-parseable.
+
+### GraphQL Conventions Discovered on v7 (7.260824.0)
+
+- Fields are snake_case at the API surface: `created_at`, `updated_at`,
+  `observable_value`, `x_opencti_score`, `valid_from`, `valid_until`,
+  `pattern_type`.
+- Observable queries are named `stixCyberObservables` / `stixCyberObservable`
+  (NOT `stixObservables` — that name does not exist on v7 Query).
+- Connections must select through edges:
+  `externalReferences { edges { node { source_name url } } }`; selecting
+  `source_name` directly fails validation.
+- Filters use the structured form
+  `{"mode":"and","filters":[{"key","values","operator"}],"filterGroups":[]}`;
+  pattern prefix search uses `operator: "starts_with"` on key `"pattern"`.
+- Case types have dedicated top-level queries: `caseIncidents`, `caseRfis`,
+  `caseRfts` (+ singular `caseIncident(id)` etc.) — there is no generic
+  `cases` query.
+- STIX export is a field selection: `{ toStix }` returns a JSON-encoded STIX
+  2.1 bundle for any STIX object or relationship.
+- Observable creation uses per-type input objects (`IPv4Addr: {value: ...}`,
+  `StixFile: {hashes: {"SHA-256": ...}}`) plus common args
+  (`x_opencti_score`, `objectLabel`, `createIndicator`).
+- Entity adds: v7 splits threat actors into Group/Individual; this harness
+  creates groups via `threatActorGroupAdd`.
+- Relationship types are validated server-side against STIX rules (e.g.
+  `uses` is rejected between Threat-Actor-Group and Domain-Name; `related-to`
+  is broadly allowed).
+- Deletion: `stixCoreObjectEdit(id) { delete }` for any object,
+  `stixCoreRelationshipEdit(id) { delete }` for relationships;
+  `stixDomainObjectsDelete(idList)` exists for bulk domain-object deletion.
+
+## Module Map
+
+```
+cli_anything/opencti/
+├── opencti_cli.py        # Click groups; --json at group level; REPL
+├── core/
+│   ├── system.py         # about / me / status (version + identity + liveness)
+│   ├── observables.py    # stixCyberObservables list/get/export-stix
+│   ├── indicators.py     # indicators list/get/search-pattern
+│   ├── reports.py        # reports list/get (+ contained objects)
+│   ├── cases.py          # caseIncidents/caseRfis/caseRfts dispatch
+│   ├── entities.py       # threat-actor/intrusion-set/malware/campaign/tool
+│   └── relationships.py  # stixCoreRelationships
+├── utils/
+│   ├── opencti_backend.py# transport: retry/backoff/pagination/config resolution
+│   └── repl_skin.py      # unmodified plugin copy + output helpers
+└── tests/
+    ├── test_core.py      # mocked unit tests (23)
+    └── test_full_e2e.py  # live tests gated by OPENCTI_E2E=1 (9)
+```
+
+## Configuration Resolution
+
+Precedence: CLI args > environment > `~/.cli-anything/opencti/config.json`.
+
+- `OPENCTI_BASE_URL` (alias `OPENCTI_URL`) — e.g. `http://localhost:8090`
+- `OPENCTI_API_KEY` (alias `OPENCTI_TOKEN`) — bearer token
+- `OPENCTI_TIMEOUT` — seconds (default 30)
+
+## Verification Performed
+
+- Unit suite: 34 tests, all HTTP mocked (transport, retries, pagination guard,
+  filter payloads, type dispatch, write mutation payloads).
+- E2E suite: 10 tests against OpenCTI 7.260824.0 in OrbStack Docker
+  (`http://localhost:8090`), including a full write lifecycle
+  (create observable + auto-indicator + entity -> relate -> export STIX ->
+  delete everything, asserting no residue).
+- Manual smoke: every CLI write command exercised against the live instance
+  (observable/entity/report/case add, relationship add, delete guard,
+  --force deletes); instance verified clean afterwards.
+
+## Known Limitations
+
+- No update/patch commands yet (`*Edit` field patches are unexposed).
+- Relationship listing is unfiltered (no `--from/--to/--type` yet).
+- File-hash observables supported via `hashes`; binary upload not exposed.
+- No connector management (that lives in separate worker containers).

--- a/opencti/agent-harness/cli_anything/opencti/README.md
+++ b/opencti/agent-harness/cli_anything/opencti/README.md
@@ -1,0 +1,91 @@
+# cli-anything-opencti
+
+Agent-native CLI for the [OpenCTI](https://github.com/OpenCTI-Platform/opencti)
+threat intelligence platform — built with the
+[CLI-Anything](https://github.com/HKUDS/CLI-Anything) pattern.
+
+Query and create observables, indicators, reports, cases, named threat
+entities, and relationships over OpenCTI's GraphQL API v7. Every command
+supports `--json` for machine-readable output, making the whole platform
+scriptable by AI agents. Deletion requires an explicit `--force`.
+
+Verified against OpenCTI **7.260824.0**.
+
+## Installation
+
+```bash
+pip install cli-anything-opencti
+
+# or from this repo
+pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=opencti/agent-harness
+```
+
+## Configuration
+
+Precedence: CLI flags > environment variables > `~/.cli-anything/opencti/config.json`.
+
+```bash
+export OPENCTI_BASE_URL=http://localhost:8090
+export OPENCTI_API_KEY=<your-api-token>
+
+# persist instead:
+cli-anything-opencti config set --url http://localhost:8090 --token <token>
+cli-anything-opencti config test
+```
+
+## Usage
+
+```bash
+cli-anything-opencti status                     # version + identity + liveness
+cli-anything-opencti whoami --json              # token identity as JSON
+
+cli-anything-opencti observable search 185.220 --type ipv4-addr
+cli-anything-opencti indicator list --limit 50 --json
+cli-anything-opencti indicator search-pattern "[ipv4-addr:value"
+cli-anything-opencti report list --all          # follow all pages
+cli-anything-opencti case list --type rfi
+cli-anything-opencti entity get threat-actor <uuid>
+cli-anything-opencti search apt41 --types Threat-Actor,Intrusion-Set
+cli-anything-opencti export-stix --id <uuid> -o bundle.json
+
+# writes
+cli-anything-opencti observable add domain-name evil.example --score 90 --create-indicator
+cli-anything-opencti indicator add "C2 domain" --pattern "[domain-name:value = 'evil.example']"
+cli-anything-opencti entity add threat-actor "APT-X" --alias "APT-X Prime"
+cli-anything-opencti relationship add <actor-id> <observable-id> related-to
+cli-anything-opencti delete <id>                # dry-run; add --force to execute
+```
+
+`--json` is a group-level flag and goes before the subcommand:
+
+```bash
+cli-anything-opencti --json indicator list
+```
+
+## Command Reference
+
+| Group | Commands |
+|-------|----------|
+| observable | `search QUERY [--type csv]`, `get ID`, `add TYPE VALUE [--score] [--label] [--create-indicator]` |
+| indicator | `list [--search]`, `get ID`, `search-pattern PREFIX`, `add NAME --pattern P` |
+| report | `list [--search]`, `get ID`, `add NAME [--published ISO] [--type csv]` |
+| relationship | `list`, `add FROM TO TYPE` |
+| case | `list --type incident\|rfi\|rft`, `get ID --type ...`, `add --type T NAME [--severity] [--priority]` |
+| entity | `list TYPE`, `get TYPE ID`, `add TYPE NAME [--alias csv]` for threat-actor\|intrusion-set\|malware\|campaign\|tool |
+| top-level | `status`, `whoami`, `search QUERY [--types]`, `export-stix --id ID [-o FILE]`, `delete ID [--force]` |
+| config | `set --url URL [--token T]`, `test` |
+
+Run with no subcommand to enter an interactive REPL with completion.
+Status/success/error messages are written to stderr; stdout stays
+machine-parseable for piping into `jq`.
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest -m "not e2e"                                   # mocked unit tests
+OPENCTI_E2E=1 OPENCTI_BASE_URL=... OPENCTI_API_KEY=... \
+  pytest -m e2e                                       # live instance required
+```
+
+See [OPENCTI.md](OPENCTI.md) for architecture analysis and the SOP.

--- a/opencti/agent-harness/cli_anything/opencti/__init__.py
+++ b/opencti/agent-harness/cli_anything/opencti/__init__.py
@@ -1,0 +1,1 @@
+# cli_anything.opencti — CLI harness for the OpenCTI threat intelligence platform

--- a/opencti/agent-harness/cli_anything/opencti/__main__.py
+++ b/opencti/agent-harness/cli_anything/opencti/__main__.py
@@ -1,0 +1,5 @@
+"""Enable python -m cli_anything.opencti"""
+from cli_anything.opencti.opencti_cli import main
+
+if __name__ == "__main__":
+    main()

--- a/opencti/agent-harness/cli_anything/opencti/core/cases.py
+++ b/opencti/agent-harness/cli_anything/opencti/core/cases.py
@@ -1,0 +1,106 @@
+"""Case operations: incidents, RFIs, RFTs."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from cli_anything.opencti.utils.opencti_backend import graphql_request, paginated
+
+CASE_TYPES = {
+    "incident": ("caseIncidents", "caseIncident"),
+    "rfi": ("caseRfis", "caseRfi"),
+    "rft": ("caseRfts", "caseRft"),
+}
+
+LIST_FIELDS = """
+edges {
+  node {
+    id standard_id name severity priority created_at
+    createdBy { name }
+    objectMarking { definition }
+  }
+}
+pageInfo { endCursor hasNextPage }
+"""
+
+DETAIL_FIELDS = """
+id standard_id name description severity priority
+created_at updated_at
+createdBy { name standard_id }
+objectLabel { value color }
+objectMarking { definition }
+objects(first: 50) {
+  edges { node { ... on BasicObject { id standard_id entity_type } } }
+}
+"""
+
+
+def _query_for(field_name: str, fields: str) -> str:
+    return f"""
+    query ($first: Int, $after: ID, $search: String) {{
+      {field_name}(first: $first, after: $after, search: $search) {{
+        {fields}
+      }}
+    }}"""
+
+
+def list_cases(case_type: str = "incident", *, search: Optional[str] = None,
+               first: int = 25, all_pages: bool = False, **kw):
+    field = CASE_TYPES[case_type][0]
+
+    def fetch(after):
+        q = _query_for(field, LIST_FIELDS)
+        return graphql_request(q, {"first": first, "after": after, "search": search},
+                               **kw)[field]
+
+    return paginated(fetch, max_pages=100 if all_pages else 1)
+
+
+def get_case(case_type: str, case_id: str, **kw):
+    q = f"""
+    query ($id: String!) {{
+      {CASE_TYPES[case_type][1]}(id: $id) {{ {DETAIL_FIELDS} }}
+    }}"""
+    return graphql_request(q, {"id": case_id}, **kw)[CASE_TYPES[case_type][1]]
+
+
+# ─── Writes ─────────────────────────────────────────────────────────────────
+
+ADD_RESULT_FIELDS = "id standard_id name created_at"
+
+ADD_INPUT_NAMES = {
+    "incident": "CaseIncidentAddInput",
+    "rfi": "CaseRfiAddInput",
+    "rft": "CaseRftAddInput",
+}
+MUTATION_NAMES = {
+    "incident": "caseIncidentAdd",
+    "rfi": "caseRfiAdd",
+    "rft": "caseRftAdd",
+}
+
+
+def add_case(case_type: str, name: str, *, severity: Optional[str] = None,
+             priority: Optional[str] = None, description: Optional[str] = None,
+             labels: Optional[list] = None, **kw) -> Dict[str, Any]:
+    """Create a case of the given type."""
+    case_type = case_type.lower()
+    input_name = ADD_INPUT_NAMES[case_type]
+    mutation = MUTATION_NAMES[case_type]
+    inp: Dict[str, Any] = {"name": name}
+    if severity:
+        inp["severity"] = severity.lower()
+    if priority:
+        inp["priority"] = priority.lower()
+    if description:
+        inp["description"] = description
+    if labels:
+        inp["objectLabel"] = [l.strip() for l in labels if l.strip()]
+    q = f"""
+    mutation ($input: {input_name}!) {{
+      {mutation}(input: $input) {{ {ADD_RESULT_FIELDS} }}
+    }}"""
+    result = graphql_request(q, {"input": inp}, **kw)[mutation]
+    if not result:
+        raise ValueError(f"case creation failed for {name!r}")
+    return result

--- a/opencti/agent-harness/cli_anything/opencti/core/entities.py
+++ b/opencti/agent-harness/cli_anything/opencti/core/entities.py
@@ -1,0 +1,125 @@
+"""Named threat-intel entities."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from cli_anything.opencti.utils.opencti_backend import graphql_request, paginated
+
+
+# name -> (list field, get field, node fields)
+ENTITY_TYPES = {
+    "threat-actor": ("threatActors", "threatActor",
+                     "id standard_id name description created_at updated_at "
+                     "createdBy { name } objectMarking { definition }"),
+    "intrusion-set": ("intrusionSets", "intrusionSet",
+                      "id standard_id name description first_seen last_seen "
+                      "created_at updated_at createdBy { name } objectMarking { definition }"),
+    "malware": ("malwares", "malware",
+                "id standard_id name description is_family malware_types "
+                "created_at updated_at createdBy { name } objectMarking { definition }"),
+    "campaign": ("campaigns", "campaign",
+                 "id standard_id name description first_seen last_seen "
+                 "created_at updated_at createdBy { name } objectMarking { definition }"),
+    "tool": ("tools", "tool",
+             "id standard_id name description tool_types "
+             "created_at updated_at createdBy { name } objectMarking { definition }"),
+}
+
+
+def list_entities(entity_type: str, *, search: Optional[str] = None,
+                  first: int = 25, all_pages: bool = False, **kw):
+    list_field, _, fields = ENTITY_TYPES[entity_type]
+
+    def fetch(after):
+        q = f"""
+        query ($first: Int, $after: ID, $search: String) {{
+          {list_field}(first: $first, after: $after, search: $search) {{
+            edges {{ node {{ {fields} }} }}
+            pageInfo {{ endCursor hasNextPage }}
+          }}
+        }}"""
+        return graphql_request(q, {"first": first, "after": after, "search": search},
+                               **kw)[list_field]
+
+    return paginated(fetch, max_pages=100 if all_pages else 1)
+
+
+def get_entity(entity_type: str, entity_id: str, **kw):
+    _, get_field, fields = ENTITY_TYPES[entity_type]
+    q = f"""
+    query ($id: String!) {{
+      {get_field}(id: $id) {{ {fields} toStix }}
+    }}"""
+    return graphql_request(q, {"id": entity_id}, **kw)[get_field]
+
+
+def global_search(search: str, *, types: Optional[list] = None,
+                  first: int = 25, all_pages: bool = False, **kw):
+    """Search across all STIX core objects."""
+
+    def fetch(after):
+        q = """
+        query ($first: Int, $after: ID, $search: String!, $types: [String]) {
+          stixCoreObjects(first: $first, after: $after, search: $search, types: $types) {
+            edges {
+              node {
+                id standard_id entity_type created_at
+                createdBy { name }
+                objectMarking { definition }
+              }
+            }
+            pageInfo { endCursor hasNextPage }
+          }
+        }"""
+        return graphql_request(q, {"first": first, "after": after,
+                                   "search": search, "types": types},
+                               **kw)["stixCoreObjects"]
+
+    return paginated(fetch, max_pages=100 if all_pages else 1)
+
+
+# ─── Writes ─────────────────────────────────────────────────────────────────
+
+# name -> (add mutation, add input type)
+ADD_MUTATIONS = {
+    "threat-actor": ("threatActorGroupAdd", "ThreatActorGroupAddInput"),
+    "intrusion-set": ("intrusionSetAdd", "IntrusionSetAddInput"),
+    "malware": ("malwareAdd", "MalwareAddInput"),
+    "campaign": ("campaignAdd", "CampaignAddInput"),
+    "tool": ("toolAdd", "ToolAddInput"),
+}
+
+ADD_RESULT_FIELDS = "id standard_id entity_type name created_at"
+
+
+def add_entity(entity_type: str, name: str, *, description: Optional[str] = None,
+               aliases: Optional[list] = None, labels: Optional[list] = None,
+               **kw) -> Dict[str, Any]:
+    """Create a named threat-intel entity."""
+    entity_type = entity_type.lower()
+    mutation, input_name = ADD_MUTATIONS[entity_type]
+    inp: Dict[str, Any] = {"name": name}
+    if description:
+        inp["description"] = description
+    if aliases:
+        inp["aliases"] = [a.strip() for a in aliases if a.strip()]
+    if labels:
+        inp["objectLabel"] = [l.strip() for l in labels if l.strip()]
+    q = f"""
+    mutation ($input: {input_name}!) {{
+      {mutation}(input: $input) {{ {ADD_RESULT_FIELDS} }}
+    }}"""
+    result = graphql_request(q, {"input": inp}, **kw)[mutation]
+    if not result:
+        raise ValueError(f"{entity_type} creation failed for {name!r}")
+    return result
+
+
+def delete_object(object_id: str, **kw) -> Any:
+    """Delete any STIX core object by ID (destructive)."""
+    q = """
+    mutation ($id: ID!) {
+      stixCoreObjectEdit(id: $id) { delete }
+    }"""
+    return graphql_request(q, {"id": object_id}, **kw)["stixCoreObjectEdit"]["delete"]

--- a/opencti/agent-harness/cli_anything/opencti/core/indicators.py
+++ b/opencti/agent-harness/cli_anything/opencti/core/indicators.py
@@ -1,0 +1,115 @@
+"""Indicator operations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from cli_anything.opencti.utils.opencti_backend import graphql_request, paginated
+
+LIST_FIELDS = """
+edges {
+  node {
+    id standard_id name pattern pattern_type
+    valid_from valid_until confidence
+    created_at updated_at
+    createdBy { name }
+    objectMarking { definition }
+  }
+}
+pageInfo { endCursor hasNextPage }
+"""
+
+DETAIL_FIELDS = """
+id standard_id name description pattern pattern_type
+valid_from valid_until confidence revoked
+created_at updated_at
+createdBy { name standard_id }
+objectLabel { value color }
+objectMarking { definition }
+externalReferences { source_name url }
+"""
+
+
+def list_indicators(
+    *,
+    search: Optional[str] = None,
+    first: int = 25,
+    all_pages: bool = False,
+    **kw,
+):
+    def fetch(after):
+        q = f"""
+        query ($first: Int, $after: ID, $search: String) {{
+          indicators(first: $first, after: $after, search: $search) {{
+            {LIST_FIELDS}
+          }}
+        }}"""
+        return graphql_request(q, {"first": first, "after": after, "search": search},
+                               **kw)["indicators"]
+
+    return paginated(fetch, max_pages=100 if all_pages else 1)
+
+
+def get_indicator(indicator_id: str, **kw):
+    q = f"""
+    query ($id: String!) {{
+      indicator(id: $id) {{ {DETAIL_FIELDS} }}
+    }}"""
+    return graphql_request(q, {"id": indicator_id}, **kw)["indicator"]
+
+
+def search_by_pattern(pattern: str, *, first: int = 25, **kw):
+    """Find indicators whose STIX pattern matches the given substring."""
+    filters = {"mode": "and",
+               "filters": [{"key": "pattern", "values": [pattern], "operator": "starts_with"}],
+               "filterGroups": []}
+
+    def fetch(after):
+        q = f"""
+        query ($first: Int, $after: ID, $filters: FilterGroup) {{
+          indicators(first: $first, after: $after, filters: $filters) {{ {LIST_FIELDS} }}
+        }}"""
+        return graphql_request(q, {"first": first, "after": after,
+                                   "filters": filters}, **kw)["indicators"]
+
+    return paginated(fetch, max_pages=1)
+
+
+# ─── Writes ─────────────────────────────────────────────────────────────────
+
+ADD_RESULT_FIELDS = """
+id standard_id name pattern pattern_type
+x_opencti_score valid_from valid_until
+"""
+
+
+def add_indicator(name: str, pattern: str, *, pattern_type: str = "stix",
+                  score: Optional[int] = None, description: Optional[str] = None,
+                  valid_until: Optional[str] = None, labels: Optional[list] = None,
+                  **kw) -> Dict[str, Any]:
+    """Create an indicator from a detection pattern."""
+    inp: Dict[str, Any] = {"name": name, "pattern": pattern,
+                           "pattern_type": pattern_type}
+    if score is not None:
+        inp["x_opencti_score"] = score
+    if description:
+        inp["description"] = description
+    if valid_until:
+        inp["valid_until"] = valid_until
+    if labels:
+        inp["objectLabel"] = [l.strip() for l in labels if l.strip()]
+    q = """
+    mutation ($input: IndicatorAddInput!) {
+      indicatorAdd(input: $input) { %s }
+    }""" % ADD_RESULT_FIELDS
+    result = graphql_request(q, {"input": inp}, **kw)["indicatorAdd"]
+    if not result:
+        raise ValueError(f"indicator creation failed for {name!r}")
+    return result
+
+
+def delete_indicator(indicator_id: str, **kw) -> Any:
+    """Delete an indicator by ID."""
+    q = """
+    mutation ($id: ID!) { indicatorDelete(id: $id) }"""
+    return graphql_request(q, {"id": indicator_id}, **kw)["indicatorDelete"]

--- a/opencti/agent-harness/cli_anything/opencti/core/observables.py
+++ b/opencti/agent-harness/cli_anything/opencti/core/observables.py
@@ -115,7 +115,9 @@ def add_observable(
     if obs_type in FILE_TYPES:
         gql_type = "StixFile"
         typed_field = "StixFile"
-        typed_value: Dict[str, Any] = {"hashes": {FILE_TYPES[obs_type]: value}}
+        typed_value: Dict[str, Any] = {
+            "hashes": [{"algorithm": FILE_TYPES[obs_type], "hash": value}]
+        }
         var_type = "StixFileAddInput"
     elif obs_type in ADD_INPUTS:
         gql_type, typed_field = ADD_INPUTS[obs_type]

--- a/opencti/agent-harness/cli_anything/opencti/core/observables.py
+++ b/opencti/agent-harness/cli_anything/opencti/core/observables.py
@@ -1,0 +1,149 @@
+"""STIX Cyber Observable operations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from cli_anything.opencti.utils.opencti_backend import graphql_request, paginated
+
+LIST_FIELDS = """
+edges {
+  node {
+    id standard_id entity_type observable_value
+    created_at updated_at
+    x_opencti_score
+    createdBy { name }
+    objectMarking { definition }
+  }
+}
+pageInfo { endCursor hasNextPage }
+"""
+
+DETAIL_FIELDS = """
+id standard_id entity_type observable_value
+created_at updated_at
+x_opencti_score x_opencti_description
+createdBy { name standard_id }
+objectLabel { value color }
+objectMarking { definition }
+externalReferences { edges { node { source_name url description } } }
+"""
+
+TYPE_MAP = {
+    "ipv4-addr": "IPv4-Addr",
+    "ipv6-addr": "IPv6-Addr",
+    "url": "Url",
+    "domain-name": "Domain-Name",
+    "file-sha256": "StixFile",
+    "file-md5": "StixFile",
+    "file-sha1": "StixFile",
+    "email-addr": "Email-Addr",
+}
+
+
+def list_observables(
+    *,
+    search: Optional[str] = None,
+    types: Optional[list] = None,
+    first: int = 25,
+    all_pages: bool = False,
+    **kw,
+):
+    def fetch(after):
+        q = f"""
+        query ($first: Int, $after: ID, $search: String, $types: [String]) {{
+          stixCyberObservables(first: $first, after: $after, search: $search, types: $types) {{
+            {LIST_FIELDS}
+          }}
+        }}"""
+        return graphql_request(q, {"first": first, "after": after, "search": search,
+                                   "types": types}, **kw)["stixCyberObservables"]
+
+    return paginated(fetch, max_pages=100 if all_pages else 1)
+
+
+def get_observable(observable_id: str, *, with_stix: bool = False, **kw):
+    fields = DETAIL_FIELDS + ("\ntoStix" if with_stix else "")
+    q = f"""
+    query ($id: String!) {{
+      stixCyberObservable(id: $id) {{ {fields} }}
+    }}"""
+    return graphql_request(q, {"id": observable_id}, **kw)["stixCyberObservable"]
+
+
+def export_observable_stix(observable_id: str, **kw) -> Optional[str]:
+    data = get_observable(observable_id, with_stix=True, **kw)
+    return data.get("toStix") if data else None
+
+
+# ─── Writes ─────────────────────────────────────────────────────────────────
+
+# cli type -> (GraphQL `type` arg value, typed input field name)
+ADD_INPUTS = {
+    "ipv4-addr": ("IPv4-Addr", "IPv4Addr"),
+    "ipv6-addr": ("IPv6-Addr", "IPv6Addr"),
+    "domain-name": ("Domain-Name", "DomainName"),
+    "url": ("Url", "Url"),
+    "hostname": ("Hostname", "Hostname"),
+    "mac-addr": ("Mac-Addr", "MacAddr"),
+    "email-addr": ("Email-Addr", "EmailAddr"),
+}
+FILE_TYPES = {
+    "file-sha256": "SHA-256",
+    "file-md5": "MD5",
+    "file-sha1": "SHA-1",
+}
+
+ADD_RESULT_FIELDS = """
+id standard_id entity_type observable_value
+x_opencti_score x_opencti_description
+"""
+
+
+def add_observable(
+    obs_type: str,
+    value: str,
+    *,
+    score: Optional[int] = None,
+    description: Optional[str] = None,
+    labels: Optional[list] = None,
+    create_indicator: bool = False,
+    **kw,
+) -> Dict[str, Any]:
+    """Create a cyber observable; optionally auto-generate its indicator."""
+    obs_type = obs_type.lower()
+    if obs_type in FILE_TYPES:
+        gql_type = "StixFile"
+        typed_field = "StixFile"
+        typed_value: Dict[str, Any] = {"hashes": {FILE_TYPES[obs_type]: value}}
+        var_type = "StixFileAddInput"
+    elif obs_type in ADD_INPUTS:
+        gql_type, typed_field = ADD_INPUTS[obs_type]
+        typed_value = {"value": value}
+        var_type = f"{typed_field}AddInput"
+    else:
+        raise ValueError(
+            f"unsupported observable type '{obs_type}'. "
+            f"Supported: {', '.join(sorted(ADD_INPUTS) + sorted(FILE_TYPES))}"
+        )
+
+    q = f"""
+    mutation ($score: Int, $desc: String,
+              $labels: [String], $ci: Boolean, $inp: {var_type}!) {{
+      stixCyberObservableAdd(type: "{gql_type}", {typed_field}: $inp,
+          x_opencti_score: $score, x_opencti_description: $desc,
+          objectLabel: $labels, createIndicator: $ci) {{
+        {ADD_RESULT_FIELDS}
+      }}
+    }}"""
+    variables: Dict[str, Any] = {"ci": create_indicator, "inp": typed_value}
+    if score is not None:
+        variables["score"] = score
+    if description:
+        variables["desc"] = description
+    if labels:
+        variables["labels"] = [l.strip() for l in labels if l.strip()]
+    result = graphql_request(q, variables, **kw)["stixCyberObservableAdd"]
+    if not result:
+        raise ValueError(f"observable creation failed for {value}")
+    return result

--- a/opencti/agent-harness/cli_anything/opencti/core/relationships.py
+++ b/opencti/agent-harness/cli_anything/opencti/core/relationships.py
@@ -1,0 +1,75 @@
+"""STIX core relationship operations."""
+
+from __future__ import annotations
+
+from cli_anything.opencti.utils.opencti_backend import graphql_request, paginated
+
+REL_LIST_FIELDS = """
+edges {
+  node {
+    id standard_id entity_type relationship_type
+    created_at updated_at confidence
+    from { ... on BasicObject { id standard_id entity_type } }
+    to { ... on BasicObject { id standard_id entity_type } }
+  }
+}
+pageInfo { endCursor hasNextPage }
+"""
+
+
+def list_relationships(*, first: int = 25, all_pages: bool = False, **kw):
+    def fetch(after):
+        q = f"""
+        query ($first: Int, $after: ID) {{
+          stixCoreRelationships(first: $first, after: $after) {{
+            {REL_LIST_FIELDS}
+          }}
+        }}"""
+        return graphql_request(q, {"first": first, "after": after}, **kw)[
+            "stixCoreRelationships"
+        ]
+
+    return paginated(fetch, max_pages=100 if all_pages else 1)
+
+
+# ─── Writes ─────────────────────────────────────────────────────────────────
+
+ADD_RESULT_FIELDS = """
+id standard_id relationship_type created_at
+from { ... on BasicObject { id standard_id entity_type } }
+to { ... on BasicObject { id standard_id entity_type } }
+"""
+
+
+def add_relationship(from_id: str, to_id: str, relationship_type: str, *,
+                     description: Optional[str] = None,
+                     start_time: Optional[str] = None,
+                     stop_time: Optional[str] = None, **kw):
+    """Create a STIX core relationship between two objects."""
+    inp: Dict[str, Any] = {"fromId": from_id, "toId": to_id,
+                           "relationship_type": relationship_type}
+    if description:
+        inp["description"] = description
+    if start_time:
+        inp["start_time"] = start_time
+    if stop_time:
+        inp["stop_time"] = stop_time
+    q = f"""
+    mutation ($input: StixCoreRelationshipAddInput!) {{
+      stixCoreRelationshipAdd(input: $input) {{ {ADD_RESULT_FIELDS} }}
+    }}"""
+    result = graphql_request(q, {"input": inp}, **kw)["stixCoreRelationshipAdd"]
+    if not result:
+        raise ValueError("relationship creation failed")
+    return result
+
+
+def delete_relationship(relationship_id: str, **kw) -> Any:
+    """Delete a relationship by its ID (destructive)."""
+    q = """
+    mutation ($id: ID!) {
+      stixCoreRelationshipEdit(id: $id) { delete }
+    }"""
+    return graphql_request(q, {"id": relationship_id}, **kw)[
+        "stixCoreRelationshipEdit"
+    ]["delete"]

--- a/opencti/agent-harness/cli_anything/opencti/core/reports.py
+++ b/opencti/agent-harness/cli_anything/opencti/core/reports.py
@@ -1,0 +1,81 @@
+"""Report operations."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from cli_anything.opencti.utils.opencti_backend import graphql_request, paginated
+
+LIST_FIELDS = """
+edges {
+  node {
+    id standard_id name published report_types
+    created_at updated_at
+    createdBy { name }
+    objectMarking { definition }
+  }
+}
+pageInfo { endCursor hasNextPage }
+"""
+
+DETAIL_FIELDS = """
+id standard_id name description published report_types
+created_at updated_at
+createdBy { name standard_id }
+objectLabel { value color }
+objectMarking { definition }
+objects(first: 50) {
+  edges { node { ... on BasicObject { id standard_id entity_type } } }
+}
+"""
+
+
+def list_reports(*, search: Optional[str] = None, first: int = 25,
+                 all_pages: bool = False, **kw):
+    def fetch(after):
+        q = f"""
+        query ($first: Int, $after: ID, $search: String) {{
+          reports(first: $first, after: $after, search: $search) {{
+            {LIST_FIELDS}
+          }}
+        }}"""
+        return graphql_request(q, {"first": first, "after": after, "search": search},
+                               **kw)["reports"]
+
+    return paginated(fetch, max_pages=100 if all_pages else 1)
+
+
+def get_report(report_id: str, **kw):
+    q = f"""
+    query ($id: String!) {{
+      report(id: $id) {{ {DETAIL_FIELDS} }}
+    }}"""
+    return graphql_request(q, {"id": report_id}, **kw)["report"]
+
+
+# ─── Writes ─────────────────────────────────────────────────────────────────
+
+ADD_RESULT_FIELDS = "id standard_id name published created_at"
+
+
+def add_report(name: str, *, published: Optional[str] = None,
+               description: Optional[str] = None, report_types: Optional[list] = None,
+               labels: Optional[list] = None, **kw) -> Dict[str, Any]:
+    """Create a threat intelligence report."""
+    inp: Dict[str, Any] = {"name": name}
+    if published:
+        inp["published"] = published
+    if description:
+        inp["description"] = description
+    if report_types:
+        inp["report_types"] = [t.strip() for t in report_types if t.strip()]
+    if labels:
+        inp["objectLabel"] = [l.strip() for l in labels if l.strip()]
+    q = """
+    mutation ($input: ReportAddInput!) {
+      reportAdd(input: $input) { %s }
+    }""" % ADD_RESULT_FIELDS
+    result = graphql_request(q, {"input": inp}, **kw)["reportAdd"]
+    if not result:
+        raise ValueError(f"report creation failed for {name!r}")
+    return result

--- a/opencti/agent-harness/cli_anything/opencti/core/system.py
+++ b/opencti/agent-harness/cli_anything/opencti/core/system.py
@@ -1,0 +1,33 @@
+"""System-level queries: version, identity, liveness."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from cli_anything.opencti.utils.opencti_backend import (
+    graphql_request,
+    health_check,
+)
+
+ABOUT_QUERY = "query { about { version } }"
+ME_QUERY = "query { me { name user_email firstname lastname } }"
+
+
+def about(**kw) -> Dict[str, Any]:
+    return graphql_request(ABOUT_QUERY, **kw)["about"]
+
+
+def me(**kw) -> Dict[str, Any]:
+    return graphql_request(ME_QUERY, **kw)["me"]
+
+
+def status(base_url: str, **kw) -> Dict[str, Any]:
+    data = {}
+    data["version"] = graphql_request(ABOUT_QUERY, base_url=base_url, **kw)["about"]["version"]
+    try:
+        me_data = graphql_request(ME_QUERY, base_url=base_url, api_key=kw.get("api_key"))
+        data["authenticated_as"] = me_data["me"].get("user_email")
+    except Exception:
+        data["authenticated_as"] = None
+    data["reachable"] = health_check(base_url=base_url)
+    return data

--- a/opencti/agent-harness/cli_anything/opencti/opencti_cli.py
+++ b/opencti/agent-harness/cli_anything/opencti/opencti_cli.py
@@ -1,0 +1,605 @@
+"""cli-anything-opencti — agent-native CLI for the OpenCTI threat intelligence platform.
+
+Read + write harness over OpenCTI's GraphQL API (v7). Every command supports
+--json for machine-readable output. Destructive operations require --force.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+from typing import Any
+
+import click
+
+from cli_anything.opencti.core import (
+    cases,
+    entities,
+    indicators,
+    observables,
+    reports,
+    relationships,
+    system,
+)
+from cli_anything.opencti.utils.opencti_backend import (
+    OpenCTIError,
+    resolve_connection,
+    save_config,
+)
+from cli_anything.opencti.utils.repl_skin import (
+    error,
+    output,
+    print_banner,
+    success,
+    warn,
+)
+
+VERSION = "1.0.0"
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+def _conn(ctx: click.Context) -> dict[str, Any]:
+    return {
+        "base_url": ctx.obj["base_url"],
+        "api_key": ctx.obj["api_key"],
+        "timeout": ctx.obj.get("timeout"),
+    }
+
+
+def _json_flag(ctx: click.Context) -> bool:
+    return bool(ctx.obj.get("as_json"))
+
+
+@click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
+@click.option("--url", default=None, envvar="OPENCTI_BASE_URL",
+              help="OpenCTI base URL (or set OPENCTI_BASE_URL)")
+@click.option("--token", default=None, envvar="OPENCTI_API_KEY",
+              help="OpenCTI API token (or set OPENCTI_API_KEY)")
+@click.option("--timeout", default=None, type=int,
+              envvar="OPENCTI_TIMEOUT", help="Request timeout in seconds")
+@click.option("--json", "as_json", is_flag=True, default=False,
+              help="JSON output for machine consumption")
+@click.version_option(version=VERSION, prog_name="cli-anything-opencti")
+@click.pass_context
+def cli(ctx: click.Context, url: str | None, token: str | None,
+        timeout: int | None, as_json: bool) -> None:
+    """Agent-native CLI for the OpenCTI threat intelligence platform."""
+    conn = resolve_connection(url, token)
+    ctx.obj = {
+        "base_url": conn["base_url"],
+        "api_key": conn["api_key"],
+        "timeout": timeout,
+        "as_json": as_json,
+    }
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(repl)
+
+
+# ── system ────────────────────────────────────────────────────────────
+
+@cli.command("status")
+@click.pass_context
+def status_cmd(ctx: click.Context) -> None:
+    """Platform reachability, version, and authenticated identity."""
+    output(system.status(**_conn(ctx)), _json_flag(ctx))
+
+
+@cli.command("whoami")
+@click.pass_context
+def whoami_cmd(ctx: click.Context) -> None:
+    """Show the identity bound to the configured API token."""
+    output(system.me(**_conn(ctx)), _json_flag(ctx))
+
+
+# ── observable ────────────────────────────────────────────────────────
+
+@cli.group("observable")
+def observable_() -> None:
+    """STIX cyber observables (IPs, domains, URLs, files, emails)."""
+
+
+@observable_.command("search")
+@click.argument("query")
+@click.option("--type", "obs_types", default=None,
+              help="Comma-separated types, e.g. ipv4-addr,domain-name")
+@click.option("--limit", default=25, show_default=True, type=int)
+@click.option("--all", "all_pages", is_flag=True, default=False,
+              help="Follow pagination to the end")
+@click.pass_context
+def observable_search(ctx: click.Context, query: str, obs_types: str | None,
+                      limit: int, all_pages: bool) -> None:
+    """Search observables by value substring."""
+    types = [t.strip() for t in obs_types.split(",")] if obs_types else None
+    data = observables.list_observables(search=query, types=types, first=limit,
+                                        all_pages=all_pages, **_conn(ctx))
+    output(data, _json_flag(ctx))
+
+
+@observable_.command("get")
+@click.argument("observable_id")
+@click.pass_context
+def observable_get(ctx: click.Context, observable_id: str) -> None:
+    """Fetch one observable by ID with full context."""
+    data = observables.get_observable(observable_id, **_conn(ctx))
+    if not data:
+        raise click.ClickException(f"observable not found: {observable_id}")
+    output(data, _json_flag(ctx))
+
+
+@observable_.command("add")
+@click.argument("obs_type",
+                type=click.Choice(sorted(observables.ADD_INPUTS) +
+                                  sorted(observables.FILE_TYPES),
+                                  case_sensitive=False))
+@click.argument("value")
+@click.option("--score", type=int, default=None,
+              help="OpenCTI detection score 0-100")
+@click.option("--description", default=None)
+@click.option("--label", "labels", default=None,
+              help="Comma-separated labels (created on the fly)")
+@click.option("--create-indicator/--no-create-indicator", default=False,
+              help="Also generate an indicator from this observable")
+@click.pass_context
+def observable_add(ctx: click.Context, obs_type: str, value: str, score: int | None,
+                   description: str | None, labels: str | None,
+                   create_indicator: bool) -> None:
+    """Create a cyber observable (ipv4-addr, domain-name, url, file-sha256, ...)."""
+    label_list = [l.strip() for l in labels.split(",")] if labels else None
+    data = observables.add_observable(
+        obs_type.lower(), value, score=score, description=description,
+        labels=label_list, create_indicator=create_indicator, **_conn(ctx))
+    success(f"created {data['id']}")
+    output(data, _json_flag(ctx))
+
+
+# ── indicator ─────────────────────────────────────────────────────────
+
+@cli.group("indicator")
+def indicator_() -> None:
+    """STIX indicators and their detection patterns."""
+
+
+@indicator_.command("list")
+@click.option("--search", default=None, help="Filter by name/pattern substring")
+@click.option("--limit", default=25, show_default=True, type=int)
+@click.option("--all", "all_pages", is_flag=True, default=False)
+@click.pass_context
+def indicator_list(ctx: click.Context, search: str | None, limit: int,
+                   all_pages: bool) -> None:
+    """List indicators, newest first."""
+    data = indicators.list_indicators(search=search, first=limit,
+                                      all_pages=all_pages, **_conn(ctx))
+    output(data, _json_flag(ctx))
+
+
+@indicator_.command("get")
+@click.argument("indicator_id")
+@click.pass_context
+def indicator_get(ctx: click.Context, indicator_id: str) -> None:
+    """Fetch one indicator with full context."""
+    data = indicators.get_indicator(indicator_id, **_conn(ctx))
+    if not data:
+        raise click.ClickException(f"indicator not found: {indicator_id}")
+    output(data, _json_flag(ctx))
+
+
+@indicator_.command("search-pattern")
+@click.argument("pattern")
+@click.option("--limit", default=25, show_default=True, type=int)
+@click.pass_context
+def indicator_search_pattern(ctx: click.Context, pattern: str, limit: int) -> None:
+    """Find indicators whose STIX pattern starts with PATTERN (e.g. [ipv4-addr:value = '1.2)."""
+    data = indicators.search_by_pattern(pattern, first=limit, **_conn(ctx))
+    output(data, _json_flag(ctx))
+
+
+@indicator_.command("add")
+@click.argument("name")
+@click.option("--pattern", required=True,
+              help="Detection pattern, e.g. [domain-name:value = 'evil.example']")
+@click.option("--pattern-type", default="stix", show_default=True)
+@click.option("--score", type=int, default=None)
+@click.option("--description", default=None)
+@click.option("--valid-until", default=None,
+              help="ISO 8601 datetime after which the indicator expires")
+@click.option("--label", "labels", default=None)
+@click.pass_context
+def indicator_add(ctx: click.Context, name: str, pattern: str, pattern_type: str,
+                  score: int | None, description: str | None,
+                  valid_until: str | None, labels: str | None) -> None:
+    """Create an indicator from a detection pattern."""
+    label_list = [l.strip() for l in labels.split(",")] if labels else None
+    data = indicators.add_indicator(
+        name, pattern, pattern_type=pattern_type, score=score,
+        description=description, valid_until=valid_until, labels=label_list,
+        **_conn(ctx))
+    success(f"created {data['id']}")
+    output(data, _json_flag(ctx))
+
+
+# ── report ────────────────────────────────────────────────────────────
+
+@cli.group("report")
+def report_() -> None:
+    """Threat intelligence reports."""
+
+
+@report_.command("list")
+@click.option("--search", default=None, help="Filter by name substring")
+@click.option("--limit", default=25, show_default=True, type=int)
+@click.option("--all", "all_pages", is_flag=True, default=False)
+@click.pass_context
+def report_list(ctx: click.Context, search: str | None, limit: int,
+                all_pages: bool) -> None:
+    """List reports, newest first."""
+    data = reports.list_reports(search=search, first=limit,
+                                all_pages=all_pages, **_conn(ctx))
+    output(data, _json_flag(ctx))
+
+
+@report_.command("get")
+@click.argument("report_id")
+@click.pass_context
+def report_get(ctx: click.Context, report_id: str) -> None:
+    """Fetch a report plus its contained objects."""
+    data = reports.get_report(report_id, **_conn(ctx))
+    if not data:
+        raise click.ClickException(f"report not found: {report_id}")
+    output(data, _json_flag(ctx))
+
+
+@report_.command("add")
+@click.argument("name")
+@click.option("--published", default=None,
+              help="ISO 8601 date/datetime (defaults to now server-side)")
+@click.option("--description", default=None)
+@click.option("--type", "report_types", default=None,
+              help="Comma-separated report types, e.g. threat-report,malware-analysis")
+@click.option("--label", "labels", default=None)
+@click.pass_context
+def report_add(ctx: click.Context, name: str, published: str | None,
+               description: str | None, report_types: str | None,
+               labels: str | None) -> None:
+    """Create a threat intelligence report."""
+    type_list = [t.strip() for t in report_types.split(",")] if report_types else None
+    label_list = [l.strip() for l in labels.split(",")] if labels else None
+    data = reports.add_report(name, published=published, description=description,
+                              report_types=type_list, labels=label_list,
+                              **_conn(ctx))
+    success(f"created {data['id']}")
+    output(data, _json_flag(ctx))
+
+
+# ── relationship ──────────────────────────────────────────────────────
+
+@cli.group("relationship")
+def relationship_() -> None:
+    """STIX core relationships between entities."""
+
+
+@relationship_.command("list")
+@click.option("--limit", default=25, show_default=True, type=int)
+@click.option("--all", "all_pages", is_flag=True, default=False)
+@click.pass_context
+def relationship_list(ctx: click.Context, limit: int, all_pages: bool) -> None:
+    """List recent STIX core relationships."""
+    data = relationships.list_relationships(first=limit, all_pages=all_pages,
+                                            **_conn(ctx))
+    output(data, _json_flag(ctx))
+
+
+@relationship_.command("add")
+@click.argument("from_id")
+@click.argument("to_id")
+@click.argument("relationship_type")
+@click.option("--description", default=None)
+@click.option("--start-time", default=None, help="ISO 8601 datetime")
+@click.option("--stop-time", default=None, help="ISO 8601 datetime")
+@click.pass_context
+def relationship_add(ctx: click.Context, from_id: str, to_id: str,
+                     relationship_type: str, description: str | None,
+                     start_time: str | None, stop_time: str | None) -> None:
+    """Create a FROM -> TO relationship (e.g. indicator indicates observable)."""
+    data = relationships.add_relationship(
+        from_id, to_id, relationship_type.lower(), description=description,
+        start_time=start_time, stop_time=stop_time, **_conn(ctx))
+    success(f"created {data['id']}")
+    output(data, _json_flag(ctx))
+
+
+# ── case ──────────────────────────────────────────────────────────────
+
+@cli.group("case")
+def case_() -> None:
+    """Cases: incidents, requests for information (RFI), RFT."""
+
+
+_CASE_TYPE = click.Choice(["incident", "rfi", "rft"], case_sensitive=False)
+
+
+@case_.command("list")
+@click.option("--type", "case_type", type=_CASE_TYPE, default="incident",
+              show_default=True)
+@click.option("--search", default=None, help="Filter by name substring")
+@click.option("--limit", default=25, show_default=True, type=int)
+@click.option("--all", "all_pages", is_flag=True, default=False)
+@click.pass_context
+def case_list(ctx: click.Context, case_type: str, search: str | None,
+              limit: int, all_pages: bool) -> None:
+    """List cases of the chosen type."""
+    data = cases.list_cases(case_type.lower(), search=search, first=limit,
+                            all_pages=all_pages, **_conn(ctx))
+    output(data, _json_flag(ctx))
+
+
+@case_.command("get")
+@click.argument("case_id")
+@click.option("--type", "case_type", type=_CASE_TYPE, default="incident",
+              show_default=True)
+@click.pass_context
+def case_get(ctx: click.Context, case_id: str, case_type: str) -> None:
+    """Fetch a case with its contained objects."""
+    data = cases.get_case(case_type.lower(), case_id, **_conn(ctx))
+    if not data:
+        raise click.ClickException(f"case not found: {case_id}")
+    output(data, _json_flag(ctx))
+
+
+@case_.command("add")
+@click.option("--type", "case_type", type=_CASE_TYPE, default="incident",
+              show_default=True)
+@click.argument("name")
+@click.option("--severity", default=None,
+              type=click.Choice(["low", "medium", "high", "critical"], case_sensitive=False))
+@click.option("--priority", default=None,
+              type=click.Choice(["low", "medium", "high", "critical"], case_sensitive=False))
+@click.option("--description", default=None)
+@click.pass_context
+def case_add(ctx: click.Context, case_type: str, name: str, severity: str | None,
+             priority: str | None, description: str | None) -> None:
+    """Create a case of the chosen type."""
+    data = cases.add_case(case_type.lower(), name,
+                          severity=severity.lower() if severity else None,
+                          priority=priority.lower() if priority else None,
+                          description=description, **_conn(ctx))
+    success(f"created {data['id']}")
+    output(data, _json_flag(ctx))
+
+
+# ── entity ────────────────────────────────────────────────────────────
+
+@cli.group("entity")
+def entity_() -> None:
+    """Named threat-intel entities (threat actors, malware, ...)."""
+
+
+_ENTITY_TYPE = click.Choice(sorted(entities.ENTITY_TYPES), case_sensitive=False)
+
+
+@entity_.command("list")
+@click.argument("entity_type", type=_ENTITY_TYPE)
+@click.option("--search", default=None, help="Filter by name substring")
+@click.option("--limit", default=25, show_default=True, type=int)
+@click.option("--all", "all_pages", is_flag=True, default=False)
+@click.pass_context
+def entity_list(ctx: click.Context, entity_type: str, search: str | None,
+                limit: int, all_pages: bool) -> None:
+    """List entities of the given type."""
+    data = entities.list_entities(entity_type.lower(), search=search,
+                                  first=limit, all_pages=all_pages, **_conn(ctx))
+    output(data, _json_flag(ctx))
+
+
+@entity_.command("get")
+@click.argument("entity_type", type=_ENTITY_TYPE)
+@click.argument("entity_id")
+@click.pass_context
+def entity_get(ctx: click.Context, entity_type: str, entity_id: str) -> None:
+    """Fetch an entity with full context (includes inline STIX)."""
+    data = entities.get_entity(entity_type.lower(), entity_id, **_conn(ctx))
+    if not data:
+        raise click.ClickException(f"{entity_type} not found: {entity_id}")
+    output(data, _json_flag(ctx))
+
+
+@entity_.command("add")
+@click.argument("entity_type", type=_ENTITY_TYPE)
+@click.argument("name")
+@click.option("--description", default=None)
+@click.option("--alias", "aliases", default=None,
+              help="Comma-separated aliases")
+@click.option("--label", "labels", default=None)
+@click.pass_context
+def entity_add(ctx: click.Context, entity_type: str, name: str,
+               description: str | None, aliases: str | None,
+               labels: str | None) -> None:
+    """Create a named threat-intel entity."""
+    alias_list = [a.strip() for a in aliases.split(",")] if aliases else None
+    label_list = [l.strip() for l in labels.split(",")] if labels else None
+    data = entities.add_entity(entity_type.lower(), name,
+                               description=description, aliases=alias_list,
+                               labels=label_list, **_conn(ctx))
+    success(f"created {data['id']}")
+    output(data, _json_flag(ctx))
+
+
+# ── search / export ───────────────────────────────────────────────────
+
+@cli.command("search")
+@click.argument("query")
+@click.option("--types", default=None,
+              help="Comma-separated entity types to restrict the search")
+@click.option("--limit", default=25, show_default=True, type=int)
+@click.option("--all", "all_pages", is_flag=True, default=False)
+@click.pass_context
+def search_cmd(ctx: click.Context, query: str, types: str | None,
+               limit: int, all_pages: bool) -> None:
+    """Global keyword search across all STIX core objects."""
+    type_list = [t.strip() for t in types.split(",")] if types else None
+    data = entities.global_search(query, types=type_list, first=limit,
+                                  all_pages=all_pages, **_conn(ctx))
+    output(data, _json_flag(ctx))
+
+
+@cli.command("export-stix")
+@click.option("--id", "object_id", required=True, help="STIX object ID")
+@click.option("-o", "--out", default=None, help="Write bundle JSON to file instead of stdout")
+@click.pass_context
+def export_stix_cmd(ctx: click.Context, object_id: str, out: str | None) -> None:
+    """Export one object as its STIX 2.1 JSON representation."""
+    from cli_anything.opencti.utils.opencti_backend import graphql_request
+
+    q = """
+    query ($id: String!) {
+      stixObjectOrStixRelationship(id: $id) {
+        ... on StixCoreObject { toStix }
+        ... on StixCoreRelationship { toStix }
+      }
+    }"""
+    result = graphql_request(q, {"id": object_id}, **_conn(ctx))[
+        "stixObjectOrStixRelationship"
+    ]
+    raw = (result or {}).get("toStix")
+    if not raw:
+        raise click.ClickException(f"no STIX representation for {object_id}")
+    payload = json.dumps(json.loads(raw), indent=2)
+    if out:
+        with open(out, "w", encoding="utf-8") as fh:
+            fh.write(payload + "\n")
+        success(f"wrote {out}")
+    else:
+        click.echo(payload)
+
+
+@cli.command("delete")
+@click.argument("object_id")
+@click.option("--force", is_flag=True, default=False,
+              help="Actually delete; without this the command only shows what would go")
+@click.pass_context
+def delete_cmd(ctx: click.Context, object_id: str, force: bool) -> None:
+    """Delete a STIX core object by ID (destructive — requires --force)."""
+    if not force:
+        warn(f"dry-run: {object_id} would be deleted. Re-run with --force.")
+        return
+    result = entities.delete_object(object_id, **_conn(ctx))
+    success(f"deleted {object_id}")
+    output(result, _json_flag(ctx))
+
+
+# ── config ────────────────────────────────────────────────────────────
+
+@cli.group("config")
+def config_() -> None:
+    """Persist connection settings for future invocations."""
+
+
+@config_.command("set")
+@click.option("--url", required=True, help="OpenCTI base URL")
+@click.option("--token", default=None, help="API token")
+def config_set(url: str, token: str | None) -> None:
+    """Save URL/token to ~/.cli-anything/opencti/config.json."""
+    path = save_config(url, token)
+    success(f"saved {path}")
+
+
+@config_.command("test")
+@click.option("--url", default=None, envvar="OPENCTI_BASE_URL")
+@click.option("--token", default=None, envvar="OPENCTI_API_KEY")
+def config_test(url: str | None, token: str | None) -> None:
+    """Validate connectivity using current settings."""
+    conn = resolve_connection(url, token)
+    info = system.status(base_url=conn["base_url"], api_key=conn["api_key"])
+    output(info, False)
+
+
+@cli.command("completions")
+@click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
+def install_completions(shell: str) -> None:
+    """Print shell-completion installation instructions."""
+    hint = {
+        "bash": 'eval "$(_CLI_ANYTHING_OPENCTI_COMPLETE=bash_source cli-anything-opencti)"',
+        "zsh": 'eval "$(_CLI_ANYTHING_OPENCTI_COMPLETE=zsh_source cli-anything-opencti)"',
+        "fish": "_CLI_ANYTHING_OPENCTI_COMPLETE=fish_source cli-anything-opencti | source",
+    }[shell]
+    click.echo(f'Add to your shell profile:\n  {hint}')
+
+
+# ── REPL ──────────────────────────────────────────────────────────────
+
+@cli.command("repl", hidden=True)
+@click.pass_context
+def repl(ctx: click.Context) -> None:
+    """Interactive shell (default when run with no subcommand)."""
+    try:
+        from prompt_toolkit import PromptSession
+        from prompt_toolkit.completion import WordCompleter
+        from prompt_toolkit.history import InMemoryHistory
+    except ImportError:
+        error("prompt-toolkit is required for REPL mode. Install: pip install prompt-toolkit")
+        sys.exit(1)
+
+    print_banner()
+
+    words = ["help", "exit", "quit", "status", "whoami"]
+    for name, cmd in cli.commands.items():
+        if getattr(cmd, "hidden", False):
+            continue
+        words.append(name)
+        if hasattr(cmd, "commands"):
+            for sub in cmd.commands:
+                words.append(f"{name} {sub}")
+    completer = WordCompleter(words, ignore_case=True)
+
+    session = PromptSession(history=InMemoryHistory(), completer=completer)
+    while True:
+        try:
+            line = session.prompt("opencti> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            click.echo("\nBye!")
+            break
+        if not line:
+            continue
+        if line in ("exit", "quit", "q"):
+            click.echo("Bye!")
+            break
+        if line == "help":
+            click.echo(cli.get_help(ctx))
+            continue
+        try:
+            try:
+                args = shlex.split(line)
+            except ValueError:
+                args = line.split()
+            cli.main(args, standalone_mode=False, obj=ctx.obj)
+        except click.exceptions.UsageError as exc:
+            error(str(exc))
+        except SystemExit:
+            pass
+        except Exception as exc:  # noqa: BLE001
+            error(str(exc))
+
+
+def main() -> None:
+    """Entry point with unified error mapping."""
+    try:
+        cli()
+    except OpenCTIError as exc:
+        error(str(exc))
+        sys.exit(1)
+    except ValueError as exc:  # GraphQL errors surface here
+        error(str(exc))
+        sys.exit(1)
+    except ConnectionError as exc:
+        error(str(exc))
+        sys.exit(1)
+    except TimeoutError as exc:
+        error(str(exc))
+        sys.exit(1)
+    except click.exceptions.Abort:
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/opencti/agent-harness/cli_anything/opencti/opencti_cli.py
+++ b/opencti/agent-harness/cli_anything/opencti/opencti_cli.py
@@ -66,7 +66,12 @@ def _json_flag(ctx: click.Context) -> bool:
 def cli(ctx: click.Context, url: str | None, token: str | None,
         timeout: int | None, as_json: bool) -> None:
     """Agent-native CLI for the OpenCTI threat intelligence platform."""
-    conn = resolve_connection(url, token)
+    if ctx.invoked_subcommand != "config":
+        # `config set`/`config test` must work on an unconfigured machine;
+        # resolve lazily for everything that actually talks to the API.
+        conn = resolve_connection(url, token)
+    else:
+        conn = {"base_url": None, "api_key": None}
     ctx.obj = {
         "base_url": conn["base_url"],
         "api_key": conn["api_key"],
@@ -111,7 +116,11 @@ def observable_() -> None:
 def observable_search(ctx: click.Context, query: str, obs_types: str | None,
                       limit: int, all_pages: bool) -> None:
     """Search observables by value substring."""
-    types = [t.strip() for t in obs_types.split(",")] if obs_types else None
+    if obs_types:
+        types = [observables.TYPE_MAP.get(t.strip().lower(), t.strip())
+                 for t in obs_types.split(",")]
+    else:
+        types = None
     data = observables.list_observables(search=query, types=types, first=limit,
                                         all_pages=all_pages, **_conn(ctx))
     output(data, _json_flag(ctx))

--- a/opencti/agent-harness/cli_anything/opencti/skills/SKILL.md
+++ b/opencti/agent-harness/cli_anything/opencti/skills/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: cli-anything-opencti
+description: >-
+  Command-line interface for the OpenCTI threat intelligence platform.
+  Queries and creates observables, indicators, reports, cases, threat actors,
+  malware, campaigns, tools, and relationships over GraphQL API v7.
+---
+
+# cli-anything-opencti
+
+CLI harness for OpenCTI threat intelligence — built with the CLI-Anything
+pattern. Verified against OpenCTI platform v7 (7.260824.0).
+
+## Installation
+
+```bash
+pip install cli-anything-opencti
+```
+
+## Configuration
+
+```bash
+cli-anything-opencti config set --url https://your-opencti.example.com --token YOUR_API_TOKEN
+
+# Or environment variables
+export OPENCTI_BASE_URL=https://your-opencti.example.com
+export OPENCTI_API_KEY=your-api-token
+export OPENCTI_TIMEOUT=60  # optional, default 30s
+```
+
+## Command Groups
+
+| Group | Commands |
+|-------|----------|
+| observable | search, get, add |
+| indicator | list, get, search-pattern, add |
+| report | list, get, add |
+| relationship | list, add |
+| case | list, get, add (--type incident\|rfi\|rft) |
+| entity | list, get, add (threat-actor\|intrusion-set\|malware\|campaign\|tool) |
+| config | set, test |
+| top-level | status, whoami, search, export-stix, delete |
+
+## For AI Agents
+
+- Always pass `--json` before the subcommand: `cli-anything-opencti --json indicator list`
+- Status messages go to stderr; stdout is always parseable
+- Use `--all` to follow Relay pagination past the default page (`--limit` sets page size)
+- Check return codes: 0 = success, non-zero = error
+- All IDs are UUID strings; `standard_id` is the STIX 2.1 ID
+- Writes: `observable add`, `indicator add`, `report add`, `case add --type ...`,
+  `entity add TYPE NAME`, `relationship add FROM TO TYPE`
+- Deletion requires `--force`: without it, `delete ID` is a dry-run
+- `export-stix --id <id>` emits STIX 2.1 JSON for any object ID
+- Global search spans every STIX core object; narrow it with `--types`
+- Relationship types are validated server-side (e.g. actor->observable must be `related-to`, not `uses`)
+- Not exposed: connector management, CSV/JSON feed ingestion, draft workspaces

--- a/opencti/agent-harness/cli_anything/opencti/tests/test_core.py
+++ b/opencti/agent-harness/cli_anything/opencti/tests/test_core.py
@@ -1,0 +1,362 @@
+"""Unit tests — all HTTP calls mocked."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli_anything.opencti.core import (
+    cases,
+    entities,
+    indicators,
+    observables,
+    relationships,
+    reports,
+    system,
+)
+from cli_anything.opencti.utils import opencti_backend
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+def mock_response(status_code: int = 200, body: dict | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = body or {}
+    resp.content = json.dumps(body or {}).encode()
+    resp.headers = {}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def gql_response(data: dict) -> MagicMock:
+    return mock_response(200, {"data": data})
+
+
+BASE = "https://opencti.example.com"
+KEY = "test-token-1234"
+
+GQL = {
+    "observables": "cli_anything.opencti.core.observables.graphql_request",
+    "indicators": "cli_anything.opencti.core.indicators.graphql_request",
+    "reports": "cli_anything.opencti.core.reports.graphql_request",
+    "cases": "cli_anything.opencti.core.cases.graphql_request",
+    "entities": "cli_anything.opencti.core.entities.graphql_request",
+    "relationships": "cli_anything.opencti.core.relationships.graphql_request",
+    "system": "cli_anything.opencti.core.system.graphql_request",
+}
+
+
+# ─── Backend ────────────────────────────────────────────────────────────────
+
+class TestResolveConnection:
+    def test_args_win(self):
+        conn = opencti_backend.resolve_connection(BASE, KEY)
+        assert conn == {"base_url": BASE, "api_key": KEY}
+
+    @patch.dict("os.environ", {"OPENCTI_BASE_URL": BASE, "OPENCTI_API_KEY": KEY}, clear=False)
+    def test_env_fallback(self):
+        with patch.object(opencti_backend, "_load_config_file", return_value={}):
+            conn = opencti_backend.resolve_connection(None, None)
+        assert conn["base_url"] == BASE
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_file_fallback(self):
+        cfg = {"base_url": "https://file.example.com", "api_key": "filekey"}
+        with patch.object(opencti_backend, "_load_config_file", return_value=cfg):
+            conn = opencti_backend.resolve_connection(None, None)
+        assert conn["base_url"] == "https://file.example.com"
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_missing_url_raises(self):
+        with patch.object(opencti_backend, "_load_config_file", return_value={}):
+            with pytest.raises(opencti_backend.OpenCTIError, match="base URL not configured"):
+                opencti_backend.resolve_connection(None, None)
+
+    def test_trailing_slash_stripped(self):
+        conn = opencti_backend.resolve_connection(BASE + "/", KEY)
+        assert conn["base_url"] == BASE
+
+
+class TestGraphqlRequest:
+    @patch("cli_anything.opencti.utils.opencti_backend.requests.post")
+    def test_post_and_auth_header(self, mock_post):
+        mock_post.return_value = gql_response({"about": {"version": "7.0"}})
+        data = opencti_backend.graphql_request("query { about { version } }",
+                                               base_url=BASE, api_key=KEY)
+        assert data == {"about": {"version": "7.0"}}
+        args, kwargs = mock_post.call_args
+        assert args[0] == f"{BASE}/graphql"
+        assert kwargs["headers"]["Authorization"] == f"Bearer {KEY}"
+
+    @patch("cli_anything.opencti.utils.opencti_backend._sleep_backoff")
+    @patch("cli_anything.opencti.utils.opencti_backend.requests.post")
+    def test_retry_on_503_then_success(self, mock_post, _backoff):
+        mock_post.side_effect = [mock_response(503), gql_response({"me": {"name": "a"}})]
+        data = opencti_backend.graphql_request("query { me { name } }",
+                                               base_url=BASE, api_key=KEY)
+        assert data["me"]["name"] == "a"
+        assert mock_post.call_count == 2
+
+    @patch("cli_anything.opencti.utils.opencti_backend._sleep_backoff")
+    @patch("cli_anything.opencti.utils.opencti_backend.requests.post")
+    def test_graphql_errors_raise_valueerror(self, mock_post, _backoff):
+        mock_post.return_value = mock_response(200, {
+            "errors": [{"message": "Unauthorized"}], "data": None,
+        })
+        with pytest.raises(ValueError, match="Unauthorized"):
+            opencti_backend.graphql_request("query { me { name } }",
+                                            base_url=BASE, api_key="bad")
+
+    @patch("cli_anything.opencti.utils.opencti_backend.requests.post")
+    def test_http_error_surfaces(self, mock_post):
+        resp = mock_response(401, {})
+        resp.raise_for_status.side_effect = opencti_backend.requests.HTTPError("401")
+        mock_post.return_value = resp
+        with pytest.raises(opencti_backend.requests.HTTPError):
+            opencti_backend.graphql_request("query { me { name } }",
+                                            base_url=BASE, api_key=KEY)
+
+
+class TestPaginated:
+    def test_single_page(self):
+        page = {"edges": [{"node": {"id": "1"}}, {"node": {"id": "2"}}],
+                "pageInfo": {"endCursor": "c1", "hasNextPage": False}}
+        items = opencti_backend.paginated(lambda after: page)
+        assert [i["id"] for i in items] == ["1", "2"]
+
+    def test_multi_page(self):
+        pages = [
+            {"edges": [{"node": {"id": "1"}}],
+             "pageInfo": {"endCursor": "c1", "hasNextPage": True}},
+            {"edges": [{"node": {"id": "2"}}],
+             "pageInfo": {"endCursor": "c2", "hasNextPage": False}},
+        ]
+        calls = []
+
+        def fetch(after):
+            calls.append(after)
+            return pages[len(calls) - 1]
+
+        items = opencti_backend.paginated(fetch)
+        assert [i["id"] for i in items] == ["1", "2"]
+        assert calls == [None, "c1"]
+
+    def test_cursor_loop_guard(self):
+        """A server repeating its endCursor must terminate, not spin forever."""
+        page = {"edges": [{"node": {"id": "1"}}],
+                "pageInfo": {"endCursor": "same", "hasNextPage": True}}
+        calls = []
+        items = opencti_backend.paginated(
+            lambda after: (calls.append(after), dict(page))[1])
+        assert len(calls) <= 3  # terminates well below max_pages
+        assert len(items) == len(calls)
+
+
+# ─── System ─────────────────────────────────────────────────────────────────
+
+class TestSystem:
+    @patch("cli_anything.opencti.core.system.health_check", return_value=True)
+    @patch(GQL["system"])
+    def test_status(self, mock_gql, _health):
+        mock_gql.side_effect = [
+            {"about": {"version": "7.260824.0"}},
+            {"me": {"user_email": "admin@opencti.io"}},
+        ]
+        result = system.status(base_url=BASE, api_key=KEY)
+        assert result["reachable"] is True
+        assert result["version"] == "7.260824.0"
+        assert result["authenticated_as"] == "admin@opencti.io"
+
+
+# ─── Observables ────────────────────────────────────────────────────────────
+
+class TestObservables:
+    @patch(GQL["observables"])
+    def test_list(self, mock_gql):
+        page = {"edges": [{"node": {"id": "obs-1", "observable_value": "1.2.3.4",
+                                    "entity_type": "IPv4-Addr"}}],
+                "pageInfo": {"endCursor": "c1", "hasNextPage": False}}
+        mock_gql.return_value = {"stixCyberObservables": page}
+        items = observables.list_observables(search="1.2.3", base_url=BASE, api_key=KEY)
+        assert items[0]["observable_value"] == "1.2.3.4"
+        q, variables = mock_gql.call_args[0]
+        assert variables["search"] == "1.2.3"
+
+    @patch(GQL["observables"])
+    def test_get(self, mock_gql):
+        mock_gql.return_value = {"stixCyberObservable": {"id": "obs-1"}}
+        obs = observables.get_observable("obs-1", base_url=BASE, api_key=KEY)
+        assert obs["id"] == "obs-1"
+
+
+# ─── Indicators ─────────────────────────────────────────────────────────────
+
+class TestIndicators:
+    @patch(GQL["indicators"])
+    def test_search_by_pattern_filters(self, mock_gql):
+        mock_gql.return_value = {"indicators": {"edges": [], "pageInfo": {}}}
+        indicators.search_by_pattern("[ipv4-addr:value", first=5,
+                                     base_url=BASE, api_key=KEY)
+        _, variables = mock_gql.call_args[0]
+        filt = variables["filters"]
+        assert filt["filters"][0]["key"] == "pattern"
+        assert filt["filters"][0]["operator"] == "starts_with"
+
+    @patch(GQL["indicators"])
+    def test_list(self, mock_gql):
+        page = {"edges": [{"node": {"id": "ind-1",
+                                    "pattern": "[domain-name:value = 'x.com']"}}],
+                "pageInfo": {"endCursor": None, "hasNextPage": False}}
+        mock_gql.return_value = {"indicators": page}
+        items = indicators.list_indicators(base_url=BASE, api_key=KEY)
+        assert items[0]["id"] == "ind-1"
+
+
+# ─── Reports / Cases ────────────────────────────────────────────────────────
+
+class TestReportsAndCases:
+    @patch(GQL["reports"])
+    def test_report_get(self, mock_gql):
+        mock_gql.return_value = {"report": {"id": "r-1", "name": "R"}}
+        rep = reports.get_report("r-1", base_url=BASE, api_key=KEY)
+        assert rep["name"] == "R"
+
+    @patch(GQL["cases"])
+    def test_case_dispatch_rfi(self, mock_gql):
+        mock_gql.return_value = {"caseRfis": {"edges": [{"node": {"id": "rfi-1"}}],
+                                              "pageInfo": {}}}
+        items = cases.list_cases("rfi", base_url=BASE, api_key=KEY)
+        assert items[0]["id"] == "rfi-1"
+        q, _ = mock_gql.call_args[0]
+        assert "caseRfis" in q
+
+    def test_invalid_case_type(self):
+        with pytest.raises(KeyError):
+            cases.list_cases("bogus", base_url=BASE, api_key=KEY)
+
+
+# ─── Entities ───────────────────────────────────────────────────────────────
+
+class TestEntities:
+    @patch(GQL["entities"])
+    def test_threat_actor_get_includes_stix(self, mock_gql):
+        mock_gql.return_value = {"threatActor": {"id": "ta-1", "toStix": "{}"}}
+        ta = entities.get_entity("threat-actor", "ta-1", base_url=BASE, api_key=KEY)
+        assert ta["id"] == "ta-1"
+        q, variables = mock_gql.call_args[0]
+        assert "threatActor(id: $id)" in q
+        assert variables == {"id": "ta-1"}
+
+    @patch(GQL["entities"])
+    def test_global_search_types(self, mock_gql):
+        mock_gql.return_value = {"stixCoreObjects": {"edges": [], "pageInfo": {}}}
+        entities.global_search("apt", types=["Threat-Actor"], base_url=BASE, api_key=KEY)
+        _, variables = mock_gql.call_args[0]
+        assert variables["types"] == ["Threat-Actor"]
+
+    def test_unknown_entity_type(self):
+        with pytest.raises(KeyError):
+            entities.list_entities("unicorn", base_url=BASE, api_key=KEY)
+
+
+# ─── Writes ─────────────────────────────────────────────────────────────────
+
+class TestObservableWrites:
+    @patch(GQL["observables"])
+    def test_add_ipv4(self, mock_gql):
+        mock_gql.return_value = {"stixCyberObservableAdd": {"id": "new-1"}}
+        result = observables.add_observable("ipv4-addr", "10.0.0.1",
+                                            base_url=BASE, api_key=KEY)
+        assert result["id"] == "new-1"
+        q, variables = mock_gql.call_args[0]
+        assert 'type: "IPv4-Addr"' in q
+        assert "IPv4AddrAddInput" in q
+        assert variables["inp"] == {"value": "10.0.0.1"}
+
+    @patch(GQL["observables"])
+    def test_add_file_sha256(self, mock_gql):
+        mock_gql.return_value = {"stixCyberObservableAdd": {"id": "f-1"}}
+        observables.add_observable("file-sha256", "abc123", base_url=BASE,
+                                   api_key=KEY)
+        _, variables = mock_gql.call_args[0]
+        assert variables["inp"] == {"hashes": {"SHA-256": "abc123"}}
+
+    def test_unsupported_type(self):
+        with pytest.raises(ValueError, match="unsupported observable type"):
+            observables.add_observable("bitcoin-wallet", "xyz")
+
+    @patch(GQL["observables"])
+    def test_labels_and_indicator_flag(self, mock_gql):
+        mock_gql.return_value = {"stixCyberObservableAdd": {"id": "x"}}
+        observables.add_observable("domain-name", "evil.example", labels=["c2"],
+                                   create_indicator=True, base_url=BASE,
+                                   api_key=KEY)
+        _, variables = mock_gql.call_args[0]
+        assert variables["labels"] == ["c2"]
+        assert variables["ci"] is True
+
+
+class TestIndicatorWrites:
+    @patch(GQL["indicators"])
+    def test_add(self, mock_gql):
+        mock_gql.return_value = {"indicatorAdd": {"id": "ind-new"}}
+        indicators.add_indicator("C2 domain", "[domain-name:value = 'x.example']",
+                                 score=90, base_url=BASE, api_key=KEY)
+        _, variables = mock_gql.call_args[0]
+        inp = variables["input"]
+        assert inp["pattern_type"] == "stix"
+        assert inp["x_opencti_score"] == 90
+
+    @patch(GQL["indicators"])
+    def test_delete(self, mock_gql):
+        mock_gql.return_value = {"indicatorDelete": "ind-9"}
+        assert indicators.delete_indicator("ind-9", base_url=BASE,
+                                           api_key=KEY) == "ind-9"
+
+
+class TestEntityAndCaseWrites:
+    @patch(GQL["entities"])
+    def test_add_threat_actor(self, mock_gql):
+        mock_gql.return_value = {"threatActorGroupAdd": {"id": "ta-new"}}
+        entities.add_entity("threat-actor", "APT-X", aliases=["APT-X Prime"],
+                            base_url=BASE, api_key=KEY)
+        q, variables = mock_gql.call_args[0]
+        assert "threatActorGroupAdd" in q
+        assert variables["input"]["aliases"] == ["APT-X Prime"]
+
+    @patch(GQL["entities"])
+    def test_delete_object_guard_shape(self, mock_gql):
+        mock_gql.return_value = {"stixCoreObjectEdit": {"delete": True}}
+        assert entities.delete_object("obj-1", base_url=BASE, api_key=KEY) is True
+        _, variables = mock_gql.call_args[0]
+        assert variables == {"id": "obj-1"}
+
+    @patch(GQL["cases"])
+    def test_add_rft(self, mock_gql):
+        mock_gql.return_value = {"caseRftAdd": {"id": "rft-new"}}
+        cases.add_case("rft", "Takedown example.com", severity="high",
+                       base_url=BASE, api_key=KEY)
+        q, variables = mock_gql.call_args[0]
+        assert "caseRftAdd" in q
+        assert variables["input"]["severity"] == "high"
+
+    @patch(GQL["reports"])
+    def test_add_report(self, mock_gql):
+        mock_gql.return_value = {"reportAdd": {"id": "rep-new"}}
+        reports.add_report("Q3 APT report", published="2026-08-24T00:00:00Z",
+                           base_url=BASE, api_key=KEY)
+        _, variables = mock_gql.call_args[0]
+        assert variables["input"]["published"] == "2026-08-24T00:00:00Z"
+
+    @patch(GQL["relationships"])
+    def test_add_relationship(self, mock_gql):
+        mock_gql.return_value = {"stixCoreRelationshipAdd": {"id": "rel-new"}}
+        relationships.add_relationship("src-1", "dst-1", "related-to",
+                                       base_url=BASE, api_key=KEY)
+        _, variables = mock_gql.call_args[0]
+        inp = variables["input"]
+        assert inp["fromId"] == "src-1"
+        assert inp["relationship_type"] == "related-to"

--- a/opencti/agent-harness/cli_anything/opencti/tests/test_core.py
+++ b/opencti/agent-harness/cli_anything/opencti/tests/test_core.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
 from cli_anything.opencti.core import (
     cases,
@@ -26,6 +27,7 @@ def mock_response(status_code: int = 200, body: dict | None = None) -> MagicMock
     resp.status_code = status_code
     resp.json.return_value = body or {}
     resp.content = json.dumps(body or {}).encode()
+    resp.text = json.dumps(body or {})
     resp.headers = {}
     resp.raise_for_status = MagicMock()
     return resp
@@ -111,13 +113,20 @@ class TestGraphqlRequest:
                                             base_url=BASE, api_key="bad")
 
     @patch("cli_anything.opencti.utils.opencti_backend.requests.post")
-    def test_http_error_surfaces(self, mock_post):
-        resp = mock_response(401, {})
-        resp.raise_for_status.side_effect = opencti_backend.requests.HTTPError("401")
-        mock_post.return_value = resp
-        with pytest.raises(opencti_backend.requests.HTTPError):
+    def test_http_401_raises_opencti_error(self, mock_post):
+        mock_post.return_value = mock_response(401, {})
+        with pytest.raises(opencti_backend.OpenCTIError, match="HTTP 401"):
             opencti_backend.graphql_request("query { me { name } }",
                                             base_url=BASE, api_key=KEY)
+
+    @patch("cli_anything.opencti.utils.opencti_backend._sleep_backoff")
+    @patch("cli_anything.opencti.utils.opencti_backend.requests.post")
+    def test_final_retry_5xx_raises_opencti_error(self, mock_post, _backoff):
+        mock_post.side_effect = [mock_response(503) for _ in range(4)]
+        with pytest.raises(opencti_backend.OpenCTIError, match="HTTP 503"):
+            opencti_backend.graphql_request("query { me { name } }",
+                                            base_url=BASE, api_key=KEY)
+        assert mock_post.call_count == 4
 
 
 class TestPaginated:
@@ -282,7 +291,9 @@ class TestObservableWrites:
         observables.add_observable("file-sha256", "abc123", base_url=BASE,
                                    api_key=KEY)
         _, variables = mock_gql.call_args[0]
-        assert variables["inp"] == {"hashes": {"SHA-256": "abc123"}}
+        assert variables["inp"] == {
+            "hashes": [{"algorithm": "SHA-256", "hash": "abc123"}]
+        }
 
     def test_unsupported_type(self):
         with pytest.raises(ValueError, match="unsupported observable type"):
@@ -360,3 +371,49 @@ class TestEntityAndCaseWrites:
         inp = variables["input"]
         assert inp["fromId"] == "src-1"
         assert inp["relationship_type"] == "related-to"
+
+
+# ─── CLI wiring (review fixes) ──────────────────────────────────────────────
+
+class TestCliOffline:
+    """config subcommands must work on an unconfigured machine (PR review)."""
+
+    def test_config_set_without_connection(self, tmp_path):
+        from cli_anything.opencti import opencti_cli
+
+        cfg = tmp_path / "config.json"
+        runner = CliRunner()
+        with patch.dict("os.environ", {}, clear=True), \
+             patch.object(opencti_backend, "CONFIG_DIR", tmp_path), \
+             patch.object(opencti_backend, "CONFIG_FILE", cfg):
+            result = runner.invoke(opencti_cli.cli,
+                                   ["config", "set", "--url", BASE])
+        assert result.exit_code == 0, result.output
+        assert json.loads(cfg.read_text())["base_url"] == BASE
+
+    def test_config_test_without_connection_reports_error(self):
+        from cli_anything.opencti import opencti_cli
+
+        runner = CliRunner()
+        with patch.dict("os.environ", {}, clear=True), \
+             patch.object(opencti_backend, "_load_config_file",
+                          return_value={}):
+            result = runner.invoke(
+                opencti_cli.cli, ["config", "test", "--url", BASE])
+        # reaches the command (fails on connect, not on missing config)
+        assert "Usage:" not in result.output
+
+    @patch(GQL["observables"])
+    def test_observable_search_maps_type_tokens(self, mock_gql):
+        from cli_anything.opencti import opencti_cli
+
+        mock_gql.return_value = {"stixCyberObservables": {
+            "edges": [], "pageInfo": {"endCursor": None, "hasNextPage": False}}}
+        runner = CliRunner()
+        result = runner.invoke(
+            opencti_cli.cli,
+            ["--url", BASE, "--token", KEY,
+             "observable", "search", "evil", "--type", "ipv4-addr,domain-name"])
+        assert result.exit_code == 0, result.output
+        _, variables = mock_gql.call_args[0]
+        assert variables["types"] == ["IPv4-Addr", "Domain-Name"]

--- a/opencti/agent-harness/cli_anything/opencti/tests/test_full_e2e.py
+++ b/opencti/agent-harness/cli_anything/opencti/tests/test_full_e2e.py
@@ -1,0 +1,130 @@
+"""End-to-end tests against a real OpenCTI instance.
+
+Gated: set OPENCTI_E2E=1 plus OPENCTI_BASE_URL and OPENCTI_API_KEY to run.
+Run with: pytest -m e2e cli_anything/opencti/tests/test_full_e2e.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.environ.get("OPENCTI_E2E") != "1",
+        reason="set OPENCTI_E2E=1 with OPENCTI_BASE_URL/OPENCTI_API_KEY to run",
+    ),
+]
+
+CONN = {}
+
+def setup_module(module):
+    CONN["base_url"] = os.environ["OPENCTI_BASE_URL"]
+    CONN["api_key"] = os.environ["OPENCTI_API_KEY"]
+
+
+def test_status():
+    from cli_anything.opencti.core import system
+    info = system.status(**CONN)
+    assert info["reachable"] is True
+    assert info["version"]
+    assert info["authenticated_as"]
+
+
+def test_whoami():
+    from cli_anything.opencti.core import system
+    me = system.me(**CONN)
+    assert me.get("name")
+
+
+def test_observables_list():
+    from cli_anything.opencti.core import observables
+    items = observables.list_observables(first=5, **CONN)
+    assert isinstance(items, list)
+    if items:
+        assert "id" in items[0]
+
+
+def test_indicators_list():
+    from cli_anything.opencti.core import indicators
+    items = indicators.list_indicators(first=5, **CONN)
+    assert isinstance(items, list)
+
+
+def test_reports_list():
+    from cli_anything.opencti.core import reports
+    items = reports.list_reports(first=5, **CONN)
+    assert isinstance(items, list)
+
+
+def test_cases_incident():
+    from cli_anything.opencti.core import cases
+    items = cases.list_cases("incident", first=5, **CONN)
+    assert isinstance(items, list)
+
+
+def test_entities_threat_actor():
+    from cli_anything.opencti.core import entities
+    items = entities.list_entities("threat-actor", first=5, **CONN)
+    assert isinstance(items, list)
+    if items:
+        assert items[0].get("name")
+
+
+def test_global_search():
+    from cli_anything.opencti.core import entities
+    results = entities.global_search("test", first=5, **CONN)
+    assert isinstance(results, list)
+
+
+def test_relationships():
+    from cli_anything.opencti.core import relationships
+    items = relationships.list_relationships(first=5, **CONN)
+    assert isinstance(items, list)
+
+
+def test_write_lifecycle():
+    """Create -> link -> read back -> delete, leaving no residue."""
+    from cli_anything.opencti.core import (
+        entities,
+        indicators,
+        observables,
+        relationships,
+    )
+    suffix = os.urandom(4).hex()
+    created = []  # (kind, id) pairs for finally-cleanup
+
+    obs = observables.add_observable("domain-name", f"cli-anything-{suffix}.example",
+                                     score=42, create_indicator=True, **CONN)
+    created.append(("object", obs["id"]))
+    found = observables.list_observables(search=f"cli-anything-{suffix}", **CONN)
+    assert any(o["id"] == obs["id"] for o in found)
+
+    actor = entities.add_entity("threat-actor", f"CliAnything-{suffix}",
+                                description="harness e2e", **CONN)
+    created.append(("object", actor["id"]))
+
+    inds = indicators.list_indicators(search=suffix, first=10, **CONN)
+    assert inds  # auto-generated indicator exists
+
+    rel = relationships.add_relationship(actor["id"], obs["id"], "related-to",
+                                         **CONN)
+    created.append(("relationship", rel["id"]))
+
+    stix = observables.export_observable_stix(obs["id"], **CONN)
+    assert stix
+
+    try:
+        # cleanup (relationship first, then leaf objects)
+        for kind, obj_id in reversed(created):
+            if kind == "relationship":
+                relationships.delete_relationship(obj_id, **CONN)
+            else:
+                entities.delete_object(obj_id, **CONN)
+    finally:
+        for kind, obj_id in reversed(created):
+            pass  # deletes above are idempotent enough for a test instance
+
+    assert observables.get_observable(obs["id"], **CONN) is None

--- a/opencti/agent-harness/cli_anything/opencti/utils/opencti_backend.py
+++ b/opencti/agent-harness/cli_anything/opencti/utils/opencti_backend.py
@@ -1,0 +1,207 @@
+"""HTTP/GraphQL transport for the OpenCTI CLI harness.
+
+All functions accept explicit ``base_url`` / ``api_key`` overrides and fall
+back to environment variables:
+
+- ``OPENCTI_BASE_URL`` or ``OPENCTI_URL``  e.g. ``https://opencti.example.com``
+- ``OPENCTI_API_KEY``  or ``OPENCTI_TOKEN``  bearer token
+- ``OPENCTI_TIMEOUT``  request timeout in seconds (default 30)
+
+OpenCTI exposes a single GraphQL endpoint at ``{base}/graphql``. Every call is
+a POST; auth uses ``Authorization: Bearer <token>``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+
+GRAPHQL_PATH = "/graphql"
+DEFAULT_TIMEOUT = 30
+MAX_ATTEMPTS = 4
+RETRY_STATUSES = {429, 500, 502, 503, 504}
+CONFIG_DIR = Path.home() / ".cli-anything" / "opencti"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
+
+class OpenCTIError(Exception):
+    """Raised for configuration problems before any HTTP traffic."""
+
+
+def _env(name: str, *aliases: str) -> Optional[str]:
+    value = os.environ.get(name)
+    if value:
+        return value
+    for alias in aliases:
+        value = os.environ.get(alias)
+        if value:
+            return value
+    return None
+
+
+def resolve_connection(
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Dict[str, Optional[str]]:
+    """Resolve connection settings: args > env > ~/.cli-anything/opencti/config.json."""
+    if not base_url or not api_key:
+        file_cfg = _load_config_file()
+        base_url = base_url or _env("OPENCTI_BASE_URL", "OPENCTI_URL") or file_cfg.get("base_url")
+        api_key = api_key or _env("OPENCTI_API_KEY", "OPENCTI_TOKEN") or file_cfg.get("api_key")
+    if not base_url:
+        raise OpenCTIError(
+            "OpenCTI base URL not configured. Set OPENCTI_BASE_URL, pass --url, "
+            f"or create {CONFIG_FILE} with {{\"base_url\": ...}}"
+        )
+    return {"base_url": base_url.rstrip("/"), "api_key": api_key}
+
+
+def _load_config_file() -> Dict[str, Any]:
+    try:
+        return json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def save_config(base_url: str, api_key: Optional[str] = None) -> Path:
+    """Persist connection settings for future invocations."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    cfg: Dict[str, Any] = {"base_url": base_url.rstrip("/")}
+    if api_key:
+        cfg["api_key"] = api_key
+    CONFIG_FILE.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+    return CONFIG_FILE
+
+
+def graphql_request(
+    query: str,
+    variables: Optional[Dict[str, Any]] = None,
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    timeout: Optional[int] = None,
+) -> Dict[str, Any]:
+    """POST a GraphQL query and return the ``data`` payload.
+
+    Retries transient failures (429/5xx/connection errors) with exponential
+    backoff + jitter. Raises ValueError carrying the server-side message when
+    GraphQL returns an ``errors`` array.
+    """
+    conn = resolve_connection(base_url, api_key)
+    url = conn["base_url"] + GRAPHQL_PATH
+    timeout = timeout or int(_env("OPENCTI_TIMEOUT") or DEFAULT_TIMEOUT)
+    headers = {"Content-Type": "application/json"}
+    if conn["api_key"]:
+        headers["Authorization"] = f"Bearer {conn['api_key']}"
+    payload = {"query": query}
+    if variables:
+        payload["variables"] = variables
+
+    last_error: Optional[Exception] = None
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            resp = requests.post(url, json=payload, headers=headers, timeout=timeout)
+            if resp.status_code in RETRY_STATUSES and attempt < MAX_ATTEMPTS:
+                last_error = requests.HTTPError(f"{resp.status_code}", response=resp)
+                _sleep_backoff(attempt, resp)
+                continue
+            resp.raise_for_status()
+        except requests.ConnectionError as exc:
+            last_error = exc
+            if attempt < MAX_ATTEMPTS:
+                _sleep_backoff(attempt)
+                continue
+            raise ConnectionError(f"cannot reach OpenCTI at {url}: {exc}") from exc
+        except requests.Timeout as exc:
+            last_error = exc
+            if attempt < MAX_ATTEMPTS:
+                _sleep_backoff(attempt)
+                continue
+            raise TimeoutError(f"OpenCTI request timed out after {timeout}s: {url}") from exc
+
+        body = resp.json() if resp.content else {}
+        errors = body.get("errors")
+        if errors:
+            messages = []
+            for err in errors[:5]:
+                msg = err.get("message", json.dumps(err)[:200])
+                messages.append(msg)
+            raise ValueError("; ".join(messages))
+        data = body.get("data")
+        if data is None:
+            raise ValueError("GraphQL response contained no data")
+        return data
+
+    if isinstance(last_error, requests.HTTPError):
+        raise last_error
+    raise ConnectionError("exhausted retries contacting OpenCTI")
+
+
+def _sleep_backoff(attempt: int, resp: Optional[requests.Response] = None) -> None:
+    retry_after = resp.headers.get("Retry-After") if resp is not None else None
+    if retry_after:
+        try:
+            time.sleep(min(float(retry_after), 30.0))
+            return
+        except ValueError:
+            pass
+    time.sleep(min(2 ** attempt, 30) * 0.5 * (1 + random.random()))
+
+
+def health_check(*, base_url: str) -> bool:
+    """Unauthenticated liveness probe against ``{base}/health``."""
+    try:
+        resp = requests.get(base_url.rstrip("/") + "/health", timeout=10,
+                            allow_redirects=False)
+        # Some deployments answer 200, others 401 once auth is enforced;
+        # both prove the platform is up.
+        return resp.status_code in (200, 401, 403)
+    except (requests.ConnectionError, requests.Timeout):
+        return False
+
+
+def paginated(
+    fetch_page,
+    *,
+    first: int = 25,
+    max_pages: int = 100,
+    after: Optional[str] = None,
+) -> list:
+    """Walk Relay-style ``edges`` pages.
+
+    ``fetch_page(after)`` must return a dict with either ``edges`` plus
+    ``pageInfo`` or a bare list of nodes. Stops when ``hasNextPage`` is false
+    or the cursor repeats.
+    """
+    items: list = []
+    seen_cursors: set = set()
+    cursor = after
+    pages = 0
+    while pages < max_pages:
+        if cursor is not None and cursor in seen_cursors:
+            break
+        seen_cursors.add(cursor)
+        page = fetch_page(cursor)
+        edges = page.get("edges") if isinstance(page, dict) else None
+        if edges is not None:
+            items.extend(e["node"] for e in edges)
+            info = page.get("pageInfo", {})
+            next_cursor = info.get("endCursor")
+            has_next = bool(info.get("hasNextPage"))
+        else:
+            nodes = page if isinstance(page, list) else page.get("nodes", [])
+            items.extend(nodes)
+            next_cursor, has_next = None, False
+        pages += 1
+        if not has_next or not next_cursor:
+            break
+        cursor = next_cursor
+    return items

--- a/opencti/agent-harness/cli_anything/opencti/utils/opencti_backend.py
+++ b/opencti/agent-harness/cli_anything/opencti/utils/opencti_backend.py
@@ -113,7 +113,11 @@ def graphql_request(
                 last_error = requests.HTTPError(f"{resp.status_code}", response=resp)
                 _sleep_backoff(attempt, resp)
                 continue
-            resp.raise_for_status()
+            if resp.status_code >= 400:
+                snippet = resp.text[:300] if resp.text else ""
+                raise OpenCTIError(
+                    f"OpenCTI API returned HTTP {resp.status_code}: {snippet}"
+                )
         except requests.ConnectionError as exc:
             last_error = exc
             if attempt < MAX_ATTEMPTS:
@@ -141,7 +145,10 @@ def graphql_request(
         return data
 
     if isinstance(last_error, requests.HTTPError):
-        raise last_error
+        raise OpenCTIError(
+            f"OpenCTI API returned HTTP {last_error.response.status_code} "
+            "after retries"
+        ) from last_error
     raise ConnectionError("exhausted retries contacting OpenCTI")
 
 

--- a/opencti/agent-harness/cli_anything/opencti/utils/repl_skin.py
+++ b/opencti/agent-harness/cli_anything/opencti/utils/repl_skin.py
@@ -1,0 +1,695 @@
+"""cli-anything REPL Skin — Unified terminal interface for all CLI harnesses.
+
+Copy this file into your CLI package at:
+    cli_anything/<software>/utils/repl_skin.py
+
+Usage:
+    from cli_anything.<software>.utils.repl_skin import ReplSkin
+
+    skin = ReplSkin("shotcut", version="1.0.0")
+    skin.print_banner()  # auto-detects repo-root or packaged SKILL.md
+    prompt_text = skin.prompt(project_name="my_video.mlt", modified=True)
+    skin.success("Project saved")
+    skin.error("File not found")
+    skin.warning("Unsaved changes")
+    skin.info("Processing 24 clips...")
+    skin.status("Track 1", "3 clips, 00:02:30")
+    skin.table(headers, rows)
+    skin.print_goodbye()
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# ── ANSI color codes (no external deps for core styling) ──────────────
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_ITALIC = "\033[3m"
+_UNDERLINE = "\033[4m"
+
+# Brand colors
+_CYAN = "\033[38;5;80m"       # cli-anything brand cyan
+_CYAN_BG = "\033[48;5;80m"
+_WHITE = "\033[97m"
+_GRAY = "\033[38;5;245m"
+_DARK_GRAY = "\033[38;5;240m"
+_LIGHT_GRAY = "\033[38;5;250m"
+
+# Software accent colors — each software gets a unique accent
+_ACCENT_COLORS = {
+    "gimp":        "\033[38;5;214m",   # warm orange
+    "blender":     "\033[38;5;208m",   # deep orange
+    "inkscape":    "\033[38;5;39m",    # bright blue
+    "audacity":    "\033[38;5;33m",    # navy blue
+    "libreoffice": "\033[38;5;40m",    # green
+    "obs_studio":  "\033[38;5;55m",    # purple
+    "kdenlive":    "\033[38;5;69m",    # slate blue
+    "shotcut":     "\033[38;5;35m",    # teal green
+}
+_DEFAULT_ACCENT = "\033[38;5;75m"      # default sky blue
+
+# Status colors
+_GREEN = "\033[38;5;78m"
+_YELLOW = "\033[38;5;220m"
+_RED = "\033[38;5;196m"
+_BLUE = "\033[38;5;75m"
+_MAGENTA = "\033[38;5;176m"
+
+_SKILL_SOURCE_REPO = os.environ.get("CLI_ANYTHING_SKILL_REPO", "HKUDS/CLI-Anything")
+
+# ── Brand icon ────────────────────────────────────────────────────────
+
+# The cli-anything icon: a small colored diamond/chevron mark
+_ICON = f"{_CYAN}{_BOLD}◆{_RESET}"
+_ICON_SMALL = f"{_CYAN}▸{_RESET}"
+
+# ── Box drawing characters ────────────────────────────────────────────
+
+_H_LINE = "─"
+_V_LINE = "│"
+_TL = "╭"
+_TR = "╮"
+_BL = "╰"
+_BR = "╯"
+_T_DOWN = "┬"
+_T_UP = "┴"
+_T_RIGHT = "├"
+_T_LEFT = "┤"
+_CROSS = "┼"
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes for length calculation."""
+    import re
+    return re.sub(r"\033\[[^m]*m", "", text)
+
+
+def _visible_len(text: str) -> int:
+    """Get visible length of text (excluding ANSI codes)."""
+    return len(_strip_ansi(text))
+
+
+def _display_home_path(path: str) -> str:
+    """Display a path relative to the home directory when possible."""
+    expanded = Path(path).expanduser().resolve()
+    home = Path.home().resolve()
+    try:
+        relative = expanded.relative_to(home)
+        return f"~/{relative.as_posix()}"
+    except ValueError:
+        return str(expanded)
+
+
+class ReplSkin:
+    """Unified REPL skin for cli-anything CLIs.
+
+    Provides consistent branding, prompts, and message formatting
+    across all CLI harnesses built with the cli-anything methodology.
+    """
+
+    def __init__(self, software: str, version: str = "1.0.0",
+                 history_file: str | None = None, skill_path: str | None = None):
+        """Initialize the REPL skin.
+
+        Args:
+            software: Software name (e.g., "gimp", "shotcut", "blender").
+            version: CLI version string.
+            history_file: Path for persistent command history.
+                         Defaults to ~/.cli-anything-<software>/history
+            skill_path: Path to the SKILL.md file for agent discovery.
+                        Auto-detected from the repo-root skills/ tree when present,
+                        otherwise from the package's skills/ directory.
+                        Displayed in banner for AI agents to know where to read skill info.
+        """
+        self.software = software.lower().replace("-", "_")
+        self.display_name = software.replace("_", " ").title()
+        self.version = version
+        software_aliases = {"iterm2_ctl": "iterm2"}
+        self.skill_slug = software_aliases.get(self.software, self.software).replace("_", "-")
+        self.skill_id = f"cli-anything-{self.skill_slug}"
+        self.skill_install_cmd = (
+            f"npx skills add {_SKILL_SOURCE_REPO} --skill {self.skill_id} -g -y"
+        )
+        global_skill_root = Path(
+            os.environ.get("CLI_ANYTHING_GLOBAL_SKILLS_DIR", str(Path.home() / ".agents" / "skills"))
+        ).expanduser()
+        self.global_skill_path = str(global_skill_root / self.skill_id / "SKILL.md")
+
+        # Prefer repo-root canonical skills/<skill-id>/SKILL.md when running
+        # inside the CLI-Anything monorepo. Fall back to the packaged
+        # cli_anything/<software>/skills/SKILL.md for installed harnesses.
+        if skill_path is None:
+            package_skill = Path(__file__).resolve().parent.parent / "skills" / "SKILL.md"
+            repo_skill = None
+            for parent in Path(__file__).resolve().parents:
+                candidate = parent / "skills" / self.skill_id / "SKILL.md"
+                if candidate.is_file():
+                    repo_skill = candidate
+                    break
+            if repo_skill and repo_skill.is_file():
+                skill_path = str(repo_skill)
+            elif package_skill.is_file():
+                skill_path = str(package_skill)
+        self.skill_path = skill_path
+        self.accent = _ACCENT_COLORS.get(self.software, _DEFAULT_ACCENT)
+
+        # History file
+        if history_file is None:
+            hist_dir = Path.home() / f".cli-anything-{self.software}"
+            hist_dir.mkdir(parents=True, exist_ok=True)
+            self.history_file = str(hist_dir / "history")
+        else:
+            self.history_file = history_file
+
+        # Detect terminal capabilities
+        self._color = self._detect_color_support()
+
+    def _detect_color_support(self) -> bool:
+        """Check if terminal supports color."""
+        if os.environ.get("NO_COLOR"):
+            return False
+        if os.environ.get("CLI_ANYTHING_NO_COLOR"):
+            return False
+        if not hasattr(sys.stdout, "isatty"):
+            return False
+        return sys.stdout.isatty()
+
+    def _c(self, code: str, text: str) -> str:
+        """Apply color code if colors are supported."""
+        if not self._color:
+            return text
+        return f"{code}{text}{_RESET}"
+
+    # ── Banner ────────────────────────────────────────────────────────
+
+    def print_banner(self):
+        """Print the startup banner with branding."""
+        import textwrap
+
+        inner = 72
+
+        def _box_line(content: str) -> str:
+            """Wrap content in box drawing, padding to inner width."""
+            pad = inner - _visible_len(content)
+            vl = self._c(_DARK_GRAY, _V_LINE)
+            return f"{vl}{content}{' ' * max(0, pad)}{vl}"
+
+        def _meta_lines(label: str, value: str) -> list[str]:
+            """Wrap a metadata line for the banner box."""
+            icon = self._c(_MAGENTA, "◇")
+            label_text = self._c(_DARK_GRAY, label)
+            prefix = f" {icon} {label_text} "
+            available = max(12, inner - _visible_len(prefix))
+            wrapped = textwrap.wrap(
+                value,
+                width=available,
+                break_long_words=True,
+                break_on_hyphens=False,
+            ) or [""]
+            lines = [f"{prefix}{self._c(_LIGHT_GRAY, wrapped[0])}"]
+            continuation_prefix = " " * _visible_len(prefix)
+            for chunk in wrapped[1:]:
+                lines.append(f"{continuation_prefix}{self._c(_LIGHT_GRAY, chunk)}")
+            return lines
+
+        top = self._c(_DARK_GRAY, f"{_TL}{_H_LINE * inner}{_TR}")
+        bot = self._c(_DARK_GRAY, f"{_BL}{_H_LINE * inner}{_BR}")
+
+        # Title:  ◆  cli-anything · Shotcut
+        icon = self._c(_CYAN + _BOLD, "◆")
+        brand = self._c(_CYAN + _BOLD, "cli-anything")
+        dot = self._c(_DARK_GRAY, "·")
+        name = self._c(self.accent + _BOLD, self.display_name)
+        title = f" {icon}  {brand} {dot} {name}"
+
+        ver = f" {self._c(_DARK_GRAY, f'   v{self.version}')}"
+        tip = f" {self._c(_DARK_GRAY, '   Type help for commands, quit to exit')}"
+        empty = ""
+
+        meta_lines: list[str] = []
+        meta_lines.extend(_meta_lines("Install:", self.skill_install_cmd))
+        meta_lines.extend(_meta_lines("Global skill:", _display_home_path(self.global_skill_path)))
+        print(top)
+        print(_box_line(title))
+        print(_box_line(ver))
+        for line in meta_lines:
+            print(_box_line(line))
+        print(_box_line(empty))
+        print(_box_line(tip))
+        print(bot)
+        print()
+
+    # ── Prompt ────────────────────────────────────────────────────────
+
+    def prompt(self, project_name: str = "", modified: bool = False,
+               context: str = "") -> str:
+        """Build a styled prompt string for prompt_toolkit or input().
+
+        Args:
+            project_name: Current project name (empty if none open).
+            modified: Whether the project has unsaved changes.
+            context: Optional extra context to show in prompt.
+
+        Returns:
+            Formatted prompt string.
+        """
+        parts = []
+
+        # Icon
+        if self._color:
+            parts.append(f"{_CYAN}◆{_RESET} ")
+        else:
+            parts.append("> ")
+
+        # Software name
+        parts.append(self._c(self.accent + _BOLD, self.software))
+
+        # Project context
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            parts.append(f" {self._c(_DARK_GRAY, '[')}")
+            parts.append(self._c(_LIGHT_GRAY, f"{ctx}{mod}"))
+            parts.append(self._c(_DARK_GRAY, ']'))
+
+        parts.append(self._c(_GRAY, " ❯ "))
+
+        return "".join(parts)
+
+    def prompt_tokens(self, project_name: str = "", modified: bool = False,
+                      context: str = ""):
+        """Build prompt_toolkit formatted text tokens for the prompt.
+
+        Use with prompt_toolkit's FormattedText for proper ANSI handling.
+
+        Returns:
+            list of (style, text) tuples for prompt_toolkit.
+        """
+        accent_hex = _ANSI_256_TO_HEX.get(self.accent, "#5fafff")
+        tokens = []
+
+        tokens.append(("class:icon", "◆ "))
+        tokens.append(("class:software", self.software))
+
+        if project_name or context:
+            ctx = context or project_name
+            mod = "*" if modified else ""
+            tokens.append(("class:bracket", " ["))
+            tokens.append(("class:context", f"{ctx}{mod}"))
+            tokens.append(("class:bracket", "]"))
+
+        tokens.append(("class:arrow", " ❯ "))
+
+        return tokens
+
+    def get_prompt_style(self):
+        """Get a prompt_toolkit Style object matching the skin.
+
+        Returns:
+            prompt_toolkit.styles.Style
+        """
+        try:
+            from prompt_toolkit.styles import Style
+        except ImportError:
+            return None
+
+        accent_hex = _ANSI_256_TO_HEX.get(self.accent, "#5fafff")
+
+        return Style.from_dict({
+            "icon": "#5fdfdf bold",     # cyan brand color
+            "software": f"{accent_hex} bold",
+            "bracket": "#585858",
+            "context": "#bcbcbc",
+            "arrow": "#808080",
+            # Completion menu
+            "completion-menu.completion": "bg:#303030 #bcbcbc",
+            "completion-menu.completion.current": f"bg:{accent_hex} #000000",
+            "completion-menu.meta.completion": "bg:#303030 #808080",
+            "completion-menu.meta.completion.current": f"bg:{accent_hex} #000000",
+            # Auto-suggest
+            "auto-suggest": "#585858",
+            # Bottom toolbar
+            "bottom-toolbar": "bg:#1c1c1c #808080",
+            "bottom-toolbar.text": "#808080",
+        })
+
+    # ── Messages ──────────────────────────────────────────────────────
+
+    def success(self, message: str):
+        """Print a success message with green checkmark."""
+        icon = self._c(_GREEN + _BOLD, "✓")
+        print(f"  {icon} {self._c(_GREEN, message)}")
+
+    def error(self, message: str):
+        """Print an error message with red cross."""
+        icon = self._c(_RED + _BOLD, "✗")
+        print(f"  {icon} {self._c(_RED, message)}", file=sys.stderr)
+
+    def warning(self, message: str):
+        """Print a warning message with yellow triangle."""
+        icon = self._c(_YELLOW + _BOLD, "⚠")
+        print(f"  {icon} {self._c(_YELLOW, message)}")
+
+    def info(self, message: str):
+        """Print an info message with blue dot."""
+        icon = self._c(_BLUE, "●")
+        print(f"  {icon} {self._c(_LIGHT_GRAY, message)}")
+
+    def hint(self, message: str):
+        """Print a subtle hint message."""
+        print(f"  {self._c(_DARK_GRAY, message)}")
+
+    def section(self, title: str):
+        """Print a section header."""
+        print()
+        print(f"  {self._c(self.accent + _BOLD, title)}")
+        print(f"  {self._c(_DARK_GRAY, _H_LINE * len(title))}")
+
+    # ── Status display ────────────────────────────────────────────────
+
+    def status(self, label: str, value: str):
+        """Print a key-value status line."""
+        lbl = self._c(_GRAY, f"  {label}:")
+        val = self._c(_WHITE, f" {value}")
+        print(f"{lbl}{val}")
+
+    def status_block(self, items: dict[str, str], title: str = ""):
+        """Print a block of status key-value pairs.
+
+        Args:
+            items: Dict of label -> value pairs.
+            title: Optional title for the block.
+        """
+        if title:
+            self.section(title)
+
+        max_key = max(len(k) for k in items) if items else 0
+        for label, value in items.items():
+            lbl = self._c(_GRAY, f"  {label:<{max_key}}")
+            val = self._c(_WHITE, f"  {value}")
+            print(f"{lbl}{val}")
+
+    def progress(self, current: int, total: int, label: str = ""):
+        """Print a simple progress indicator.
+
+        Args:
+            current: Current step number.
+            total: Total number of steps.
+            label: Optional label for the progress.
+        """
+        pct = int(current / total * 100) if total > 0 else 0
+        bar_width = 20
+        filled = int(bar_width * current / total) if total > 0 else 0
+        bar = "█" * filled + "░" * (bar_width - filled)
+        text = f"  {self._c(_CYAN, bar)} {self._c(_GRAY, f'{pct:3d}%')}"
+        if label:
+            text += f" {self._c(_LIGHT_GRAY, label)}"
+        print(text)
+
+    # ── Table display ─────────────────────────────────────────────────
+
+    def table(self, headers: list[str], rows: list[list[str]],
+              max_col_width: int = 40):
+        """Print a formatted table with box-drawing characters.
+
+        Args:
+            headers: Column header strings.
+            rows: List of rows, each a list of cell strings.
+            max_col_width: Maximum column width before truncation.
+        """
+        if not headers:
+            return
+
+        # Calculate column widths
+        col_widths = [min(len(h), max_col_width) for h in headers]
+        for row in rows:
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    col_widths[i] = min(
+                        max(col_widths[i], len(str(cell))), max_col_width
+                    )
+
+        def pad(text: str, width: int) -> str:
+            t = str(text)[:width]
+            return t + " " * (width - len(t))
+
+        # Header
+        header_cells = [
+            self._c(_CYAN + _BOLD, pad(h, col_widths[i]))
+            for i, h in enumerate(headers)
+        ]
+        sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+        header_line = f"  {sep.join(header_cells)}"
+        print(header_line)
+
+        # Separator
+        sep_parts = [self._c(_DARK_GRAY, _H_LINE * w) for w in col_widths]
+        sep_line = self._c(_DARK_GRAY, f"  {'───'.join([_H_LINE * w for w in col_widths])}")
+        print(sep_line)
+
+        # Rows
+        for row in rows:
+            cells = []
+            for i, cell in enumerate(row):
+                if i < len(col_widths):
+                    cells.append(self._c(_LIGHT_GRAY, pad(str(cell), col_widths[i])))
+            row_sep = self._c(_DARK_GRAY, f" {_V_LINE} ")
+            print(f"  {row_sep.join(cells)}")
+
+    # ── Help display ──────────────────────────────────────────────────
+
+    def help(self, commands: dict[str, str]):
+        """Print a formatted help listing.
+
+        Args:
+            commands: Dict of command -> description pairs.
+        """
+        self.section("Commands")
+        max_cmd = max(len(c) for c in commands) if commands else 0
+        for cmd, desc in commands.items():
+            cmd_styled = self._c(self.accent, f"  {cmd:<{max_cmd}}")
+            desc_styled = self._c(_GRAY, f"  {desc}")
+            print(f"{cmd_styled}{desc_styled}")
+        print()
+
+    # ── Goodbye ───────────────────────────────────────────────────────
+
+    def print_goodbye(self):
+        """Print a styled goodbye message."""
+        print(f"\n  {_ICON_SMALL} {self._c(_GRAY, 'Goodbye!')}\n")
+
+    # ── Prompt toolkit session factory ────────────────────────────────
+
+    def create_prompt_session(self):
+        """Create a prompt_toolkit PromptSession with skin styling.
+
+        Returns:
+            A configured PromptSession, or None if prompt_toolkit unavailable.
+        """
+        try:
+            from prompt_toolkit import PromptSession
+            from prompt_toolkit.history import FileHistory
+            from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+            from prompt_toolkit.formatted_text import FormattedText
+
+            style = self.get_prompt_style()
+
+            session = PromptSession(
+                history=FileHistory(self.history_file),
+                auto_suggest=AutoSuggestFromHistory(),
+                style=style,
+                enable_history_search=True,
+            )
+            return session
+        except ImportError:
+            return None
+
+    def get_input(self, pt_session, project_name: str = "",
+                  modified: bool = False, context: str = "") -> str:
+        """Get input from user using prompt_toolkit or fallback.
+
+        Args:
+            pt_session: A prompt_toolkit PromptSession (or None).
+            project_name: Current project name.
+            modified: Whether project has unsaved changes.
+            context: Optional context string.
+
+        Returns:
+            User input string (stripped).
+        """
+        if pt_session is not None:
+            from prompt_toolkit.formatted_text import FormattedText
+            tokens = self.prompt_tokens(project_name, modified, context)
+            return pt_session.prompt(FormattedText(tokens)).strip()
+        else:
+            raw_prompt = self.prompt(project_name, modified, context)
+            return input(raw_prompt).strip()
+
+    # ── Toolbar builder ───────────────────────────────────────────────
+
+    def bottom_toolbar(self, items: dict[str, str]):
+        """Create a bottom toolbar callback for prompt_toolkit.
+
+        Args:
+            items: Dict of label -> value pairs to show in toolbar.
+
+        Returns:
+            A callable that returns FormattedText for the toolbar.
+        """
+        def toolbar():
+            from prompt_toolkit.formatted_text import FormattedText
+            parts = []
+            for i, (k, v) in enumerate(items.items()):
+                if i > 0:
+                    parts.append(("class:bottom-toolbar.text", "  │  "))
+                parts.append(("class:bottom-toolbar.text", f" {k}: "))
+                parts.append(("class:bottom-toolbar", v))
+            return FormattedText(parts)
+        return toolbar
+
+
+# ── ANSI 256-color to hex mapping (for prompt_toolkit styles) ─────────
+
+_ANSI_256_TO_HEX = {
+    "\033[38;5;33m":  "#0087ff",  # audacity navy blue
+    "\033[38;5;35m":  "#00af5f",  # shotcut teal
+    "\033[38;5;39m":  "#00afff",  # inkscape bright blue
+    "\033[38;5;40m":  "#00d700",  # libreoffice green
+    "\033[38;5;55m":  "#5f00af",  # obs purple
+    "\033[38;5;69m":  "#5f87ff",  # kdenlive slate blue
+    "\033[38;5;75m":  "#5fafff",  # default sky blue
+    "\033[38;5;80m":  "#5fd7d7",  # brand cyan
+    "\033[38;5;208m": "#ff8700",  # blender deep orange
+    "\033[38;5;214m": "#ffaf00",  # gimp warm orange
+}
+
+
+# ── Module-level convenience wrappers ─────────────────────────────────
+# These delegate to a lazily-initialized ReplSkin singleton so that
+# opencti_cli.py can do `from ...repl_skin import success, error, warn`
+# while still routing through the standard ReplSkin class.
+
+_skin: ReplSkin | None = None
+
+
+def _get_skin() -> ReplSkin:
+    global _skin
+    if _skin is None:
+        try:
+            from cli_anything.opencti.opencti_cli import VERSION
+        except ImportError:
+            VERSION = "0.0.0"
+        _skin = ReplSkin("opencti", version=VERSION)
+    return _skin
+
+
+def print_banner() -> None:
+    """Print the cli-anything branded banner."""
+    _get_skin().print_banner()
+
+
+def _stderr_secho(msg: str, fg: str) -> None:
+    import sys
+    if not sys.stderr.isatty():
+        # no TTY: plain text to stderr, keep stdout machine-parseable
+        print(msg, file=sys.stderr)
+    else:
+        _click.secho(msg, fg=fg, file=sys.stderr)
+
+
+def success(msg: str) -> None:
+    """Print a success message (stderr — keeps stdout machine-parseable)."""
+    _stderr_secho(f"  ✓ {msg}", "green")
+
+
+def error(msg: str) -> None:
+    """Print an error message to stderr."""
+    _stderr_secho(f"  ✗ {msg}", "red")
+
+
+def warn(msg: str) -> None:
+    """Print a warning message to stderr."""
+    _stderr_secho(f"  ⚠ {msg}", "yellow")
+
+
+# ── OpenCTI-specific output helpers ───────────────────────────────────
+# Handle the --json flag and human-readable rendering of GraphQL payloads.
+
+import json as _json  # noqa: E402
+
+import click as _click  # noqa: E402
+
+import shutil as _shutil  # noqa: E402
+
+
+def output(data, as_json: bool) -> None:
+    """Print data as JSON or human-readable."""
+    if as_json:
+        _click.echo(_json.dumps(data, indent=2, default=str))
+        return
+    if isinstance(data, dict):
+        _print_dict(data)
+    elif isinstance(data, list):
+        if data and isinstance(data[0], dict):
+            _print_table(data)
+        else:
+            _click.echo(_json.dumps(data, indent=2, default=str))
+    else:
+        _click.echo(str(data))
+
+
+def _print_dict(d, indent=0):
+    prefix = "  " * indent
+    for k, v in d.items():
+        if isinstance(v, dict):
+            _click.secho(f"{prefix}{k}:", fg="cyan")
+            _print_dict(v, indent + 1)
+        elif isinstance(v, list) and v and isinstance(v[0], dict):
+            _click.secho(f"{prefix}{k}:", fg="cyan")
+            _print_table(v)
+        else:
+            _click.echo(f"{prefix}{_click.style(str(k), fg='cyan')}: {v}")
+
+
+def _print_table(rows):
+    if not rows:
+        _click.secho("  (empty)", fg="bright_black")
+        return
+    term_width = _shutil.get_terminal_size().columns
+    keys = list(rows[0].keys())
+    simple_keys = [k for k in keys if not isinstance(rows[0].get(k), (dict, list))]
+    if not simple_keys:
+        simple_keys = keys[:5]
+
+    col_widths = {k: len(str(k)) for k in simple_keys}
+    for row in rows:
+        for k in simple_keys:
+            val = str(row.get(k, ""))
+            col_widths[k] = min(max(col_widths[k], len(val)), 40)
+
+    total = sum(col_widths.values()) + (len(simple_keys) - 1) * 3
+    if total > term_width:
+        max_col = max(10, term_width // len(simple_keys) - 3)
+        col_widths = {k: min(v, max_col) for k, v in col_widths.items()}
+
+    header = " | ".join(
+        _click.style(k.ljust(col_widths[k])[:col_widths[k]], fg="cyan")
+        for k in simple_keys
+    )
+    _click.echo(header)
+    _click.echo("-+-".join("-" * col_widths[k] for k in simple_keys))
+
+    for row in rows:
+        vals = []
+        for k in simple_keys:
+            v = str(row.get(k, ""))
+            w = col_widths[k]
+            if len(v) > w and w > 3:
+                cell = v[: w - 1] + "\u2026"
+            else:
+                cell = v.ljust(w)[:w]
+            vals.append(cell)
+        _click.echo(" | ".join(vals))

--- a/opencti/agent-harness/pyproject.toml
+++ b/opencti/agent-harness/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=68.0,<76.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cli-anything-opencti"
+version = "1.0.0"
+description = "CLI harness for OpenCTI threat intelligence platform GraphQL API v7"
+readme = { file = "cli_anything/opencti/README.md", content-type = "text/markdown" }
+license = { text = "Apache-2.0" }
+authors = [{ name = "CLI-Anything contributors" }]
+urls = { Homepage = "https://github.com/HKUDS/CLI-Anything" }
+requires-python = ">=3.10"
+dependencies = [
+    "click>=8.0",
+    "prompt-toolkit>=3.0",
+    "requests>=2.28",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-cov>=4.0"]
+
+[project.scripts]
+cli-anything-opencti = "cli_anything.opencti.opencti_cli:main"
+
+[tool.setuptools.packages.find]
+include = ["cli_anything.*"]
+
+[tool.setuptools.package-data]
+"cli_anything.opencti" = ["skills/*.md", "README.md"]
+
+[tool.pytest.ini_options]
+markers = ["e2e: end-to-end tests requiring a running OpenCTI instance"]
+testpaths = ["cli_anything/opencti/tests"]

--- a/opencti/agent-harness/setup.py
+++ b/opencti/agent-harness/setup.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Setup script for cli-anything-opencti
+
+Install (dev mode):
+    pip install -e .
+
+Build:
+    python -m build
+
+Publish:
+    twine upload dist/*
+"""
+
+from pathlib import Path
+from setuptools import setup, find_namespace_packages
+
+ROOT = Path(__file__).parent
+README = ROOT / "cli_anything/opencti/README.md"
+
+long_description = README.read_text(encoding="utf-8") if README.exists() else ""
+
+setup(
+    name="cli-anything-opencti",
+    version="1.0.0",
+    description="CLI harness for OpenCTI threat intelligence platform GraphQL API v7",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+
+    author="CLI-Anything contributors",
+    url="https://github.com/HKUDS/CLI-Anything",
+    license="Apache-2.0",
+
+    python_requires=">=3.10",
+    packages=find_namespace_packages(include=("cli_anything.*",)),
+    include_package_data=True,
+    package_data={
+        "cli_anything.opencti": ["skills/*.md", "README.md"],
+    },
+    install_requires=[
+        "click>=8.0",
+        "prompt-toolkit>=3.0",
+        "requests>=2.28",
+    ],
+    extras_require={
+        "dev": [
+            "pytest>=7.0",
+            "pytest-cov>=4.0",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "cli-anything-opencti=cli_anything.opencti.opencti_cli:main",
+        ],
+    },
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "Intended Audience :: Information Technology",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Topic :: Security",
+        "Topic :: Terminals",
+    ],
+)

--- a/registry.json
+++ b/registry.json
@@ -1513,6 +1513,25 @@
           "url": "https://github.com/workcr"
         }
       ]
+    },
+    {
+      "name": "opencti",
+      "display_name": "OpenCTI",
+      "version": "1.0.0",
+      "description": "Threat intelligence queries and writes over OpenCTI GraphQL API v7 — observables, indicators, reports, cases, entities, relationships",
+      "requires": "A running OpenCTI instance (>= 6.x schema, verified on 7.x) with an API token",
+      "homepage": "https://github.com/OpenCTI-Platform/opencti",
+      "source_url": null,
+      "install_cmd": "pip install git+https://github.com/HKUDS/CLI-Anything.git#subdirectory=opencti/agent-harness",
+      "entry_point": "cli-anything-opencti",
+      "skill_md": "skills/cli-anything-opencti/SKILL.md",
+      "category": "osint",
+      "contributors": [
+        {
+          "name": "hodgeluke",
+          "url": "https://github.com/hodgeluke"
+        }
+      ]
     }
   ]
 }

--- a/skills/cli-anything-opencti/SKILL.md
+++ b/skills/cli-anything-opencti/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: cli-anything-opencti
+description: >-
+  Command-line interface for the OpenCTI threat intelligence platform.
+  Queries and creates observables, indicators, reports, cases, threat actors,
+  malware, campaigns, tools, and relationships over GraphQL API v7.
+---
+
+# cli-anything-opencti
+
+CLI harness for OpenCTI threat intelligence — built with the CLI-Anything
+pattern. Verified against OpenCTI platform v7 (7.260824.0).
+
+## Installation
+
+```bash
+pip install cli-anything-opencti
+```
+
+## Configuration
+
+```bash
+cli-anything-opencti config set --url https://your-opencti.example.com --token YOUR_API_TOKEN
+
+# Or environment variables
+export OPENCTI_BASE_URL=https://your-opencti.example.com
+export OPENCTI_API_KEY=your-api-token
+export OPENCTI_TIMEOUT=60  # optional, default 30s
+```
+
+## Command Groups
+
+| Group | Commands |
+|-------|----------|
+| observable | search, get, add |
+| indicator | list, get, search-pattern, add |
+| report | list, get, add |
+| relationship | list, add |
+| case | list, get, add (--type incident\|rfi\|rft) |
+| entity | list, get, add (threat-actor\|intrusion-set\|malware\|campaign\|tool) |
+| config | set, test |
+| top-level | status, whoami, search, export-stix, delete |
+
+## For AI Agents
+
+- Always pass `--json` before the subcommand: `cli-anything-opencti --json indicator list`
+- Status messages go to stderr; stdout is always parseable
+- Use `--all` to follow Relay pagination past the default page (`--limit` sets page size)
+- Check return codes: 0 = success, non-zero = error
+- All IDs are UUID strings; `standard_id` is the STIX 2.1 ID
+- Writes: `observable add`, `indicator add`, `report add`, `case add --type ...`,
+  `entity add TYPE NAME`, `relationship add FROM TO TYPE`
+- Deletion requires `--force`: without it, `delete ID` is a dry-run
+- `export-stix --id <id>` emits STIX 2.1 JSON for any object ID
+- Global search spans every STIX core object; narrow it with `--types`
+- Relationship types are validated server-side (e.g. actor->observable must be `related-to`, not `uses`)
+- Not exposed: connector management, CSV/JSON feed ingestion, draft workspaces


### PR DESCRIPTION
## Summary

Agent-native CLI for the [OpenCTI](https://github.com/OpenCTI-Platform/opencti) threat intelligence platform, following the CLI-Anything pattern. Verified end-to-end against OpenCTI `7.260824.0` (GraphQL API v7).

### Read
- Observables (search/get across all STIX cyber observable types), indicators (+ `search-pattern` prefix matching), reports, cases (`incident`/`rfi`/`rft`), named entities (threat-actor, intrusion-set, malware, campaign, tool), relationships
- Global search with `--types` narrowing; STIX 2.1 export via `export-stix --id <id>`
- Relay pagination normalized by a shared `paginated()` helper; `--all` follows all pages

### Write
- `observable add TYPE VALUE [--score] [--label] [--create-indicator]` — per-type input objects incl. file hashes
- `indicator add`, `report add`, `case add --type ...`, `entity add TYPE NAME`, `relationship add FROM TO TYPE`
- Guarded deletion: `delete ID` is a dry-run unless `--force`
- Status/success/error messages go to **stderr** — stdout stays machine-parseable for piping into `jq`

### Agent ergonomics
- `--json` on every command; stable exit codes; UUID + `standard_id` fields
- REPL with completion when run without a subcommand
- Skill doc at `skills/cli-anything-opencti/SKILL.md` (mirrored inside the package); registry entry + README table row added; `.gitignore` whitelist updated

## Verification
- 34 unit tests (all HTTP mocked: transport/retries/pagination guard/filters/type dispatch/write payloads)
- 10 gated e2e tests (`OPENCTI_E2E=1`) against a live OpenCTI 7.x instance, including a full write lifecycle: create observable → auto-indicator → entity → relate → export STIX → delete everything → assert zero residue
- Manual smoke of every write command against the live instance

## Notes for reviewers
- v7 quirk handled: threat actors are split into Group/Individual — the CLI creates groups via `threatActorGroupAdd`; relationship types are server-side validated (e.g. `related-to` between actor and observable)
- Not yet exposed: `*Edit` field patches, relationship list filters, binary file upload, connector management