### PR TITLE
fix(blender): invoke Blender on render execute

### DIFF
--- a/blender/agent-harness/BLENDER.md
+++ b/blender/agent-harness/BLENDER.md
@@ -80,7 +80,7 @@ No translation gap — bpy is the native API.
 
 ## Export: bpy Script Generation
 
-The `render execute` command generates a complete Python script:
+The `render execute` command generates a complete Python script and runs it with `blender --background --python`:
 1. Creates all objects with correct mesh types and transforms
 2. Creates and assigns materials with all Principled BSDF properties
 3. Adds and configures modifiers

--- a/blender/agent-harness/cli_anything/blender/README.md
+++ b/blender/agent-harness/cli_anything/blender/README.md
@@ -38,11 +38,8 @@ python3 -m cli.blender_cli --project scene.json light add sun -r -45,0,30
 # Save
 python3 -m cli.blender_cli --project scene.json scene save
 
-# Generate render script
+# Render with Blender headless (writes _render_script.py, then invokes blender)
 python3 -m cli.blender_cli --project scene.json render execute render.png --overwrite
-
-# Execute with Blender (if installed)
-blender --background --python /path/to/_render_script.py
 ```
 
 ## JSON Output Mode
@@ -167,7 +164,7 @@ animation list-keyframes  - List keyframes for an object
 render settings - Configure render settings
 render info     - Show current render settings
 render presets  - List available render presets
-render execute  - Render the scene (generates bpy script)
+render execute  - Render the scene with Blender headless
 render script   - Generate bpy script to stdout
 ```
 
@@ -249,7 +246,7 @@ Since Blender's `.blend` format is binary, this CLI uses a JSON scene format
 and generates Blender Python (bpy) scripts for rendering. The workflow:
 
 1. Edit the scene using CLI commands (creates/modifies JSON)
-2. Generate a bpy script with `render execute` or `render script`
-3. Run the script with `blender --background --python script.py`
+2. `render execute` generates a bpy script and runs `blender --background --python` on it
+3. `render script` still prints the bpy script if you want to run Blender yourself
 
 The generated scripts reconstruct the entire scene in Blender and render it.

--- a/blender/agent-harness/cli_anything/blender/blender_cli.py
+++ b/blender/agent-harness/cli_anything/blender/blender_cli.py
@@ -864,13 +864,17 @@ def render_presets():
 @click.option("--overwrite", is_flag=True, help="Overwrite existing file")
 @handle_error
 def render_execute(output_path, frame, animation, overwrite):
-    """Render the scene (generates bpy script)."""
+    """Render the scene with Blender headless."""
     sess = get_session()
     result = render_mod.render_scene(
         sess.get_project(), output_path,
         frame=frame, animation=animation, overwrite=overwrite,
+        execute=True,
     )
-    output(result, f"Render script generated: {result['script_path']}")
+    rendered = result.get("output", result["output_path"])
+    file_size = result.get("file_size")
+    size_note = f" ({file_size:,} bytes)" if file_size is not None else ""
+    output(result, f"Rendered: {rendered}{size_note} via {result.get('method', 'blender-headless')}")
 
 
 @render_group.command("script")
@@ -1078,7 +1082,7 @@ def repl(project_path):
     global _repl_mode
     _repl_mode = True
 
-    skin = ReplSkin("blender", version="1.0.0")
+    skin = ReplSkin("blender", version="1.0.1")
 
     if project_path:
         sess = get_session()

--- a/blender/agent-harness/cli_anything/blender/blender_cli.py
+++ b/blender/agent-harness/cli_anything/blender/blender_cli.py
@@ -862,14 +862,15 @@ def render_presets():
 @click.option("--frame", "-f", type=int, default=None, help="Specific frame to render")
 @click.option("--animation", "-a", is_flag=True, help="Render full animation")
 @click.option("--overwrite", is_flag=True, help="Overwrite existing file")
+@click.option("--timeout", type=int, default=None, help="Seconds to wait for Blender; omit for no limit")
 @handle_error
-def render_execute(output_path, frame, animation, overwrite):
+def render_execute(output_path, frame, animation, overwrite, timeout):
     """Render the scene with Blender headless."""
     sess = get_session()
     result = render_mod.render_scene(
         sess.get_project(), output_path,
         frame=frame, animation=animation, overwrite=overwrite,
-        execute=True,
+        execute=True, timeout=timeout,
     )
     rendered = result.get("output", result["output_path"])
     file_size = result.get("file_size")

--- a/blender/agent-harness/cli_anything/blender/core/preview.py
+++ b/blender/agent-harness/cli_anything/blender/core/preview.py
@@ -31,7 +31,7 @@ from . import scene as scene_mod
 from .lighting import add_camera, add_light
 from .session import Session
 
-HARNESS_VERSION = "1.0.0"
+HARNESS_VERSION = "1.0.1"
 LIVE_PROTOCOL_VERSION = "preview-live/v1"
 DEFAULT_REFRESH_HINT_MS = 1500
 DEFAULT_SOURCE_POLL_MS = 500

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -5,9 +5,9 @@ for actual Blender rendering.
 """
 
 import os
-import json
 from typing import Dict, Any, Optional, List
-from datetime import datetime
+
+from cli_anything.blender.utils import blender_backend
 
 
 # Render presets
@@ -185,11 +185,10 @@ def render_scene(
     frame: Optional[int] = None,
     animation: bool = False,
     overwrite: bool = False,
+    execute: bool = False,
+    timeout: int = 300,
 ) -> Dict[str, Any]:
-    """Render the scene by generating a bpy script.
-
-    Since we cannot call Blender directly in all environments, this generates
-    a Python script that can be run with `blender --background --python script.py`.
+    """Prepare a render script, and optionally execute it with Blender.
 
     Args:
         project: The scene dict
@@ -197,9 +196,11 @@ def render_scene(
         frame: Specific frame to render (None = current frame)
         animation: If True, render the full animation range
         overwrite: Allow overwriting existing files
+        execute: If True, run Blender headless after generating the script
+        timeout: Maximum seconds to wait when execute=True
 
     Returns:
-        Dict with render info and script path
+        Dict with render info, script path, and optional backend output metadata
     """
     if os.path.exists(output_path) and not overwrite and not animation:
         raise FileExistsError(f"Output file exists: {output_path}. Use --overwrite.")
@@ -235,6 +236,32 @@ def render_scene(
         result["frame_range"] = f"{scene_settings.get('frame_start', 1)}-{scene_settings.get('frame_end', 250)}"
     else:
         result["frame"] = frame or scene_settings.get("frame_current", 1)
+
+    if execute:
+        backend_result = blender_backend.render_script(
+            result["script_path"],
+            output_path=result["output_path"],
+            animation=animation,
+            timeout=timeout,
+        )
+        if backend_result["returncode"] != 0:
+            raise RuntimeError(
+                f"Blender render failed (exit {backend_result['returncode']}):\n"
+                f"  stderr: {backend_result['stderr'][-500:]}"
+            )
+
+        result.update({
+            "executed": True,
+            "output": backend_result["output"],
+            "outputs": backend_result["outputs"],
+            "output_count": backend_result["output_count"],
+            "file_size": backend_result["file_size"],
+            "blender_version": backend_result["blender_version"],
+            "method": backend_result["method"],
+            "returncode": backend_result["returncode"],
+        })
+    else:
+        result["executed"] = False
 
     return result
 

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -186,7 +186,7 @@ def render_scene(
     animation: bool = False,
     overwrite: bool = False,
     execute: bool = False,
-    timeout: int = 300,
+    timeout: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Prepare a render script, and optionally execute it with Blender.
 
@@ -197,7 +197,7 @@ def render_scene(
         animation: If True, render the full animation range
         overwrite: Allow overwriting existing files
         execute: If True, run Blender headless after generating the script
-        timeout: Maximum seconds to wait when execute=True
+        timeout: Maximum seconds to wait when execute=True, or None for no limit
 
     Returns:
         Dict with render info, script path, and optional backend output metadata

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -5,6 +5,8 @@ for actual Blender rendering.
 """
 
 import os
+import tempfile
+from contextlib import suppress
 from typing import Dict, Any, Optional, List
 
 from cli_anything.blender.utils import blender_backend, bpy_gen
@@ -259,14 +261,26 @@ def render_scene(
     script_dir = os.path.dirname(os.path.abspath(output_path))
     os.makedirs(script_dir, exist_ok=True)
 
-    script_path = os.path.join(script_dir, "_render_script.py")
     # Ensure output_path is absolute before passing it to the script generator
     # as Blender's background process may have a different CWD.
     abs_output_path = os.path.abspath(output_path)
     script_content = generate_bpy_script(project, abs_output_path, frame=frame, animation=animation)
 
-    with open(script_path, "w") as f:
-        f.write(script_content)
+    if execute:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".py",
+            prefix="_render_script_",
+            dir=script_dir,
+            delete=False,
+            encoding="utf-8",
+        ) as script_file:
+            script_file.write(script_content)
+            script_path = script_file.name
+    else:
+        script_path = os.path.join(script_dir, "_render_script.py")
+        with open(script_path, "w", encoding="utf-8") as script_file:
+            script_file.write(script_content)
 
     result = {
         "script_path": os.path.abspath(script_path),
@@ -276,7 +290,7 @@ def render_scene(
         "samples": render_settings.get("samples", 128),
         "format": render_settings.get("output_format", "PNG"),
         "animation": animation,
-        "command": f"blender --background --python {os.path.abspath(script_path)}",
+        "command": f"blender --background --python-exit-code 1 --python {os.path.abspath(script_path)}",
     }
 
     if animation:
@@ -285,13 +299,17 @@ def render_scene(
         result["frame"] = frame or scene_settings.get("frame_current", 1)
 
     if execute:
-        backend_result = blender_backend.render_script(
-            result["script_path"],
-            output_path=result["output_path"],
-            animation=animation,
-            expected_outputs=expected_outputs,
-            timeout=timeout,
-        )
+        try:
+            backend_result = blender_backend.render_script(
+                result["script_path"],
+                output_path=result["output_path"],
+                animation=animation,
+                expected_outputs=expected_outputs,
+                timeout=timeout,
+            )
+        finally:
+            with suppress(FileNotFoundError):
+                os.unlink(script_path)
         if backend_result["returncode"] != 0:
             raise RuntimeError(
                 f"Blender render failed (exit {backend_result['returncode']}):\n"

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -61,6 +61,20 @@ VALID_ENGINES = ["CYCLES", "EEVEE", "WORKBENCH"]
 VALID_OUTPUT_FORMATS = ["PNG", "JPEG", "BMP", "TIFF", "OPEN_EXR", "HDR", "FFMPEG"]
 
 
+def _expected_animation_outputs(
+    project: Dict[str, Any], output_path: str
+) -> Optional[List[str]]:
+    """Return the explicit movie artifact path Blender uses for FFMPEG."""
+    if project.get("render", {}).get("output_format") != "FFMPEG":
+        return None
+
+    scene = project.get("scene", {})
+    base, ext = os.path.splitext(os.path.abspath(output_path))
+    start = scene.get("frame_start", 1)
+    end = scene.get("frame_end", 250)
+    return [f"{base}{start:04d}-{end:04d}{ext}"]
+
+
 def set_render_settings(
     project: Dict[str, Any],
     engine: Optional[str] = None,
@@ -202,9 +216,13 @@ def render_scene(
     Returns:
         Dict with render info, script path, and optional backend output metadata
     """
+    expected_outputs = _expected_animation_outputs(project, output_path) if animation else None
+
     if not overwrite:
         existing = (
-            blender_backend.find_render_outputs(output_path, animation=True)
+            [path for path in expected_outputs if os.path.isfile(path)]
+            if expected_outputs is not None
+            else blender_backend.find_render_outputs(output_path, animation=True)
             if animation
             else ([output_path] if os.path.exists(output_path) else [])
         )
@@ -248,6 +266,7 @@ def render_scene(
             result["script_path"],
             output_path=result["output_path"],
             animation=animation,
+            expected_outputs=expected_outputs,
             timeout=timeout,
         )
         if backend_result["returncode"] != 0:

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -7,7 +7,7 @@ for actual Blender rendering.
 import os
 from typing import Dict, Any, Optional, List
 
-from cli_anything.blender.utils import blender_backend
+from cli_anything.blender.utils import blender_backend, bpy_gen
 
 
 # Render presets
@@ -69,8 +69,6 @@ def _expected_render_outputs(
     Returns [] when the naming model cannot predict the artifact (unknown
     image format); the caller then falls back to directory scanning.
     """
-    from cli_anything.blender.utils import bpy_gen
-
     render = project.get("render", {})
     fmt = render.get("output_format", "PNG")
     scene = project.get("scene", {})

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -87,11 +87,10 @@ def _expected_render_outputs(
         return [still] if still else []
 
     start = scene.get("frame_start", 1)
-    step = scene.get("frame_step", 1)
     end = scene.get("frame_end", 250)
     frames = [
         bpy_gen.blender_frame_path(abs_path, fmt, frame)
-        for frame in range(start, end + 1, max(step, 1))
+        for frame in range(start, end + 1)
     ]
     return [path for path in frames if path]
 

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -61,21 +61,41 @@ VALID_ENGINES = ["CYCLES", "EEVEE", "WORKBENCH"]
 VALID_OUTPUT_FORMATS = ["PNG", "JPEG", "BMP", "TIFF", "OPEN_EXR", "HDR", "FFMPEG"]
 
 
-def _expected_animation_outputs(
-    project: Dict[str, Any], output_path: str
-) -> Optional[List[str]]:
-    """Return the explicit movie artifact path Blender uses for FFMPEG."""
-    if project.get("render", {}).get("output_format") != "FFMPEG":
-        return None
+def _expected_render_outputs(
+    project: Dict[str, Any], output_path: str, animation: bool
+) -> List[str]:
+    """Exact artifact paths Blender writes for this render request.
 
-    from cli_anything.blender.utils.bpy_gen import ffmpeg_movie_extension
+    Returns [] when the naming model cannot predict the artifact (unknown
+    image format); the caller then falls back to directory scanning.
+    """
+    from cli_anything.blender.utils import bpy_gen
 
+    render = project.get("render", {})
+    fmt = render.get("output_format", "PNG")
     scene = project.get("scene", {})
-    base, _ = os.path.splitext(os.path.abspath(output_path))
+    abs_path = os.path.abspath(output_path)
+
+    if fmt == "FFMPEG":
+        movie = bpy_gen.blender_movie_path(
+            abs_path,
+            scene.get("frame_start", 1),
+            scene.get("frame_end", 250),
+        )
+        return [movie] if animation else []
+
+    if not animation:
+        still = bpy_gen.blender_still_path(abs_path, fmt)
+        return [still] if still else []
+
     start = scene.get("frame_start", 1)
+    step = scene.get("frame_step", 1)
     end = scene.get("frame_end", 250)
-    ext = ffmpeg_movie_extension(output_path)
-    return [f"{base}{start:04d}-{end:04d}{ext}"]
+    frames = [
+        bpy_gen.blender_frame_path(abs_path, fmt, frame)
+        for frame in range(start, end + 1, max(step, 1))
+    ]
+    return [path for path in frames if path]
 
 
 def set_render_settings(
@@ -219,12 +239,15 @@ def render_scene(
     Returns:
         Dict with render info, script path, and optional backend output metadata
     """
-    expected_outputs = _expected_animation_outputs(project, output_path) if animation else None
+    expected_outputs = (
+        _expected_render_outputs(project, output_path, animation)
+        if execute else None
+    )
 
     if not overwrite:
         existing = (
-            [path for path in expected_outputs if os.path.isfile(path)]
-            if expected_outputs is not None
+            [path for path in (expected_outputs or []) if os.path.isfile(path)]
+            if expected_outputs is not None and expected_outputs
             else blender_backend.find_render_outputs(output_path, animation=True)
             if animation
             else ([output_path] if os.path.exists(output_path) else [])

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -68,10 +68,13 @@ def _expected_animation_outputs(
     if project.get("render", {}).get("output_format") != "FFMPEG":
         return None
 
+    from cli_anything.blender.utils.bpy_gen import ffmpeg_movie_extension
+
     scene = project.get("scene", {})
-    base, ext = os.path.splitext(os.path.abspath(output_path))
+    base, _ = os.path.splitext(os.path.abspath(output_path))
     start = scene.get("frame_start", 1)
     end = scene.get("frame_end", 250)
+    ext = ffmpeg_movie_extension(output_path)
     return [f"{base}{start:04d}-{end:04d}{ext}"]
 
 

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -202,8 +202,14 @@ def render_scene(
     Returns:
         Dict with render info, script path, and optional backend output metadata
     """
-    if os.path.exists(output_path) and not overwrite and not animation:
-        raise FileExistsError(f"Output file exists: {output_path}. Use --overwrite.")
+    if not overwrite:
+        existing = (
+            blender_backend.find_render_outputs(output_path, animation=True)
+            if animation
+            else ([output_path] if os.path.exists(output_path) else [])
+        )
+        if existing:
+            raise FileExistsError(f"Output file exists: {existing[0]}. Use --overwrite.")
 
     render_settings = project.get("render", {})
     scene_settings = project.get("scene", {})

--- a/blender/agent-harness/cli_anything/blender/skills/SKILL.md
+++ b/blender/agent-harness/cli_anything/blender/skills/SKILL.md
@@ -154,7 +154,7 @@ Render settings and output commands.
 | `settings` | Configure render settings |
 | `info` | Show current render settings |
 | `presets` | List available render presets |
-| `execute` | Render the scene (generates bpy script) |
+| `execute` | Render the scene with Blender headless |
 | `script` | Generate bpy script without rendering |
 
 ### Preview
@@ -296,4 +296,4 @@ When using this CLI programmatically:
 
 ## Version
 
-1.0.0
+1.0.1

--- a/blender/agent-harness/cli_anything/blender/tests/test_bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_bpy_gen.py
@@ -4,6 +4,7 @@ Tests verify that generated scripts are syntactically valid Python,
 especially with Windows-style paths that could trigger escape errors.
 """
 
+import ast
 from typing import Any, Dict
 
 import pytest
@@ -82,6 +83,31 @@ class TestGeneratedScriptSyntax:
         project = _minimal_project()
         script = generate_full_script(project, "C:\\Users\\o'brien\\output.png")
         compile(script, "<test>", "exec")
+
+    def test_entity_names_with_quotes_are_serialized(self) -> None:
+        """Names carrying quotes/backslashes must stay data, not become code."""
+        project = _minimal_project()
+        hostile = "Bob's Cube\nraise RuntimeError('owned')"
+        project["objects"] = [{
+            "id": 1, "name": hostile, "mesh_type": "cube",
+            "material": 9, "visible": True, "parent": 2,
+            "modifiers": [{
+                "name": "Mod'\\name", "type": "boolean", "bpy_type": "BOOLEAN",
+                "params": {"operand_object": "Other'\\object"},
+            }],
+            "keyframes": [{"frame": 1, "property": "location", "value": [0, 0, 0]}],
+        }, {
+            "id": 2, "name": "Parent'\\name", "mesh_type": "empty",
+            "visible": True, "keyframes": [],
+        }]
+        project["materials"] = [{"id": 9, "name": "Mat'\""}]
+        project["cameras"] = [{"name": "Cam <>&\"'", "is_active": True}]
+        project["lights"] = [{"name": "Lamp\\x'", "type": "POINT"}]
+        script = generate_full_script(project, "/tmp/render.png")
+        tree = ast.parse(script, "<test>", "exec")
+        name_line = next(line for line in script.splitlines() if line.startswith("obj.name"))
+        assert name_line == f"obj.name = {hostile!r}"
+        assert not any(isinstance(node, ast.Raise) for node in ast.walk(tree))
 
     def test_hdri_path_with_windows_slashes(self) -> None:
         """HDRI paths on Windows must not cause SyntaxError."""

--- a/blender/agent-harness/cli_anything/blender/tests/test_bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_bpy_gen.py
@@ -135,6 +135,13 @@ class TestFFMPEGContainerPin:
         script = generate_full_script(project, "/tmp/render.mkv")
         assert "scene.render.ffmpeg.format = 'MKV'" in script
 
+    def test_webm_output_pins_webm_container_and_codec(self) -> None:
+        project = _minimal_project()
+        project["render"]["output_format"] = "FFMPEG"
+        script = generate_full_script(project, "/tmp/render.webm")
+        assert "scene.render.ffmpeg.format = 'WEBM'" in script
+        assert "scene.render.ffmpeg.codec = 'WEBM'" in script
+
     def test_non_ffmpeg_output_has_no_container_line(self) -> None:
         project = _minimal_project()
         script = generate_full_script(project, "/tmp/render.png")

--- a/blender/agent-harness/cli_anything/blender/tests/test_bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_bpy_gen.py
@@ -118,3 +118,24 @@ def _excerpt(err: SyntaxError, script: str) -> str:
         marker = " >>> " if i == lineno else "     "
         result += f"{marker}{i}: {line}\n"
     return result
+
+
+class TestFFMPEGContainerPin:
+    """Generated FFMPEG renders pin the container to the requested extension."""
+
+    def test_mp4_output_pins_mpeg4_container(self) -> None:
+        project = _minimal_project()
+        project["render"]["output_format"] = "FFMPEG"
+        script = generate_full_script(project, "/tmp/render.mp4")
+        assert "scene.render.ffmpeg.format = 'MPEG4'" in script
+
+    def test_mkv_output_pins_matroska_container(self) -> None:
+        project = _minimal_project()
+        project["render"]["output_format"] = "FFMPEG"
+        script = generate_full_script(project, "/tmp/render.mkv")
+        assert "scene.render.ffmpeg.format = 'MATROSKA'" in script
+
+    def test_non_ffmpeg_output_has_no_container_line(self) -> None:
+        project = _minimal_project()
+        script = generate_full_script(project, "/tmp/render.png")
+        assert "scene.render.ffmpeg.format" not in script

--- a/blender/agent-harness/cli_anything/blender/tests/test_bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_bpy_gen.py
@@ -133,7 +133,7 @@ class TestFFMPEGContainerPin:
         project = _minimal_project()
         project["render"]["output_format"] = "FFMPEG"
         script = generate_full_script(project, "/tmp/render.mkv")
-        assert "scene.render.ffmpeg.format = 'MATROSKA'" in script
+        assert "scene.render.ffmpeg.format = 'MKV'" in script
 
     def test_non_ffmpeg_output_has_no_container_line(self) -> None:
         project = _minimal_project()

--- a/blender/agent-harness/cli_anything/blender/tests/test_bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_bpy_gen.py
@@ -141,8 +141,3 @@ class TestFFMPEGContainerPin:
         script = generate_full_script(project, "/tmp/render.webm")
         assert "scene.render.ffmpeg.format = 'WEBM'" in script
         assert "scene.render.ffmpeg.codec = 'WEBM'" in script
-
-    def test_non_ffmpeg_output_has_no_container_line(self) -> None:
-        project = _minimal_project()
-        script = generate_full_script(project, "/tmp/render.png")
-        assert "scene.render.ffmpeg.format" not in script

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -1183,13 +1183,13 @@ class TestRender:
             f"{tmp_path}/frame_0002.png",
         ]
 
-    def test_expected_frame_outputs_append_digits_after_extension(self, tmp_path):
+    def test_expected_frame_outputs_keep_explicit_extension(self, tmp_path):
         proj = self._make_scene()
         proj["scene"]["frame_start"] = 1
         proj["scene"]["frame_end"] = 1
         output = tmp_path / "render.png"
         assert _expected_render_outputs(proj, str(output), animation=True) == [
-            f"{tmp_path}/render.png0001.png"
+            f"{tmp_path}/render.png"
         ]
 
     def test_expected_still_output_follows_configured_format(self, tmp_path):

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -5,6 +5,7 @@ Tests use synthetic data only — no real 3D files or Blender installation.
 
 import json
 import os
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -896,8 +897,9 @@ class TestRender:
         add_object(proj, name="Cube")
         calls = {"count": 0}
 
-        def fake_render_script(script_path, output_path=None, animation=False, timeout=300):
+        def fake_render_script(script_path, output_path=None, animation=False, timeout=None):
             calls["count"] += 1
+            calls["timeout"] = timeout
             assert os.path.exists(script_path)
             Path(output_path).write_bytes(b"\x89PNG\r\n\x1a\n")
             return {
@@ -920,14 +922,18 @@ class TestRender:
             output_path = os.path.join(tmp, "render.png")
             result = render_scene(proj, output_path, overwrite=True, execute=True)
             assert calls["count"] == 1
+            assert calls["timeout"] is None
             assert result["executed"] is True
             assert result["method"] == "blender-headless"
             assert result["file_size"] == 8
 
+            render_scene(proj, output_path, overwrite=True, execute=True, timeout=60)
+            assert calls["timeout"] == 60
+
     def test_render_scene_execution_failure(self, monkeypatch):
         proj = self._make_scene()
 
-        def fake_render_script(script_path, output_path=None, animation=False, timeout=300):
+        def fake_render_script(script_path, output_path=None, animation=False, timeout=None):
             return {
                 "command": "blender --background --python script.py",
                 "returncode": 1,
@@ -968,6 +974,43 @@ class TestRender:
         framed = tmp_path / "render0001.png"
         framed.write_bytes(b"png")
         assert blender_backend.find_render_outputs(str(output_path)) == [str(framed)]
+
+    def test_find_render_outputs_animation_sequence(self, tmp_path):
+        output_path = tmp_path / "render.png"
+        frame1 = tmp_path / "render0001.png"
+        frame2 = tmp_path / "render0002.png"
+        frame1.write_bytes(b"a")
+        frame2.write_bytes(b"b")
+        assert blender_backend.find_render_outputs(str(output_path), animation=True) == [
+            str(frame1),
+            str(frame2),
+        ]
+
+    def test_render_script_rejects_stale_overwrite(self, monkeypatch, tmp_path):
+        script = tmp_path / "_render_script.py"
+        script.write_text("print('ok')")
+        output_path = tmp_path / "out.png"
+        output_path.write_bytes(b"old")
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=None):
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+        monkeypatch.setattr(blender_backend, "find_blender", lambda: "blender")
+        monkeypatch.setattr(blender_backend.subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError, match="produced no output"):
+            blender_backend.render_script(str(script), output_path=str(output_path))
+
+    def test_render_script_timeout_is_loud(self, monkeypatch, tmp_path):
+        script = tmp_path / "_render_script.py"
+        script.write_text("print('ok')")
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=None):
+            raise subprocess.TimeoutExpired(cmd, timeout)
+
+        monkeypatch.setattr(blender_backend, "find_blender", lambda: "blender")
+        monkeypatch.setattr(blender_backend.subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError, match="timed out after 1 seconds"):
+            blender_backend.render_script(str(script), timeout=1)
 
     def test_render_scene_overwrite_protection(self):
         proj = self._make_scene()

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -897,7 +897,9 @@ class TestRender:
         add_object(proj, name="Cube")
         calls = {"count": 0}
 
-        def fake_render_script(script_path, output_path=None, animation=False, timeout=None):
+        def fake_render_script(
+            script_path, output_path=None, animation=False, expected_outputs=None, timeout=None
+        ):
             calls["count"] += 1
             calls["timeout"] = timeout
             assert os.path.exists(script_path)
@@ -930,10 +932,46 @@ class TestRender:
             render_scene(proj, output_path, overwrite=True, execute=True, timeout=60)
             assert calls["timeout"] == 60
 
+    def test_render_scene_uses_exact_ffmpeg_animation_output(self, monkeypatch, tmp_path):
+        proj = self._make_scene()
+        set_render_settings(proj, output_format="FFMPEG")
+        proj["scene"]["frame_start"] = 1
+        proj["scene"]["frame_end"] = 250
+        expected = tmp_path / "render0001-0250.mp4"
+        seen = {}
+
+        def fake_render_script(
+            script_path, output_path=None, animation=False, expected_outputs=None, timeout=None
+        ):
+            seen["expected_outputs"] = expected_outputs
+            return {
+                "returncode": 0,
+                "output": str(expected),
+                "outputs": [str(expected)],
+                "output_count": 1,
+                "file_size": 1,
+                "blender_version": "Blender 5.2",
+                "method": "blender-headless",
+            }
+
+        monkeypatch.setattr(blender_backend, "render_script", fake_render_script)
+        result = render_scene(proj, str(tmp_path / "render.mp4"), animation=True, execute=True)
+        assert seen["expected_outputs"] == [str(expected)]
+        assert result["output"] == str(expected)
+
+    def test_render_scene_ffmpeg_animation_requires_overwrite(self, tmp_path):
+        proj = self._make_scene()
+        set_render_settings(proj, output_format="FFMPEG")
+        (tmp_path / "render0001-0250.mp4").write_bytes(b"old")
+        with pytest.raises(FileExistsError, match="--overwrite"):
+            render_scene(proj, str(tmp_path / "render.mp4"), animation=True)
+
     def test_render_scene_execution_failure(self, monkeypatch):
         proj = self._make_scene()
 
-        def fake_render_script(script_path, output_path=None, animation=False, timeout=None):
+        def fake_render_script(
+            script_path, output_path=None, animation=False, expected_outputs=None, timeout=None
+        ):
             return {
                 "command": "blender --background --python script.py",
                 "returncode": 1,
@@ -1056,6 +1094,25 @@ class TestRender:
         monkeypatch.setattr(blender_backend.subprocess, "run", fail_run)
         with pytest.raises(ValueError, match="not a file"):
             blender_backend.render_script(str(script), output_path=str(out_dir))
+
+    def test_render_script_collects_explicit_ffmpeg_output(self, monkeypatch, tmp_path):
+        script = tmp_path / "_render_script.py"
+        script.write_text("print('ok')")
+        output_path = tmp_path / "render.mp4"
+        expected = tmp_path / "render0001-0250.mp4"
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=None):
+            expected.write_bytes(b"movie")
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+        monkeypatch.setattr(blender_backend, "find_blender", lambda: "blender")
+        monkeypatch.setattr(blender_backend, "get_version", lambda: "Blender 5.2")
+        monkeypatch.setattr(blender_backend.subprocess, "run", fake_run)
+        result = blender_backend.render_script(
+            str(script), output_path=str(output_path), animation=True,
+            expected_outputs=[str(expected)],
+        )
+        assert result["outputs"] == [str(expected)]
 
     def test_render_scene_overwrite_protection(self):
         proj = self._make_scene()

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -1026,6 +1026,37 @@ class TestRender:
         blender_backend.render_script(str(script), 120)
         assert seen["timeout"] == 120
 
+    def test_find_render_outputs_matches_only_blender_frame_names(self, tmp_path):
+        output_path = tmp_path / "render.png"
+        preview = tmp_path / "render-preview.png"
+        preview.write_bytes(b"preview")
+        backup = tmp_path / "render-backup.png"
+        backup.write_bytes(b"backup")
+
+        assert blender_backend.find_render_outputs(str(output_path)) == []
+        assert blender_backend.find_render_outputs(str(output_path), animation=True) == []
+
+        frame1 = tmp_path / "render0001.png"
+        frame1.write_bytes(b"frame")
+        assert blender_backend.find_render_outputs(str(output_path)) == [str(frame1)]
+        assert blender_backend.find_render_outputs(
+            str(output_path), animation=True
+        ) == [str(frame1)]
+
+    def test_render_script_rejects_directory_output(self, monkeypatch, tmp_path):
+        script = tmp_path / "_render_script.py"
+        script.write_text("print('ok')")
+        out_dir = tmp_path / "out.png"
+        out_dir.mkdir()
+
+        def fail_run(cmd, capture_output=True, text=True, timeout=None):
+            raise AssertionError("blender should not run for a directory output path")
+
+        monkeypatch.setattr(blender_backend, "find_blender", lambda: "blender")
+        monkeypatch.setattr(blender_backend.subprocess, "run", fail_run)
+        with pytest.raises(ValueError, match="not a file"):
+            blender_backend.render_script(str(script), output_path=str(out_dir))
+
     def test_render_scene_overwrite_protection(self):
         proj = self._make_scene()
         with tempfile.TemporaryDirectory() as tmp:

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -1066,6 +1066,8 @@ class TestRender:
 
     def test_find_render_outputs_matches_only_blender_frame_names(self, tmp_path):
         output_path = tmp_path / "render.png"
+        wrong_extension = tmp_path / "render.txt"
+        wrong_extension.write_bytes(b"not a render")
         preview = tmp_path / "render-preview.png"
         preview.write_bytes(b"preview")
         backup = tmp_path / "render-backup.png"
@@ -1123,6 +1125,25 @@ class TestRender:
         )
         assert result["outputs"] == [str(expected)]
 
+    def test_render_script_scans_when_expected_outputs_are_unknown(
+        self, monkeypatch, tmp_path
+    ):
+        script = tmp_path / "_render_script.py"
+        script.write_text("print('ok')")
+        output_path = tmp_path / "render.png"
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=None):
+            output_path.write_bytes(b"image")
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+        monkeypatch.setattr(blender_backend, "find_blender", lambda: "blender")
+        monkeypatch.setattr(blender_backend, "get_version", lambda: "Blender 5.2")
+        monkeypatch.setattr(blender_backend.subprocess, "run", fake_run)
+        result = blender_backend.render_script(
+            str(script), output_path=str(output_path), expected_outputs=[]
+        )
+        assert result["outputs"] == [str(output_path)]
+
     def test_render_scene_overwrite_protection(self):
         proj = self._make_scene()
         with tempfile.TemporaryDirectory() as tmp:
@@ -1164,13 +1185,13 @@ class TestRender:
         proj["scene"]["frame_end"] = 250
         output = tmp_path / "render.m4v"
         assert _expected_render_outputs(proj, str(output), animation=True) == [
-            f"{tmp_path}/render.m4v0001-0250.mp4"
+            str(tmp_path / "render.m4v0001-0250.mp4")
         ]
 
     def test_expected_still_output_keeps_known_extension(self, tmp_path):
         proj = self._make_scene()
         assert _expected_render_outputs(proj, str(tmp_path / "render.png"), animation=False) == [
-            f"{tmp_path}/render.png"
+            str(tmp_path / "render.png")
         ]
 
     def test_expected_frame_outputs_expand_placeholders(self, tmp_path):
@@ -1179,8 +1200,8 @@ class TestRender:
         proj["scene"]["frame_end"] = 2
         output = tmp_path / "frame_####.png"
         assert _expected_render_outputs(proj, str(output), animation=True) == [
-            f"{tmp_path}/frame_0001.png",
-            f"{tmp_path}/frame_0002.png",
+            str(tmp_path / "frame_0001.png"),
+            str(tmp_path / "frame_0002.png"),
         ]
 
     def test_expected_frame_outputs_append_digits_after_explicit_extension(self, tmp_path):
@@ -1189,7 +1210,7 @@ class TestRender:
         proj["scene"]["frame_end"] = 1
         output = tmp_path / "render.png"
         assert _expected_render_outputs(proj, str(output), animation=True) == [
-            f"{tmp_path}/render.png0001.png"
+            str(tmp_path / "render.png0001.png")
         ]
 
     def test_expected_still_output_follows_configured_format(self, tmp_path):
@@ -1197,7 +1218,7 @@ class TestRender:
         proj["render"]["output_format"] = "JPEG"
         output = tmp_path / "render.png"
         assert _expected_render_outputs(proj, str(output), animation=False) == [
-            f"{tmp_path}/render.jpg"
+            str(tmp_path / "render.jpg")
         ]
 
     def test_all_engines_valid(self):

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -902,6 +902,7 @@ class TestRender:
         ):
             calls["count"] += 1
             calls["timeout"] = timeout
+            calls.setdefault("script_paths", []).append(script_path)
             assert os.path.exists(script_path)
             Path(output_path).write_bytes(b"\x89PNG\r\n\x1a\n")
             return {
@@ -928,9 +929,13 @@ class TestRender:
             assert result["executed"] is True
             assert result["method"] == "blender-headless"
             assert result["file_size"] == 8
+            assert "--python-exit-code 1" in result["command"]
+            assert not os.path.exists(result["script_path"])
 
             render_scene(proj, output_path, overwrite=True, execute=True, timeout=60)
             assert calls["timeout"] == 60
+            assert calls["script_paths"][0] != calls["script_paths"][1]
+            assert not os.path.exists(calls["script_paths"][1])
 
     def test_render_scene_uses_exact_ffmpeg_animation_output(self, monkeypatch, tmp_path):
         proj = self._make_scene()

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -889,6 +889,85 @@ class TestRender:
             assert os.path.exists(result["script_path"])
             assert "blender" in result["command"]
             assert result["engine"] == "CYCLES"
+            assert result["executed"] is False
+
+    def test_render_scene_executes_blender(self, monkeypatch):
+        proj = self._make_scene()
+        add_object(proj, name="Cube")
+        calls = {"count": 0}
+
+        def fake_render_script(script_path, output_path=None, animation=False, timeout=300):
+            calls["count"] += 1
+            assert os.path.exists(script_path)
+            Path(output_path).write_bytes(b"\x89PNG\r\n\x1a\n")
+            return {
+                "command": "blender --background --python script.py",
+                "returncode": 0,
+                "stdout": "ok",
+                "stderr": "",
+                "output": output_path,
+                "outputs": [output_path],
+                "output_count": 1,
+                "format": "png",
+                "method": "blender-headless",
+                "blender_version": "Blender 5.2",
+                "file_size": 8,
+            }
+
+        monkeypatch.setattr(blender_backend, "render_script", fake_render_script)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = os.path.join(tmp, "render.png")
+            result = render_scene(proj, output_path, overwrite=True, execute=True)
+            assert calls["count"] == 1
+            assert result["executed"] is True
+            assert result["method"] == "blender-headless"
+            assert result["file_size"] == 8
+
+    def test_render_scene_execution_failure(self, monkeypatch):
+        proj = self._make_scene()
+
+        def fake_render_script(script_path, output_path=None, animation=False, timeout=300):
+            return {
+                "command": "blender --background --python script.py",
+                "returncode": 1,
+                "stdout": "",
+                "stderr": "render failed",
+            }
+
+        monkeypatch.setattr(blender_backend, "render_script", fake_render_script)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = os.path.join(tmp, "render.png")
+            with pytest.raises(RuntimeError, match="Blender render failed"):
+                render_scene(proj, output_path, overwrite=True, execute=True)
+
+    def test_render_scene_execute_missing_blender(self, monkeypatch):
+        proj = self._make_scene()
+        monkeypatch.delenv("BLENDER_EXECUTABLE", raising=False)
+        monkeypatch.setattr(blender_backend.shutil, "which", lambda name: None)
+        monkeypatch.setattr(blender_backend.platform, "system", lambda: "Darwin")
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = os.path.join(tmp, "render.png")
+            with pytest.raises(RuntimeError, match="Blender is not installed"):
+                render_scene(proj, output_path, overwrite=True, execute=True)
+
+    def test_find_blender_windows_default_install(self, monkeypatch, tmp_path):
+        fake = tmp_path / "Blender Foundation" / "Blender 5.2" / "blender.exe"
+        fake.parent.mkdir(parents=True)
+        fake.write_bytes(b"")
+        monkeypatch.delenv("BLENDER_EXECUTABLE", raising=False)
+        monkeypatch.setenv("ProgramFiles", str(tmp_path))
+        monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "x86"))
+        monkeypatch.setattr(blender_backend.shutil, "which", lambda name: None)
+        monkeypatch.setattr(blender_backend.platform, "system", lambda: "Windows")
+        assert blender_backend.find_blender() == str(fake)
+
+    def test_find_render_outputs_frame_suffix(self, tmp_path):
+        output_path = tmp_path / "render.png"
+        framed = tmp_path / "render0001.png"
+        framed.write_bytes(b"png")
+        assert blender_backend.find_render_outputs(str(output_path)) == [str(framed)]
 
     def test_render_scene_overwrite_protection(self):
         proj = self._make_scene()

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -1012,6 +1012,20 @@ class TestRender:
         with pytest.raises(RuntimeError, match="timed out after 1 seconds"):
             blender_backend.render_script(str(script), timeout=1)
 
+    def test_render_script_positional_timeout(self, monkeypatch, tmp_path):
+        script = tmp_path / "_render_script.py"
+        script.write_text("print('ok')")
+        seen = {}
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=None):
+            seen["timeout"] = timeout
+            return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+        monkeypatch.setattr(blender_backend, "find_blender", lambda: "blender")
+        monkeypatch.setattr(blender_backend.subprocess, "run", fake_run)
+        blender_backend.render_script(str(script), 120)
+        assert seen["timeout"] == 120
+
     def test_render_scene_overwrite_protection(self):
         proj = self._make_scene()
         with tempfile.TemporaryDirectory() as tmp:
@@ -1021,6 +1035,21 @@ class TestRender:
                 f.write("existing")
             with pytest.raises(FileExistsError):
                 render_scene(proj, output_path, overwrite=False)
+
+    def test_render_scene_animation_requires_overwrite(self, tmp_path):
+        proj = self._make_scene()
+        output_path = tmp_path / "render.png"
+        (tmp_path / "render0001.png").write_bytes(b"old")
+        with pytest.raises(FileExistsError, match="--overwrite"):
+            render_scene(proj, str(output_path), animation=True, overwrite=False)
+        result = render_scene(proj, str(output_path), animation=True, overwrite=True)
+        assert result["animation"] is True
+        assert result["executed"] is False
+
+        fresh_dir = tmp_path / "fresh"
+        fresh_dir.mkdir()
+        fresh = render_scene(proj, str(fresh_dir / "render.png"), animation=True, overwrite=False)
+        assert fresh["executed"] is False
 
     def test_all_engines_valid(self):
         assert "CYCLES" in VALID_ENGINES

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -37,7 +37,7 @@ from cli_anything.blender.core.animation import (
 )
 from cli_anything.blender.core.render import (
     set_render_settings, get_render_settings, list_render_presets,
-    render_scene, RENDER_PRESETS, VALID_ENGINES, _expected_animation_outputs,
+    render_scene, RENDER_PRESETS, VALID_ENGINES, _expected_render_outputs,
 )
 from cli_anything.blender.core import preview as preview_mod
 from cli_anything.blender.utils import blender_backend
@@ -937,7 +937,7 @@ class TestRender:
         set_render_settings(proj, output_format="FFMPEG")
         proj["scene"]["frame_start"] = 1
         proj["scene"]["frame_end"] = 250
-        expected = tmp_path / "render0001-0250.mp4"
+        expected = tmp_path / "render.mp4"
         seen = {}
 
         def fake_render_script(
@@ -955,14 +955,14 @@ class TestRender:
             }
 
         monkeypatch.setattr(blender_backend, "render_script", fake_render_script)
-        result = render_scene(proj, str(tmp_path / "render.mp4"), animation=True, execute=True)
+        result = render_scene(proj, str(expected), animation=True, execute=True)
         assert seen["expected_outputs"] == [str(expected)]
         assert result["output"] == str(expected)
 
     def test_render_scene_ffmpeg_animation_requires_overwrite(self, tmp_path):
         proj = self._make_scene()
         set_render_settings(proj, output_format="FFMPEG")
-        (tmp_path / "render0001-0250.mp4").write_bytes(b"old")
+        (tmp_path / "render.mp4").write_bytes(b"old")
         with pytest.raises(FileExistsError, match="--overwrite"):
             render_scene(proj, str(tmp_path / "render.mp4"), animation=True)
 
@@ -1139,22 +1139,57 @@ class TestRender:
         fresh = render_scene(proj, str(fresh_dir / "render.png"), animation=True, overwrite=False)
         assert fresh["executed"] is False
 
-    def test_expected_animation_outputs_follow_container_extension(self, tmp_path):
+    def test_expected_movie_output_keeps_exact_path(self, tmp_path):
         proj = self._make_scene()
         proj["render"]["output_format"] = "FFMPEG"
         output = tmp_path / "render.mp4"
-        assert _expected_animation_outputs(proj, str(output)) == [
-            f"{tmp_path}/render0001-0250.mp4"
-        ]
+        assert _expected_render_outputs(proj, str(output), animation=True) == [str(output)]
 
         webm = tmp_path / "render.webm"
-        assert _expected_animation_outputs(proj, str(webm)) == [
-            f"{tmp_path}/render0001-0250.webm"
+        assert _expected_render_outputs(proj, str(webm), animation=True) == [str(webm)]
+
+    def test_expected_movie_output_adds_range_for_other_extensions(self, tmp_path):
+        proj = self._make_scene()
+        proj["render"]["output_format"] = "FFMPEG"
+        proj["scene"]["frame_start"] = 1
+        proj["scene"]["frame_end"] = 250
+        output = tmp_path / "render.m4v"
+        assert _expected_render_outputs(proj, str(output), animation=True) == [
+            f"{tmp_path}/render.m4v0001-0250.mp4"
         ]
 
-    def test_expected_animation_outputs_none_for_stills(self, tmp_path):
+    def test_expected_still_output_keeps_known_extension(self, tmp_path):
         proj = self._make_scene()
-        assert _expected_animation_outputs(proj, str(tmp_path / "render.png")) is None
+        assert _expected_render_outputs(proj, str(tmp_path / "render.png"), animation=False) == [
+            f"{tmp_path}/render.png"
+        ]
+
+    def test_expected_frame_outputs_expand_placeholders(self, tmp_path):
+        proj = self._make_scene()
+        proj["scene"]["frame_start"] = 1
+        proj["scene"]["frame_end"] = 2
+        output = tmp_path / "frame_####.png"
+        assert _expected_render_outputs(proj, str(output), animation=True) == [
+            f"{tmp_path}/frame_0001.png",
+            f"{tmp_path}/frame_0002.png",
+        ]
+
+    def test_expected_frame_outputs_append_digits_after_extension(self, tmp_path):
+        proj = self._make_scene()
+        proj["scene"]["frame_start"] = 1
+        proj["scene"]["frame_end"] = 1
+        output = tmp_path / "render.png"
+        assert _expected_render_outputs(proj, str(output), animation=True) == [
+            f"{tmp_path}/render.png0001.png"
+        ]
+
+    def test_expected_still_output_follows_configured_format(self, tmp_path):
+        proj = self._make_scene()
+        proj["render"]["output_format"] = "JPEG"
+        output = tmp_path / "render.png"
+        assert _expected_render_outputs(proj, str(output), animation=False) == [
+            f"{tmp_path}/render.jpg"
+        ]
 
     def test_all_engines_valid(self):
         assert "CYCLES" in VALID_ENGINES

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -1198,10 +1198,11 @@ class TestRender:
             str(tmp_path / "render.png")
         ]
 
-    def test_expected_frame_outputs_expand_placeholders(self, tmp_path):
+    def test_expected_frame_outputs_match_generated_scene_range(self, tmp_path):
         proj = self._make_scene()
         proj["scene"]["frame_start"] = 1
         proj["scene"]["frame_end"] = 2
+        proj["scene"]["frame_step"] = 2
         output = tmp_path / "frame_####.png"
         assert _expected_render_outputs(proj, str(output), animation=True) == [
             str(tmp_path / "frame_0001.png"),

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -1149,7 +1149,7 @@ class TestRender:
 
         webm = tmp_path / "render.webm"
         assert _expected_animation_outputs(proj, str(webm)) == [
-            f"{tmp_path}/render0001-0250.mp4"
+            f"{tmp_path}/render0001-0250.webm"
         ]
 
     def test_expected_animation_outputs_none_for_stills(self, tmp_path):

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -1050,6 +1050,31 @@ class TestRender:
         with pytest.raises(RuntimeError, match="timed out after 1 seconds"):
             blender_backend.render_script(str(script), timeout=1)
 
+    def test_render_script_forces_python_exception_exit_code(
+        self, monkeypatch, tmp_path
+    ):
+        script = tmp_path / "_render_script.py"
+        script.write_text("raise RuntimeError('broken render')")
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=None):
+            exit_code = (
+                int(cmd[cmd.index("--python-exit-code") + 1])
+                if "--python-exit-code" in cmd
+                else 0
+            )
+            return subprocess.CompletedProcess(
+                cmd, exit_code, stdout="", stderr="broken render"
+            )
+
+        monkeypatch.setattr(blender_backend, "find_blender", lambda: "blender")
+        monkeypatch.setattr(blender_backend.subprocess, "run", fake_run)
+
+        result = blender_backend.render_script(str(script))
+        assert result["returncode"] == 1
+        assert result["command"].startswith(
+            "blender --background --python-exit-code 1 --python "
+        )
+
     def test_render_script_positional_timeout(self, monkeypatch, tmp_path):
         script = tmp_path / "_render_script.py"
         script.write_text("print('ok')")

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -1081,6 +1081,15 @@ class TestRender:
             str(output_path), animation=True
         ) == [str(frame1)]
 
+    def test_find_render_outputs_expands_frame_placeholders(self, tmp_path):
+        output_path = tmp_path / "frame_####.png"
+        frame1 = tmp_path / "frame_0001.png"
+        frame1.write_bytes(b"frame")
+
+        assert blender_backend.find_render_outputs(
+            str(output_path), animation=True
+        ) == [str(frame1)]
+
     def test_render_script_rejects_directory_output(self, monkeypatch, tmp_path):
         script = tmp_path / "_render_script.py"
         script.write_text("print('ok')")

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -1068,6 +1068,8 @@ class TestRender:
         output_path = tmp_path / "render.png"
         wrong_extension = tmp_path / "render.txt"
         wrong_extension.write_bytes(b"not a render")
+        wrong_frame_extension = tmp_path / "render0001.txt"
+        wrong_frame_extension.write_bytes(b"not a render frame")
         preview = tmp_path / "render-preview.png"
         preview.write_bytes(b"preview")
         backup = tmp_path / "render-backup.png"
@@ -1085,6 +1087,8 @@ class TestRender:
 
     def test_find_render_outputs_expands_frame_placeholders(self, tmp_path):
         output_path = tmp_path / "frame_####.png"
+        wrong_extension = tmp_path / "frame_0001.txt"
+        wrong_extension.write_bytes(b"not a render frame")
         frame1 = tmp_path / "frame_0001.png"
         frame1.write_bytes(b"frame")
 

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -1183,13 +1183,13 @@ class TestRender:
             f"{tmp_path}/frame_0002.png",
         ]
 
-    def test_expected_frame_outputs_keep_explicit_extension(self, tmp_path):
+    def test_expected_frame_outputs_append_digits_after_explicit_extension(self, tmp_path):
         proj = self._make_scene()
         proj["scene"]["frame_start"] = 1
         proj["scene"]["frame_end"] = 1
         output = tmp_path / "render.png"
         assert _expected_render_outputs(proj, str(output), animation=True) == [
-            f"{tmp_path}/render.png"
+            f"{tmp_path}/render.png0001.png"
         ]
 
     def test_expected_still_output_follows_configured_format(self, tmp_path):

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -37,7 +37,7 @@ from cli_anything.blender.core.animation import (
 )
 from cli_anything.blender.core.render import (
     set_render_settings, get_render_settings, list_render_presets,
-    render_scene, RENDER_PRESETS, VALID_ENGINES,
+    render_scene, RENDER_PRESETS, VALID_ENGINES, _expected_animation_outputs,
 )
 from cli_anything.blender.core import preview as preview_mod
 from cli_anything.blender.utils import blender_backend
@@ -1138,6 +1138,23 @@ class TestRender:
         fresh_dir.mkdir()
         fresh = render_scene(proj, str(fresh_dir / "render.png"), animation=True, overwrite=False)
         assert fresh["executed"] is False
+
+    def test_expected_animation_outputs_follow_container_extension(self, tmp_path):
+        proj = self._make_scene()
+        proj["render"]["output_format"] = "FFMPEG"
+        output = tmp_path / "render.mp4"
+        assert _expected_animation_outputs(proj, str(output)) == [
+            f"{tmp_path}/render0001-0250.mp4"
+        ]
+
+        webm = tmp_path / "render.webm"
+        assert _expected_animation_outputs(proj, str(webm)) == [
+            f"{tmp_path}/render0001-0250.mp4"
+        ]
+
+    def test_expected_animation_outputs_none_for_stills(self, tmp_path):
+        proj = self._make_scene()
+        assert _expected_animation_outputs(proj, str(tmp_path / "render.png")) is None
 
     def test_all_engines_valid(self):
         assert "CYCLES" in VALID_ENGINES

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -7,10 +7,13 @@ Requires: blender (system package)
 import glob
 import os
 import platform
+import re
 import shutil
 import subprocess
 import tempfile
 from typing import Optional
+
+_FRAME_RUN = re.compile(r"#+")
 
 
 def _fingerprint(path: str) -> Optional[tuple[int, int]]:
@@ -71,11 +74,35 @@ def get_version() -> str:
     return result.stdout.strip().split("\n")[0]
 
 
-def _is_render_output(path: str, abs_output_path: str) -> bool:
+def _is_render_output(path: str, abs_output_path: str, animation: bool = False) -> bool:
     """Whether a path is a file Blender writes for this render target."""
     stem = os.path.splitext(path)[0]
-    base = os.path.splitext(abs_output_path)[0]
-    return stem == base or (stem.startswith(base) and stem[len(base):].isdigit())
+    base, ext = os.path.splitext(abs_output_path)
+    if stem == base:
+        return True
+    if "#" in base:
+        # A '#' run in the target expands to the zero-padded frame number,
+        # so frame_####.png produces frame_0001.png.
+        pattern = _frame_stem_pattern(base)
+        return pattern.fullmatch(stem) is not None
+    suffix = stem[len(base):] if stem.startswith(base) else ""
+    if suffix.isdigit():
+        return True
+    # Frame digits land after the whole name, extension included:
+    # an animation to render.png writes render.png0001.png.
+    return animation and bool(ext) and suffix.startswith(ext) and suffix[len(ext):].isdigit()
+
+
+def _frame_stem_pattern(base: str) -> "re.Pattern[str]":
+    runs = list(_FRAME_RUN.finditer(base))
+    if not runs:
+        return re.compile(re.escape(base))
+    last = runs[-1]
+    return re.compile(
+        re.escape(base[:last.start()])
+        + rf"\d{{{last.end() - last.start()},}}"
+        + re.escape(base[last.end():])
+    )
 
 
 def find_render_outputs(
@@ -85,15 +112,14 @@ def find_render_outputs(
 ) -> list[str]:
     """Resolve Blender's actual output file(s) for a requested render path."""
     abs_output_path = os.path.abspath(output_path)
-    base, ext = os.path.splitext(abs_output_path)
+    base, _ = os.path.splitext(abs_output_path)
     stale = prior or {}
 
     matches = sorted(
         path
-        for pattern in ([f"{base}*{ext}"] if ext else [f"{abs_output_path}*"])
-        for path in glob.glob(pattern)
+        for path in glob.glob(f"{glob.escape(base)}*")
         if os.path.isfile(path) and _is_fresh(path, stale)
-        and _is_render_output(path, abs_output_path)
+        and _is_render_output(path, abs_output_path, animation)
     )
     if animation:
         return matches

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -109,17 +109,18 @@ def find_render_outputs(
 
 def render_script(
     script_path: str,
+    timeout: Optional[int] = 300,
+    *,
     output_path: Optional[str] = None,
     animation: bool = False,
-    timeout: Optional[int] = 300,
 ) -> dict:
     """Run a bpy script using Blender headless.
 
     Args:
         script_path: Path to the Python script to execute
+        timeout: Maximum seconds to wait, or None to wait until Blender exits
         output_path: Expected render output path
         animation: Whether Blender is expected to render an animation sequence
-        timeout: Maximum seconds to wait, or None to wait until Blender exits
 
     Returns:
         Dict with stdout, stderr, return code, and optional output metadata

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -114,10 +114,11 @@ def find_render_outputs(
     abs_output_path = os.path.abspath(output_path)
     base, _ = os.path.splitext(abs_output_path)
     stale = prior or {}
+    glob_base = base if "#" not in base else base[:base.index("#")]
 
     matches = sorted(
         path
-        for path in glob.glob(f"{glob.escape(base)}*")
+        for path in glob.glob(f"{glob.escape(glob_base)}*")
         if os.path.isfile(path) and _is_fresh(path, stale)
         and _is_render_output(path, abs_output_path, animation)
     )

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -106,6 +106,7 @@ def render_script(
     *,
     output_path: Optional[str] = None,
     animation: bool = False,
+    expected_outputs: Optional[list[str]] = None,
 ) -> dict:
     """Run a bpy script using Blender headless.
 
@@ -114,6 +115,7 @@ def render_script(
         timeout: Maximum seconds to wait, or None to wait until Blender exits
         output_path: Expected render output path
         animation: Whether Blender is expected to render an animation sequence
+        expected_outputs: Exact artifact paths derived by the render caller
 
     Returns:
         Dict with stdout, stderr, return code, and optional output metadata
@@ -128,7 +130,8 @@ def render_script(
     prior = None
     if output_path:
         prior = {}
-        for path in find_render_outputs(output_path, animation=True):
+        candidates = expected_outputs or find_render_outputs(output_path, animation=True)
+        for path in candidates:
             fp = _fingerprint(path)
             if fp is not None:
                 prior[os.path.abspath(path)] = fp
@@ -155,7 +158,14 @@ def render_script(
         return render_result
 
     if output_path:
-        outputs = find_render_outputs(output_path, animation=animation, prior=prior)
+        outputs = (
+            [
+                path for path in expected_outputs
+                if os.path.isfile(path) and _is_fresh(path, prior or {})
+            ]
+            if expected_outputs is not None
+            else find_render_outputs(output_path, animation=animation, prior=prior)
+        )
         if not outputs:
             raise RuntimeError(
                 "Blender render produced no output file.\n"

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -4,23 +4,51 @@ Requires: blender (system package)
     apt install blender
 """
 
+import glob
 import os
+import platform
 import shutil
 import subprocess
 import tempfile
 from typing import Optional
 
 
+_FRAME_SUFFIXES = ("0001", "0000", "1")
+
+
+def _windows_install_candidates() -> list[str]:
+    """Common Blender install locations when PATH lookup misses."""
+    candidates: list[str] = []
+    for root in (
+        os.environ.get("ProgramFiles", r"C:\Program Files"),
+        os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"),
+    ):
+        pattern = os.path.join(root, "Blender Foundation", "Blender *", "blender.exe")
+        candidates.extend(sorted(glob.glob(pattern), reverse=True))
+    return candidates
+
+
 def find_blender() -> str:
     """Find the Blender executable. Raises RuntimeError if not found."""
-    for name in ("blender",):
+    env_path = os.environ.get("BLENDER_EXECUTABLE", "").strip()
+    if env_path and os.path.isfile(env_path):
+        return env_path
+
+    for name in ("blender", "blender.exe"):
         path = shutil.which(name)
         if path:
             return path
+
+    if platform.system().lower() == "windows":
+        for candidate in _windows_install_candidates():
+            if os.path.isfile(candidate):
+                return candidate
+
     raise RuntimeError(
         "Blender is not installed. Install it with:\n"
         "  apt install blender   # Debian/Ubuntu\n"
-        "  brew install --cask blender  # macOS"
+        "  brew install --cask blender  # macOS\n"
+        "  https://www.blender.org/download/  # Windows"
     )
 
 
@@ -34,18 +62,49 @@ def get_version() -> str:
     return result.stdout.strip().split("\n")[0]
 
 
+def find_render_outputs(output_path: str, animation: bool = False) -> list[str]:
+    """Resolve Blender's actual output file(s) for a requested render path."""
+    abs_output_path = os.path.abspath(output_path)
+    base, ext = os.path.splitext(abs_output_path)
+
+    direct_candidates = [abs_output_path]
+    if ext:
+        direct_candidates.extend(f"{base}{suffix}{ext}" for suffix in _FRAME_SUFFIXES)
+    else:
+        direct_candidates.extend(f"{abs_output_path}{suffix}" for suffix in _FRAME_SUFFIXES)
+
+    for candidate in direct_candidates:
+        if os.path.exists(candidate):
+            return [candidate]
+
+    patterns = [f"{base}*{ext}"] if ext else [f"{abs_output_path}*"]
+    matches = sorted(
+        path
+        for pattern in patterns
+        for path in glob.glob(pattern)
+        if os.path.isfile(path)
+    )
+    if animation:
+        return matches
+    return matches[:1]
+
+
 def render_script(
     script_path: str,
+    output_path: Optional[str] = None,
+    animation: bool = False,
     timeout: int = 300,
 ) -> dict:
     """Run a bpy script using Blender headless.
 
     Args:
         script_path: Path to the Python script to execute
+        output_path: Expected render output path
+        animation: Whether Blender is expected to render an animation sequence
         timeout: Maximum seconds to wait
 
     Returns:
-        Dict with stdout, stderr, return code
+        Dict with stdout, stderr, return code, and optional output metadata
     """
     if not os.path.exists(script_path):
         raise FileNotFoundError(f"Script not found: {script_path}")
@@ -59,12 +118,37 @@ def render_script(
         timeout=timeout,
     )
 
-    return {
+    render_result = {
         "command": " ".join(cmd),
         "returncode": result.returncode,
         "stdout": result.stdout,
         "stderr": result.stderr,
     }
+
+    if result.returncode != 0:
+        return render_result
+
+    if output_path:
+        outputs = find_render_outputs(output_path, animation=animation)
+        if not outputs:
+            raise RuntimeError(
+                "Blender render produced no output file.\n"
+                f"  Expected: {output_path}\n"
+                f"  stdout: {result.stdout[-500:]}"
+            )
+
+        primary_output = outputs[0]
+        render_result.update({
+            "output": os.path.abspath(primary_output),
+            "outputs": [os.path.abspath(path) for path in outputs],
+            "output_count": len(outputs),
+            "format": os.path.splitext(primary_output)[1].lstrip("."),
+            "method": "blender-headless",
+            "blender_version": get_version(),
+            "file_size": os.path.getsize(primary_output),
+        })
+
+    return render_result
 
 
 def render_scene_headless(
@@ -89,7 +173,7 @@ def render_scene_headless(
         script_path = f.name
 
     try:
-        result = render_script(script_path, timeout=timeout)
+        result = render_script(script_path, output_path=output_path, timeout=timeout)
 
         if result["returncode"] != 0:
             raise RuntimeError(
@@ -97,32 +181,12 @@ def render_scene_headless(
                 f"  stderr: {result['stderr'][-500:]}"
             )
 
-        # Verify the output file was created
-        # Blender appends frame number to output path for single frames
-        # e.g., /tmp/render.png becomes /tmp/render0001.png
-        actual_output = output_path
-        if not os.path.exists(actual_output):
-            # Try with frame number suffix
-            base, ext = os.path.splitext(output_path)
-            for suffix in ["0001", "0000", "1"]:
-                candidate = f"{base}{suffix}{ext}"
-                if os.path.exists(candidate):
-                    actual_output = candidate
-                    break
-
-        if not os.path.exists(actual_output):
-            raise RuntimeError(
-                f"Blender render produced no output file.\n"
-                f"  Expected: {output_path}\n"
-                f"  stdout: {result['stdout'][-500:]}"
-            )
-
         return {
-            "output": os.path.abspath(actual_output),
-            "format": os.path.splitext(actual_output)[1].lstrip("."),
+            "output": result["output"],
+            "format": result["format"],
             "method": "blender-headless",
-            "blender_version": get_version(),
-            "file_size": os.path.getsize(actual_output),
+            "blender_version": result["blender_version"],
+            "file_size": result["file_size"],
         }
     finally:
         os.unlink(script_path)

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -13,7 +13,14 @@ import subprocess
 import tempfile
 from typing import Optional
 
+from cli_anything.blender.utils import bpy_gen
+
 _FRAME_RUN = re.compile(r"#+")
+_RENDER_ARTIFACT_EXTENSIONS = bpy_gen.KNOWN_IMAGE_EXTENSIONS | {
+    extension
+    for extensions in bpy_gen.FFMPEG_CONTAINER_EXTENSIONS.values()
+    for extension in extensions
+}
 
 
 def _fingerprint(path: str) -> Optional[tuple[int, int]]:
@@ -76,9 +83,9 @@ def get_version() -> str:
 
 def _is_render_output(path: str, abs_output_path: str, animation: bool = False) -> bool:
     """Whether a path is a file Blender writes for this render target."""
-    stem = os.path.splitext(path)[0]
+    stem, path_ext = os.path.splitext(path)
     base, ext = os.path.splitext(abs_output_path)
-    if stem == base:
+    if stem == base and path_ext.lower() in _RENDER_ARTIFACT_EXTENSIONS:
         return True
     if "#" in base:
         # A '#' run in the target expands to the zero-padded frame number,
@@ -190,7 +197,7 @@ def render_script(
                 path for path in expected_outputs
                 if os.path.isfile(path) and _is_fresh(path, prior or {})
             ]
-            if expected_outputs is not None
+            if expected_outputs
             else find_render_outputs(output_path, animation=animation, prior=prior)
         )
         if not outputs:

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -16,6 +16,18 @@ from typing import Optional
 _FRAME_SUFFIXES = ("0001", "0000", "1")
 
 
+def _fingerprint(path: str) -> Optional[tuple[int, int]]:
+    try:
+        st = os.stat(path)
+    except FileNotFoundError:
+        return None
+    return (st.st_mtime_ns, st.st_size)
+
+
+def _is_fresh(path: str, prior: dict[str, tuple[int, int]]) -> bool:
+    return prior.get(os.path.abspath(path)) != _fingerprint(path)
+
+
 def _windows_install_candidates() -> list[str]:
     """Common Blender install locations when PATH lookup misses."""
     candidates: list[str] = []
@@ -62,10 +74,15 @@ def get_version() -> str:
     return result.stdout.strip().split("\n")[0]
 
 
-def find_render_outputs(output_path: str, animation: bool = False) -> list[str]:
+def find_render_outputs(
+    output_path: str,
+    animation: bool = False,
+    prior: Optional[dict[str, tuple[int, int]]] = None,
+) -> list[str]:
     """Resolve Blender's actual output file(s) for a requested render path."""
     abs_output_path = os.path.abspath(output_path)
     base, ext = os.path.splitext(abs_output_path)
+    stale = prior or {}
 
     direct_candidates = [abs_output_path]
     if ext:
@@ -73,16 +90,17 @@ def find_render_outputs(output_path: str, animation: bool = False) -> list[str]:
     else:
         direct_candidates.extend(f"{abs_output_path}{suffix}" for suffix in _FRAME_SUFFIXES)
 
-    for candidate in direct_candidates:
-        if os.path.exists(candidate):
-            return [candidate]
+    if not animation:
+        for candidate in direct_candidates:
+            if os.path.exists(candidate) and _is_fresh(candidate, stale):
+                return [candidate]
 
     patterns = [f"{base}*{ext}"] if ext else [f"{abs_output_path}*"]
     matches = sorted(
         path
         for pattern in patterns
         for path in glob.glob(pattern)
-        if os.path.isfile(path)
+        if os.path.isfile(path) and _is_fresh(path, stale)
     )
     if animation:
         return matches
@@ -93,7 +111,7 @@ def render_script(
     script_path: str,
     output_path: Optional[str] = None,
     animation: bool = False,
-    timeout: int = 300,
+    timeout: Optional[int] = 300,
 ) -> dict:
     """Run a bpy script using Blender headless.
 
@@ -101,7 +119,7 @@ def render_script(
         script_path: Path to the Python script to execute
         output_path: Expected render output path
         animation: Whether Blender is expected to render an animation sequence
-        timeout: Maximum seconds to wait
+        timeout: Maximum seconds to wait, or None to wait until Blender exits
 
     Returns:
         Dict with stdout, stderr, return code, and optional output metadata
@@ -111,12 +129,24 @@ def render_script(
 
     blender = find_blender()
     cmd = [blender, "--background", "--python", script_path]
+    prior = None
+    if output_path:
+        prior = {}
+        for path in find_render_outputs(output_path, animation=True):
+            fp = _fingerprint(path)
+            if fp is not None:
+                prior[os.path.abspath(path)] = fp
 
-    result = subprocess.run(
-        cmd,
-        capture_output=True, text=True,
-        timeout=timeout,
-    )
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True, text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"Blender render timed out after {timeout} seconds"
+        ) from exc
 
     render_result = {
         "command": " ".join(cmd),
@@ -129,7 +159,7 @@ def render_script(
         return render_result
 
     if output_path:
-        outputs = find_render_outputs(output_path, animation=animation)
+        outputs = find_render_outputs(output_path, animation=animation, prior=prior)
         if not outputs:
             raise RuntimeError(
                 "Blender render produced no output file.\n"

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -85,7 +85,9 @@ def _is_render_output(path: str, abs_output_path: str, animation: bool = False) 
     """Whether a path is a file Blender writes for this render target."""
     stem, path_ext = os.path.splitext(path)
     base, ext = os.path.splitext(abs_output_path)
-    if stem == base and path_ext.lower() in _RENDER_ARTIFACT_EXTENSIONS:
+    if path_ext.lower() not in _RENDER_ARTIFACT_EXTENSIONS:
+        return False
+    if stem == base:
         return True
     if "#" in base:
         # A '#' run in the target expands to the zero-padded frame number,

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -162,7 +162,7 @@ def render_script(
         raise ValueError(f"Output path is not a file: {output_path}")
 
     blender = find_blender()
-    cmd = [blender, "--background", "--python", script_path]
+    cmd = [blender, "--background", "--python-exit-code", "1", "--python", script_path]
     prior = None
     if output_path:
         prior = {}

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -13,9 +13,6 @@ import tempfile
 from typing import Optional
 
 
-_FRAME_SUFFIXES = ("0001", "0000", "1")
-
-
 def _fingerprint(path: str) -> Optional[tuple[int, int]]:
     try:
         st = os.stat(path)
@@ -74,6 +71,13 @@ def get_version() -> str:
     return result.stdout.strip().split("\n")[0]
 
 
+def _is_render_output(path: str, abs_output_path: str) -> bool:
+    """Whether a path is a file Blender writes for this render target."""
+    stem = os.path.splitext(path)[0]
+    base = os.path.splitext(abs_output_path)[0]
+    return stem == base or (stem.startswith(base) and stem[len(base):].isdigit())
+
+
 def find_render_outputs(
     output_path: str,
     animation: bool = False,
@@ -84,23 +88,12 @@ def find_render_outputs(
     base, ext = os.path.splitext(abs_output_path)
     stale = prior or {}
 
-    direct_candidates = [abs_output_path]
-    if ext:
-        direct_candidates.extend(f"{base}{suffix}{ext}" for suffix in _FRAME_SUFFIXES)
-    else:
-        direct_candidates.extend(f"{abs_output_path}{suffix}" for suffix in _FRAME_SUFFIXES)
-
-    if not animation:
-        for candidate in direct_candidates:
-            if os.path.exists(candidate) and _is_fresh(candidate, stale):
-                return [candidate]
-
-    patterns = [f"{base}*{ext}"] if ext else [f"{abs_output_path}*"]
     matches = sorted(
         path
-        for pattern in patterns
+        for pattern in ([f"{base}*{ext}"] if ext else [f"{abs_output_path}*"])
         for path in glob.glob(pattern)
         if os.path.isfile(path) and _is_fresh(path, stale)
+        and _is_render_output(path, abs_output_path)
     )
     if animation:
         return matches
@@ -127,6 +120,8 @@ def render_script(
     """
     if not os.path.exists(script_path):
         raise FileNotFoundError(f"Script not found: {script_path}")
+    if output_path and os.path.exists(output_path) and not os.path.isfile(output_path):
+        raise ValueError(f"Output path is not a file: {output_path}")
 
     blender = find_blender()
     cmd = [blender, "--background", "--python", script_path]

--- a/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
@@ -187,7 +187,7 @@ def _gen_scene_settings(project: Dict[str, Any]) -> List[str]:
     lines = [
         "# ── Scene Settings ──────────────────────────────────────────",
         "scene = bpy.context.scene",
-        f"scene.unit_settings.system = '{scene.get('unit_system', 'METRIC').upper()}'",
+        f"scene.unit_settings.system = {scene.get('unit_system', 'METRIC').upper()!r}",
         f"scene.unit_settings.scale_length = {scene.get('unit_scale', 1.0)}",
         f"scene.frame_start = {scene.get('frame_start', 1)}",
         f"scene.frame_end = {scene.get('frame_end', 250)}",
@@ -204,7 +204,7 @@ def _gen_render_settings(project: Dict[str, Any]) -> List[str]:
 
     lines = [
         "# ── Render Settings ─────────────────────────────────────────",
-        f"scene.render.engine = '{_engine_to_bpy(engine)}'",
+        f"scene.render.engine = {_engine_to_bpy(engine)!r}",
         f"scene.render.resolution_x = {render.get('resolution_x', 1920)}",
         f"scene.render.resolution_y = {render.get('resolution_y', 1080)}",
         f"scene.render.resolution_percentage = {render.get('resolution_percentage', 100)}",
@@ -272,7 +272,7 @@ def _gen_materials(project: Dict[str, Any]) -> List[str]:
 
         var_name = _safe_var_name(name)
         lines.extend([
-            f"mat_{var_name} = bpy.data.materials.new(name='{name}')",
+            f"mat_{var_name} = bpy.data.materials.new(name={name!r})",
             f"mat_{var_name}.use_nodes = True",
             f"bsdf_{var_name} = mat_{var_name}.node_tree.nodes.get('Principled BSDF')",
             f"if bsdf_{var_name}:",
@@ -310,7 +310,7 @@ def _gen_objects(project: Dict[str, Any]) -> List[str]:
         scl = obj.get("scale", [1, 1, 1])
         params = obj.get("mesh_params", {})
 
-        lines.append(f"# Object: {name}")
+        lines.append(f"# Object: {name!r}")
 
         # Create mesh primitive
         if mesh_type == "cube":
@@ -346,11 +346,11 @@ def _gen_objects(project: Dict[str, Any]) -> List[str]:
         elif mesh_type == "empty":
             lines.append(f"bpy.ops.object.empty_add(location=({loc[0]}, {loc[1]}, {loc[2]}))")
         else:
-            lines.append(f"# Unknown mesh type: {mesh_type}")
+            lines.append(f"# Unknown mesh type: {mesh_type!r}")
             continue
 
         lines.append("obj = bpy.context.active_object")
-        lines.append(f"obj.name = '{name}'")
+        lines.append(f"obj.name = {name!r}")
         lines.append(f"obj.rotation_euler = (math.radians({rot[0]}), math.radians({rot[1]}), math.radians({rot[2]}))")
         lines.append(f"obj.scale = ({scl[0]}, {scl[1]}, {scl[2]})")
 
@@ -402,8 +402,8 @@ def _gen_object_parenting(project: Dict[str, Any]) -> List[str]:
     lines = ["# ── Object Parenting ───────────────────────────────────────"]
     for child_name, parent_name in parent_pairs:
         lines.extend([
-            f"child_obj = bpy.data.objects.get('{child_name}')",
-            f"parent_obj = bpy.data.objects.get('{parent_name}')",
+            f"child_obj = bpy.data.objects.get({child_name!r})",
+            f"parent_obj = bpy.data.objects.get({parent_name!r})",
             "if child_obj and parent_obj:",
             "    child_obj.parent = parent_obj",
             "    child_obj.matrix_parent_inverse = parent_obj.matrix_world.inverted()",
@@ -420,7 +420,7 @@ def _gen_modifier(mod: Dict[str, Any]) -> List[str]:
     params = mod.get("params", {})
 
     lines = [
-        f"mod = obj.modifiers.new(name='{mod_name}', type='{bpy_type}')",
+        f"mod = obj.modifiers.new(name={mod_name!r}, type={bpy_type!r})",
     ]
 
     if mod_type == "subdivision_surface":
@@ -443,7 +443,7 @@ def _gen_modifier(mod: Dict[str, Any]) -> List[str]:
         lines.append(f"mod.width = {params.get('width', 0.1)}")
         lines.append(f"mod.segments = {params.get('segments', 1)}")
         limit = params.get("limit_method", "NONE")
-        lines.append(f"mod.limit_method = '{limit}'")
+        lines.append(f"mod.limit_method = {limit!r}")
         if limit == "ANGLE":
             lines.append(f"mod.angle_limit = {params.get('angle_limit', 0.523599)}")
     elif mod_type == "solidify":
@@ -452,15 +452,15 @@ def _gen_modifier(mod: Dict[str, Any]) -> List[str]:
         lines.append(f"mod.use_even_offset = {params.get('use_even_offset', False)}")
     elif mod_type == "decimate":
         lines.append(f"mod.ratio = {params.get('ratio', 0.5)}")
-        lines.append(f"mod.decimate_type = '{params.get('decimate_type', 'COLLAPSE')}'")
+        lines.append(f"mod.decimate_type = {params.get('decimate_type', 'COLLAPSE')!r}")
     elif mod_type == "boolean":
         op = params.get("operation", "DIFFERENCE")
-        lines.append(f"mod.operation = '{op}'")
+        lines.append(f"mod.operation = {op!r}")
         operand = params.get("operand_object", "")
         if operand:
-            lines.append(f"mod.object = bpy.data.objects.get('{operand}')")
+            lines.append(f"mod.object = bpy.data.objects.get({operand!r})")
         solver = params.get("solver", "EXACT")
-        lines.append(f"mod.solver = '{solver}'")
+        lines.append(f"mod.solver = {solver!r}")
     elif mod_type == "smooth":
         lines.append(f"mod.factor = {params.get('factor', 0.5)}")
         lines.append(f"mod.iterations = {params.get('iterations', 1)}")
@@ -490,8 +490,8 @@ def _gen_cameras(project: Dict[str, Any]) -> List[str]:
         clip_e = cam.get("clip_end", 1000.0)
 
         lines.extend([
-            f"cam_data = bpy.data.cameras.new(name='{name}')",
-            f"cam_data.type = '{cam_type}'",
+            f"cam_data = bpy.data.cameras.new(name={name!r})",
+            f"cam_data.type = {cam_type!r}",
             f"cam_data.lens = {focal}",
             f"cam_data.sensor_width = {sensor}",
             f"cam_data.clip_start = {clip_s}",
@@ -506,7 +506,7 @@ def _gen_cameras(project: Dict[str, Any]) -> List[str]:
             ])
 
         lines.extend([
-            f"cam_obj = bpy.data.objects.new('{name}', cam_data)",
+            f"cam_obj = bpy.data.objects.new({name!r}, cam_data)",
             "bpy.context.collection.objects.link(cam_obj)",
             f"cam_obj.location = ({loc[0]}, {loc[1]}, {loc[2]})",
             f"cam_obj.rotation_euler = (math.radians({rot[0]}), math.radians({rot[1]}), math.radians({rot[2]}))",
@@ -537,7 +537,7 @@ def _gen_lights(project: Dict[str, Any]) -> List[str]:
         power = light.get("power", 1000)
 
         lines.extend([
-            f"light_data = bpy.data.lights.new(name='{name}', type='{light_type}')",
+            f"light_data = bpy.data.lights.new(name={name!r}, type={light_type!r})",
             f"light_data.energy = {power}",
             f"light_data.color = ({color[0]}, {color[1]}, {color[2]})",
         ])
@@ -553,10 +553,10 @@ def _gen_lights(project: Dict[str, Any]) -> List[str]:
         elif light_type == "AREA":
             lines.append(f"light_data.size = {light.get('size', 1.0)}")
             lines.append(f"light_data.size_y = {light.get('size_y', 1.0)}")
-            lines.append(f"light_data.shape = '{light.get('shape', 'RECTANGLE')}'")
+            lines.append(f"light_data.shape = {light.get('shape', 'RECTANGLE')!r}")
 
         lines.extend([
-            f"light_obj = bpy.data.objects.new('{name}', light_data)",
+            f"light_obj = bpy.data.objects.new({name!r}, light_data)",
             "bpy.context.collection.objects.link(light_obj)",
             f"light_obj.location = ({loc[0]}, {loc[1]}, {loc[2]})",
             f"light_obj.rotation_euler = (math.radians({rot[0]}), math.radians({rot[1]}), math.radians({rot[2]}))",
@@ -582,7 +582,7 @@ def _gen_keyframes(project: Dict[str, Any]) -> List[str]:
             continue
 
         name = obj.get("name", "Object")
-        lines.append(f"obj = bpy.data.objects.get('{name}')")
+        lines.append(f"obj = bpy.data.objects.get({name!r})")
         lines.append("if obj:")
 
         for kf in keyframes:
@@ -631,12 +631,12 @@ def _gen_render_output(
 
     lines = [
         "# ── Render Output ───────────────────────────────────────────",
-        f"scene.render.image_settings.file_format = '{bpy_format}'",
+        f"scene.render.image_settings.file_format = {bpy_format!r}",
         f"scene.render.filepath = {output_path!r}",
     ]
     if bpy_format == "FFMPEG":
         container = _ffmpeg_container(output_path)
-        lines.append(f"scene.render.ffmpeg.format = '{container}'")
+        lines.append(f"scene.render.ffmpeg.format = {container!r}")
         if container == "WEBM":
             lines.append("scene.render.ffmpeg.codec = 'WEBM'")
 

--- a/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
@@ -14,7 +14,7 @@ from typing import Dict, Any, Optional, List
 # file aligned with the requested output path.
 FFMPEG_CONTAINER_FORMATS = {
     ".mp4": "MPEG4", ".m4v": "MPEG4", ".mov": "QUICKTIME",
-    ".avi": "AVI", ".mkv": "MKV",
+    ".avi": "AVI", ".mkv": "MKV", ".webm": "WEBM",
 }
 FFMPEG_DEFAULT_FORMAT = "MPEG4"
 

--- a/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
@@ -7,32 +7,106 @@ run with: blender --background --python script.py
 import json
 import math
 import os
+import re
 from typing import Dict, Any, Optional, List
 
 # Blender's FFmpegSettings.format defaults to Matroska, which rewrites the
 # movie extension the user asked for; pinning the container keeps the written
 # file aligned with the requested output path.
 FFMPEG_CONTAINER_FORMATS = {
-    ".mp4": "MPEG4", ".mov": "QUICKTIME",
+    ".mp4": "MPEG4", ".mpg": "MPEG4", ".mpeg": "MPEG4",
+    ".mov": "QUICKTIME",
     ".avi": "AVI", ".mkv": "MKV", ".webm": "WEBM",
 }
 FFMPEG_DEFAULT_FORMAT = "MPEG4"
+
+# Extensions Blender's FFMPEG writer accepts as "already the container's"
+# (get_file_extensions in writeffmpeg.cc): a target ending in one of these is
+# written verbatim; anything else gains the frame range plus the first entry.
+FFMPEG_CONTAINER_EXTENSIONS = {
+    "MPEG4": (".mp4", ".mpg", ".mpeg"),
+    "QUICKTIME": (".mov",),
+    "AVI": (".avi",),
+    "MKV": (".mkv",),
+    "WEBM": (".webm",),
+    "OGG": (".ogv", ".ogg"),
+}
+
+# First extension Blender writes per image format (image_path_ext_from_imformat_impl).
+IMAGE_FORMAT_EXTENSIONS = {
+    "PNG": ".png", "JPEG": ".jpg", "BMP": ".bmp",
+    "TIFF": ".tif", "OPEN_EXR": ".exr", "HDR": ".hdr",
+}
+
+# imb_ext_image: suffixes Blender treats as an existing image extension, so a
+# configured format replaces them instead of appending its own.
+KNOWN_IMAGE_EXTENSIONS = {
+    ".png", ".tga", ".bmp", ".jpg", ".jpeg", ".sgi", ".rgb", ".rgba",
+    ".tif", ".tiff", ".tx", ".avif", ".jp2", ".j2c", ".hdr", ".dds",
+    ".dpx", ".cin", ".exr", ".psd", ".pdd", ".psb", ".webp",
+}
+
+_FRAME_PLACEHOLDER = re.compile(r"#+")
+_FRAME_DIGITS = 4
+
+
+def _ensure_image_extension(path: str, ext: str) -> str:
+    """Mirror Blender's do_ensure_image_extension for a configured format."""
+    if path.lower().endswith(ext):
+        return path
+    root, current = os.path.splitext(path)
+    if current and current.lower() in KNOWN_IMAGE_EXTENSIONS:
+        return root + ext
+    return path + ext
+
+
+def _expand_frame_digits(path: str, frame: int) -> str:
+    """Mirror BLI_path_frame: replace a '#' run or append digits to the name."""
+    directory, name = os.path.split(path)
+    match = None
+    for found in _FRAME_PLACEHOLDER.finditer(name):
+        match = found  # Blender keeps scanning and uses the last run
+    if match:
+        width = match.end() - match.start()
+        name = name[:match.start()] + f"{frame:0{width}d}" + name[match.end():]
+    else:
+        name = name + f"{frame:0{_FRAME_DIGITS}d}"
+    return os.path.join(directory, name)
+
+
+def blender_still_path(output_path: str, output_format: str) -> Optional[str]:
+    """The exact file Blender writes for a write_still render."""
+    ext = IMAGE_FORMAT_EXTENSIONS.get(output_format)
+    if ext is None:
+        return None
+    return _ensure_image_extension(output_path, ext)
+
+
+def blender_frame_path(output_path: str, output_format: str, frame: int) -> Optional[str]:
+    """The exact file Blender writes for one frame of an image animation."""
+    ext = IMAGE_FORMAT_EXTENSIONS.get(output_format)
+    if ext is None:
+        return None
+    return _ensure_image_extension(_expand_frame_digits(output_path, frame), ext)
+
+
+def blender_movie_path(output_path: str, start: int, end: int) -> str:
+    """The exact file Blender's FFmpeg writer produces for an animation.
+
+    A target already ending in the pinned container's extension is written
+    verbatim; any other target keeps its name and gains the frame range plus
+    the container's extension.
+    """
+    exts = FFMPEG_CONTAINER_EXTENSIONS[_ffmpeg_container(output_path)]
+    if any(output_path.lower().endswith(ext) for ext in exts):
+        return output_path
+    return f"{output_path}{start:04d}-{end:04d}{exts[0]}"
 
 
 def _ffmpeg_container(output_path: str) -> str:
     """Blender FFmpegSettings.format value matching the requested extension."""
     ext = os.path.splitext(output_path)[1].lower()
     return FFMPEG_CONTAINER_FORMATS.get(ext, FFMPEG_DEFAULT_FORMAT)
-
-
-def ffmpeg_movie_extension(output_path: str) -> str:
-    """The filename extension an FFMPEG render actually writes.
-
-    A recognized movie extension is kept as-is; anything else falls back to
-    Blender's default MPEG4 container and gains the .mp4 extension.
-    """
-    ext = os.path.splitext(output_path)[1].lower()
-    return ext if ext in FFMPEG_CONTAINER_FORMATS else ".mp4"
 
 
 def generate_full_script(

--- a/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
@@ -6,7 +6,33 @@ run with: blender --background --python script.py
 
 import json
 import math
+import os
 from typing import Dict, Any, Optional, List
+
+# Blender's FFmpegSettings.format defaults to Matroska, which rewrites the
+# movie extension the user asked for; pinning the container keeps the written
+# file aligned with the requested output path.
+FFMPEG_CONTAINER_FORMATS = {
+    ".mp4": "MPEG4", ".m4v": "MPEG4", ".mov": "QUICKTIME",
+    ".avi": "AVI", ".mkv": "MATROSKA",
+}
+FFMPEG_DEFAULT_FORMAT = "MPEG4"
+
+
+def _ffmpeg_container(output_path: str) -> str:
+    """Blender FFmpegSettings.format value matching the requested extension."""
+    ext = os.path.splitext(output_path)[1].lower()
+    return FFMPEG_CONTAINER_FORMATS.get(ext, FFMPEG_DEFAULT_FORMAT)
+
+
+def ffmpeg_movie_extension(output_path: str) -> str:
+    """The filename extension an FFMPEG render actually writes.
+
+    A recognized movie extension is kept as-is; anything else falls back to
+    Blender's default MPEG4 container and gains the .mp4 extension.
+    """
+    ext = os.path.splitext(output_path)[1].lower()
+    return ext if ext in FFMPEG_CONTAINER_FORMATS else ".mp4"
 
 
 def generate_full_script(
@@ -534,6 +560,8 @@ def _gen_render_output(
         f"scene.render.image_settings.file_format = '{bpy_format}'",
         f"scene.render.filepath = {output_path!r}",
     ]
+    if bpy_format == "FFMPEG":
+        lines.append(f"scene.render.ffmpeg.format = '{_ffmpeg_container(output_path)}'")
 
     if animation:
         lines.extend([

--- a/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
@@ -87,8 +87,6 @@ def blender_frame_path(output_path: str, output_format: str, frame: int) -> Opti
     ext = IMAGE_FORMAT_EXTENSIONS.get(output_format)
     if ext is None:
         return None
-    if "#" not in os.path.basename(output_path) and os.path.splitext(output_path)[1]:
-        return _ensure_image_extension(output_path, ext)
     return _ensure_image_extension(_expand_frame_digits(output_path, frame), ext)
 
 

--- a/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
@@ -87,6 +87,8 @@ def blender_frame_path(output_path: str, output_format: str, frame: int) -> Opti
     ext = IMAGE_FORMAT_EXTENSIONS.get(output_format)
     if ext is None:
         return None
+    if "#" not in os.path.basename(output_path) and os.path.splitext(output_path)[1]:
+        return _ensure_image_extension(output_path, ext)
     return _ensure_image_extension(_expand_frame_digits(output_path, frame), ext)
 
 

--- a/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
@@ -13,7 +13,7 @@ from typing import Dict, Any, Optional, List
 # movie extension the user asked for; pinning the container keeps the written
 # file aligned with the requested output path.
 FFMPEG_CONTAINER_FORMATS = {
-    ".mp4": "MPEG4", ".m4v": "MPEG4", ".mov": "QUICKTIME",
+    ".mp4": "MPEG4", ".mov": "QUICKTIME",
     ".avi": "AVI", ".mkv": "MKV", ".webm": "WEBM",
 }
 FFMPEG_DEFAULT_FORMAT = "MPEG4"
@@ -561,7 +561,10 @@ def _gen_render_output(
         f"scene.render.filepath = {output_path!r}",
     ]
     if bpy_format == "FFMPEG":
-        lines.append(f"scene.render.ffmpeg.format = '{_ffmpeg_container(output_path)}'")
+        container = _ffmpeg_container(output_path)
+        lines.append(f"scene.render.ffmpeg.format = '{container}'")
+        if container == "WEBM":
+            lines.append("scene.render.ffmpeg.codec = 'WEBM'")
 
     if animation:
         lines.extend([

--- a/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
@@ -14,7 +14,7 @@ from typing import Dict, Any, Optional, List
 # file aligned with the requested output path.
 FFMPEG_CONTAINER_FORMATS = {
     ".mp4": "MPEG4", ".m4v": "MPEG4", ".mov": "QUICKTIME",
-    ".avi": "AVI", ".mkv": "MATROSKA",
+    ".avi": "AVI", ".mkv": "MKV",
 }
 FFMPEG_DEFAULT_FORMAT = "MPEG4"
 

--- a/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
+++ b/blender/agent-harness/cli_anything/blender/utils/bpy_gen.py
@@ -21,7 +21,7 @@ FFMPEG_CONTAINER_FORMATS = {
 FFMPEG_DEFAULT_FORMAT = "MPEG4"
 
 # Extensions Blender's FFMPEG writer accepts as "already the container's"
-# (get_file_extensions in writeffmpeg.cc): a target ending in one of these is
+# (the movie writer's get_file_extensions): a target ending in one of these is
 # written verbatim; anything else gains the frame range plus the first entry.
 FFMPEG_CONTAINER_EXTENSIONS = {
     "MPEG4": (".mp4", ".mpg", ".mpeg"),

--- a/blender/agent-harness/setup.py
+++ b/blender/agent-harness/setup.py
@@ -22,7 +22,7 @@ long_description = README.read_text(encoding="utf-8") if README.exists() else ""
 
 setup(
     name="cli-anything-blender",
-    version="1.0.0",
+    version="1.0.1",
     description="CLI harness for Blender - run 3D modeling, animation, and rendering via blender --background --python",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/registry.json
+++ b/registry.json
@@ -179,7 +179,7 @@
     {
       "name": "blender",
       "display_name": "Blender",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "3D modeling, animation, and rendering via blender --background --python",
       "requires": "blender >= 4.2",
       "homepage": "https://www.blender.org",

--- a/skills/cli-anything-blender/SKILL.md
+++ b/skills/cli-anything-blender/SKILL.md
@@ -153,7 +153,7 @@ Render settings and output commands.
 | `settings` | Configure render settings |
 | `info` | Show current render settings |
 | `presets` | List available render presets |
-| `execute` | Render the scene (generates bpy script) |
+| `execute` | Render the scene with Blender headless |
 | `script` | Generate bpy script without rendering |
 
 ### Preview
@@ -295,4 +295,4 @@ When using this CLI programmatically:
 
 ## Version
 
-1.0.0
+1.0.1


### PR DESCRIPTION
## Description

I changed `render execute` so it actually runs Blender. Previously it wrote `_render_script.py`, printed `blender --background --python ...`, and exited 0 without spawning Blender or writing the output file. Now it invokes `blender_backend.render_script` on that script. A missing binary, a non-zero Blender exit, or a missing output file raises and the CLI exits 1.

Artifact checks now follow Blender's configured image format, frame placeholders, and FFmpeg container naming. That keeps overwrite protection and reported outputs aligned with the files Blender actually writes.

`render script` is still generate-only. If you were treating `render execute` as "write the bpy file and stop", use `render script` instead.

On Windows, `find_blender` also looks for `blender.exe` and the default `Program Files\Blender Foundation\Blender *\blender.exe` install when PATH lookup misses.

Fixes #451

## Type of Change

- [x] **Bug Fix**, fixes incorrect behavior

### For Existing CLI Modifications

- [x] All unit tests pass: `python3 -m pytest cli_anything/blender/tests/test_core.py -v`
- [ ] All E2E tests pass: `python3 -m pytest cli_anything/blender/tests/test_full_e2e.py -v` (backend classes need Blender installed; the generate-path failures on EEVEE_NEXT / preview are present on current `main`)
- [x] No test regressions, no previously passing tests were removed or weakened
- [x] `registry.json` entry is updated if version, description, or requirements changed

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands
- [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
- [x] I have tested my changes locally

## Test Results

```
PYTHONPATH=blender/agent-harness python3 -m pytest blender/agent-harness/cli_anything/blender/tests/test_core.py blender/agent-harness/cli_anything/blender/tests/test_bpy_gen.py -q
202 passed in 0.11s
```

## Why

An agent (or a human) cannot tell a completed render from a no-op when the command prints `output_path` / `command` and exits 0. Invocation failures have to be loud.

## Verification

- before, on current `main`: `cli-anything-blender --project scene.blend-cli.json render execute ./out.png`: exit 0, `_render_script.py` written, no `out.png`, Blender never starts
- after, Blender missing: same command, exit 1, `Error: Blender is not installed`
- after, Blender exits 42: exit 1, `Blender render failed (exit 42)` with stderr
- after, Blender exits 0 and writes the png: exit 0, `Rendered: ... via blender-headless`, file present
