### PR TITLE
fix(freecad): correct primitive center-of-mass calculations

### DIFF
--- a/freecad/agent-harness/cli_anything/freecad/core/measure.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/measure.py
@@ -63,9 +63,10 @@ def _to_world(part: Dict[str, Any], local_point: List[float]) -> List[float]:
 def _bbox_center(part: Dict[str, Any]) -> Optional[List[float]]:
     """Return the world-axis-aligned bounding-box centre of a part."""
     supported_bounds = {"box", "cylinder", "sphere", "cone", "torus", "wedge"}
-    bounds = world_bounds(part) if part["type"] in supported_bounds else None
+    part_type = str(part.get("type", "")).lower()
+    bounds = world_bounds(part) if part_type in supported_bounds else None
     if bounds is None:
-        if part["type"] in supported_bounds:
+        if part_type in supported_bounds:
             return None
         # Boolean or unknown — preserve the placement-position fallback.
         return _get_position(part)
@@ -75,7 +76,7 @@ def _bbox_center(part: Dict[str, Any]) -> Optional[List[float]]:
 def _center_of_mass(part: Dict[str, Any]) -> Optional[List[float]]:
     """Return the analytical centre of mass for supported uniform primitives."""
     p = part["params"]
-    t = part["type"]
+    t = str(part.get("type", "")).lower()
 
     if t in {"cylinder", "sphere", "cone", "torus"} and world_bounds(part) is None:
         return None
@@ -589,7 +590,7 @@ def measure_bounding_box(
         Measurement record with ``min``, ``max``, and ``size`` vectors.
     """
     part = get_part(project, index)
-    t = part["type"]
+    t = str(part.get("type", "")).lower()
 
     supported_bounds = {"box", "cylinder", "sphere", "cone", "torus", "wedge"}
     bounds = world_bounds(part) if t in supported_bounds else None

--- a/freecad/agent-harness/cli_anything/freecad/core/measure.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/measure.py
@@ -21,6 +21,11 @@ from cli_anything.freecad.core.parts import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+_MEASURABLE_BOUNDS_TYPES = {
+    "box", "cylinder", "sphere", "cone", "torus", "wedge",
+}
+
+
 def _next_measurement_id(project: Dict[str, Any]) -> int:
     """Return the next available integer ID for measurements."""
     items = project.get("measurements", [])
@@ -62,11 +67,14 @@ def _to_world(part: Dict[str, Any], local_point: List[float]) -> List[float]:
 
 def _bbox_center(part: Dict[str, Any]) -> Optional[List[float]]:
     """Return the world-axis-aligned bounding-box centre of a part."""
-    supported_bounds = {"box", "cylinder", "sphere", "cone", "torus", "wedge"}
     part_type = str(part.get("type", "")).lower()
-    bounds = world_bounds(part) if part_type in supported_bounds else None
+    bounds = (
+        world_bounds(part)
+        if part_type in _MEASURABLE_BOUNDS_TYPES
+        else None
+    )
     if bounds is None:
-        if part_type in supported_bounds:
+        if part_type in _MEASURABLE_BOUNDS_TYPES:
             return None
         # Boolean or unknown — preserve the placement-position fallback.
         return _get_position(part)
@@ -74,11 +82,14 @@ def _bbox_center(part: Dict[str, Any]) -> Optional[List[float]]:
 
 
 def _center_of_mass(part: Dict[str, Any]) -> Optional[List[float]]:
-    """Return the analytical centre of mass for supported uniform primitives."""
+    """Return analytical centre of mass for supported uniform primitives."""
     p = part["params"]
     t = str(part.get("type", "")).lower()
 
-    if t in {"cylinder", "sphere", "cone", "torus"} and world_bounds(part) is None:
+    if (
+        t in {"cylinder", "sphere", "cone", "torus"}
+        and world_bounds(part) is None
+    ):
         return None
 
     if t == "box":
@@ -567,7 +578,11 @@ def measure_center_of_mass(
 
     result_com: Dict[str, Any] = {
         "part_index": index,
-        "center_of_mass": [round(v, 6) for v in com] if com is not None else None,
+        "center_of_mass": (
+            [round(v, 6) for v in com]
+            if com is not None
+            else None
+        ),
         "deferred": com is None,
     }
     if additive:
@@ -592,8 +607,7 @@ def measure_bounding_box(
     part = get_part(project, index)
     t = str(part.get("type", "")).lower()
 
-    supported_bounds = {"box", "cylinder", "sphere", "cone", "torus", "wedge"}
-    bounds = world_bounds(part) if t in supported_bounds else None
+    bounds = world_bounds(part) if t in _MEASURABLE_BOUNDS_TYPES else None
     if bounds is None:
         # Unknown / boolean — deferred
         result_bb_def: Dict[str, Any] = {

--- a/freecad/agent-harness/cli_anything/freecad/core/measure.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/measure.py
@@ -14,6 +14,7 @@ from cli_anything.freecad.core.parts import (
     PRIMITIVES,
     _rotation_matrix,
     _transform_point,
+    _world_bounds,
     get_part,
 )
 
@@ -60,8 +61,8 @@ def _to_world(part: Dict[str, Any], local_point: List[float]) -> List[float]:
     )
 
 
-def _cone_aabb_center(part: Dict[str, Any]) -> List[float]:
-    """Return the exact world-axis-aligned bounding-box centre of a cone."""
+def _cone_aabb_bounds(part: Dict[str, Any]) -> tuple[List[float], List[float]]:
+    """Return the exact world-axis-aligned bounds of a cone."""
     params = part["params"]
     placement = part["placement"]
     position = list(placement["position"])
@@ -70,7 +71,8 @@ def _cone_aabb_center(part: Dict[str, Any]) -> List[float]:
     radius2 = float(params["radius2"])
     height = float(params["height"])
 
-    center: List[float] = []
+    bounds_min: List[float] = []
+    bounds_max: List[float] = []
     for axis in range(3):
         radial_support = math.hypot(matrix[axis][0], matrix[axis][1])
         upper_center = matrix[axis][2] * height
@@ -84,8 +86,15 @@ def _cone_aabb_center(part: Dict[str, Any]) -> List[float]:
             radial_support * radius1,
             upper_center + radial_support * radius2,
         )
-        center.append(position[axis] + (axis_min + axis_max) / 2.0)
-    return center
+        bounds_min.append(position[axis] + axis_min)
+        bounds_max.append(position[axis] + axis_max)
+    return bounds_min, bounds_max
+
+
+def _cone_aabb_center(part: Dict[str, Any]) -> List[float]:
+    """Return the exact world-axis-aligned bounding-box centre of a cone."""
+    bounds_min, bounds_max = _cone_aabb_bounds(part)
+    return [(bounds_min[i] + bounds_max[i]) / 2.0 for i in range(3)]
 
 
 def _bbox_center(part: Dict[str, Any]) -> List[float]:
@@ -592,8 +601,8 @@ def measure_bounding_box(
 ) -> Dict[str, Any]:
     """Compute the axis-aligned bounding box of a part.
 
-    The bounding box is derived from the part's position and primitive
-    parameters.
+    The bounding box is derived from the part's placement and primitive
+    parameters in world space.
 
     Returns
     -------
@@ -601,57 +610,29 @@ def measure_bounding_box(
         Measurement record with ``min``, ``max``, and ``size`` vectors.
     """
     part = get_part(project, index)
-    pos = _get_position(part)
-    p = part["params"]
     t = part["type"]
 
-    if t == "box":
-        bb_min = pos[:]
-        bb_max = [
-            pos[0] + p["length"],
-            pos[1] + p["width"],
-            pos[2] + p["height"],
-        ]
-    elif t == "cylinder":
-        r = p["radius"]
-        bb_min = [pos[0] - r, pos[1] - r, pos[2]]
-        bb_max = [pos[0] + r, pos[1] + r, pos[2] + p["height"]]
-    elif t == "sphere":
-        r = p["radius"]
-        bb_min = [pos[0] - r, pos[1] - r, pos[2] - r]
-        bb_max = [pos[0] + r, pos[1] + r, pos[2] + r]
-    elif t == "cone":
-        r = max(p["radius1"], p["radius2"])
-        bb_min = [pos[0] - r, pos[1] - r, pos[2]]
-        bb_max = [pos[0] + r, pos[1] + r, pos[2] + p["height"]]
-    elif t == "torus":
-        R, r = p["radius1"], p["radius2"]
-        outer = R + r
-        bb_min = [pos[0] - outer, pos[1] - outer, pos[2] - r]
-        bb_max = [pos[0] + outer, pos[1] + outer, pos[2] + r]
-    elif t == "wedge":
-        bb_min = [
-            pos[0] + p["xmin"],
-            pos[1] + p["ymin"],
-            pos[2] + p["zmin"],
-        ]
-        bb_max = [
-            pos[0] + p["xmax"],
-            pos[1] + p["ymax"],
-            pos[2] + p["zmax"],
-        ]
+    if t == "cone":
+        bb_min, bb_max = _cone_aabb_bounds(part)
     else:
-        # Unknown / boolean — deferred
-        result_bb_def: Dict[str, Any] = {
-            "part_index": index,
-            "min": None,
-            "max": None,
-            "size": None,
-            "deferred": True,
-        }
-        if additive:
-            result_bb_def["additive"] = True
-        return _store_measurement(project, "bounding_box", result_bb_def)
+        supported_bounds = {"box", "cylinder", "sphere", "torus", "wedge"}
+        world_bounds = _world_bounds(part) if t in supported_bounds else None
+        if world_bounds is not None:
+            axes = ("x", "y", "z")
+            bb_min = [world_bounds["min"][axis] for axis in axes]
+            bb_max = [world_bounds["max"][axis] for axis in axes]
+        else:
+            # Unknown / boolean — deferred
+            result_bb_def: Dict[str, Any] = {
+                "part_index": index,
+                "min": None,
+                "max": None,
+                "size": None,
+                "deferred": True,
+            }
+            if additive:
+                result_bb_def["additive"] = True
+            return _store_measurement(project, "bounding_box", result_bb_def)
 
     size = [bb_max[i] - bb_min[i] for i in range(3)]
 

--- a/freecad/agent-harness/cli_anything/freecad/core/measure.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/measure.py
@@ -12,10 +12,9 @@ from typing import Any, Dict, List, Optional
 from cli_anything.freecad.core.document import ensure_collection
 from cli_anything.freecad.core.parts import (
     PRIMITIVES,
-    _rotation_matrix,
-    _transform_point,
-    _world_bounds,
     get_part,
+    transform_point,
+    world_bounds,
 )
 
 # ---------------------------------------------------------------------------
@@ -54,75 +53,21 @@ def _get_position(part: Dict[str, Any]) -> List[float]:
 def _to_world(part: Dict[str, Any], local_point: List[float]) -> List[float]:
     """Transform a primitive-local point through the part placement."""
     placement = part["placement"]
-    return _transform_point(
+    return transform_point(
         local_point,
         list(placement["rotation"]),
         list(placement["position"]),
     )
 
 
-def _cone_aabb_bounds(part: Dict[str, Any]) -> tuple[List[float], List[float]]:
-    """Return the exact world-axis-aligned bounds of a cone."""
-    params = part["params"]
-    placement = part["placement"]
-    position = list(placement["position"])
-    matrix = _rotation_matrix(list(placement["rotation"]))
-    radius1 = float(params["radius1"])
-    radius2 = float(params["radius2"])
-    height = float(params["height"])
-
-    bounds_min: List[float] = []
-    bounds_max: List[float] = []
-    for axis in range(3):
-        radial_support = math.hypot(matrix[axis][0], matrix[axis][1])
-        upper_center = matrix[axis][2] * height
-        # Each world-axis support is linear along the frustum, so its
-        # extrema occur on one of the two end disks.
-        axis_min = min(
-            -radial_support * radius1,
-            upper_center - radial_support * radius2,
-        )
-        axis_max = max(
-            radial_support * radius1,
-            upper_center + radial_support * radius2,
-        )
-        bounds_min.append(position[axis] + axis_min)
-        bounds_max.append(position[axis] + axis_max)
-    return bounds_min, bounds_max
-
-
-def _cone_aabb_center(part: Dict[str, Any]) -> List[float]:
-    """Return the exact world-axis-aligned bounding-box centre of a cone."""
-    bounds_min, bounds_max = _cone_aabb_bounds(part)
-    return [(bounds_min[i] + bounds_max[i]) / 2.0 for i in range(3)]
-
-
 def _bbox_center(part: Dict[str, Any]) -> List[float]:
-    """Estimate the bounding-box centre of a part from its position and params."""
-    p = part["params"]
-    t = part["type"]
-
-    if t == "box":
-        local_center = [p["length"] / 2.0, p["width"] / 2.0, p["height"] / 2.0]
-    elif t == "cylinder":
-        local_center = [0.0, 0.0, p["height"] / 2.0]
-    elif t == "sphere":
-        local_center = [0.0, 0.0, 0.0]
-    elif t == "cone":
-        return _cone_aabb_center(part)
-    elif t == "torus":
-        local_center = [0.0, 0.0, 0.0]
-    elif t == "wedge":
-        local_center = [
-            (p["xmin"] + p["xmax"]) / 2.0,
-            (p["ymin"] + p["ymax"]) / 2.0,
-            (p["zmin"] + p["zmax"]) / 2.0,
-        ]
-    else:
+    """Return the world-axis-aligned bounding-box centre of a part."""
+    supported_bounds = {"box", "cylinder", "sphere", "cone", "torus", "wedge"}
+    bounds = world_bounds(part) if part["type"] in supported_bounds else None
+    if bounds is None:
         # Boolean or unknown — fall back to placement position
         return _get_position(part)
-
-    return _to_world(part, local_center)
+    return [bounds["center"][axis] for axis in ("x", "y", "z")]
 
 
 def _center_of_mass(part: Dict[str, Any]) -> List[float]:
@@ -612,27 +557,24 @@ def measure_bounding_box(
     part = get_part(project, index)
     t = part["type"]
 
-    if t == "cone":
-        bb_min, bb_max = _cone_aabb_bounds(part)
-    else:
-        supported_bounds = {"box", "cylinder", "sphere", "torus", "wedge"}
-        world_bounds = _world_bounds(part) if t in supported_bounds else None
-        if world_bounds is not None:
-            axes = ("x", "y", "z")
-            bb_min = [world_bounds["min"][axis] for axis in axes]
-            bb_max = [world_bounds["max"][axis] for axis in axes]
-        else:
-            # Unknown / boolean — deferred
-            result_bb_def: Dict[str, Any] = {
-                "part_index": index,
-                "min": None,
-                "max": None,
-                "size": None,
-                "deferred": True,
-            }
-            if additive:
-                result_bb_def["additive"] = True
-            return _store_measurement(project, "bounding_box", result_bb_def)
+    supported_bounds = {"box", "cylinder", "sphere", "cone", "torus", "wedge"}
+    bounds = world_bounds(part) if t in supported_bounds else None
+    if bounds is None:
+        # Unknown / boolean — deferred
+        result_bb_def: Dict[str, Any] = {
+            "part_index": index,
+            "min": None,
+            "max": None,
+            "size": None,
+            "deferred": True,
+        }
+        if additive:
+            result_bb_def["additive"] = True
+        return _store_measurement(project, "bounding_box", result_bb_def)
+
+    axes = ("x", "y", "z")
+    bb_min = [bounds["min"][axis] for axis in axes]
+    bb_max = [bounds["max"][axis] for axis in axes]
 
     size = [bb_max[i] - bb_min[i] for i in range(3)]
 

--- a/freecad/agent-harness/cli_anything/freecad/core/measure.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/measure.py
@@ -10,8 +10,7 @@ import math
 from typing import Any, Dict, List, Optional
 
 from cli_anything.freecad.core.document import ensure_collection
-from cli_anything.freecad.core.parts import PRIMITIVES, get_part
-
+from cli_anything.freecad.core.parts import PRIMITIVES, _transform_point, get_part
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -46,51 +45,69 @@ def _get_position(part: Dict[str, Any]) -> List[float]:
     return list(part["placement"]["position"])
 
 
+def _to_world(part: Dict[str, Any], local_point: List[float]) -> List[float]:
+    """Transform a primitive-local point through the part placement."""
+    placement = part["placement"]
+    return _transform_point(
+        local_point,
+        list(placement["rotation"]),
+        list(placement["position"]),
+    )
+
+
 def _bbox_center(part: Dict[str, Any]) -> List[float]:
     """Estimate the bounding-box centre of a part from its position and params."""
-    pos = _get_position(part)
     p = part["params"]
     t = part["type"]
 
     if t == "box":
-        return [
-            pos[0] + p["length"] / 2.0,
-            pos[1] + p["width"] / 2.0,
-            pos[2] + p["height"] / 2.0,
-        ]
+        local_center = [p["length"] / 2.0, p["width"] / 2.0, p["height"] / 2.0]
     elif t == "cylinder":
-        r = p["radius"]
-        return [
-            pos[0] + r,
-            pos[1] + r,
-            pos[2] + p["height"] / 2.0,
-        ]
+        local_center = [0.0, 0.0, p["height"] / 2.0]
     elif t == "sphere":
-        r = p["radius"]
-        return [pos[0] + r, pos[1] + r, pos[2] + r]
+        local_center = [0.0, 0.0, 0.0]
     elif t == "cone":
-        r = max(p["radius1"], p["radius2"])
-        return [
-            pos[0] + r,
-            pos[1] + r,
-            pos[2] + p["height"] / 2.0,
-        ]
+        local_center = [0.0, 0.0, p["height"] / 2.0]
     elif t == "torus":
-        R = p["radius1"]
-        r = p["radius2"]
-        return [
-            pos[0] + R + r,
-            pos[1] + R + r,
-            pos[2] + r,
-        ]
+        local_center = [0.0, 0.0, 0.0]
     elif t == "wedge":
-        return [
-            pos[0] + (p["xmin"] + p["xmax"]) / 2.0,
-            pos[1] + (p["ymin"] + p["ymax"]) / 2.0,
-            pos[2] + (p["zmin"] + p["zmax"]) / 2.0,
+        local_center = [
+            (p["xmin"] + p["xmax"]) / 2.0,
+            (p["ymin"] + p["ymax"]) / 2.0,
+            (p["zmin"] + p["zmax"]) / 2.0,
         ]
-    # Boolean or unknown — fall back to placement position
-    return pos
+    else:
+        # Boolean or unknown — fall back to placement position
+        return _get_position(part)
+
+    return _to_world(part, local_center)
+
+
+def _center_of_mass(part: Dict[str, Any]) -> List[float]:
+    """Return the analytical centre of mass for supported uniform primitives."""
+    p = part["params"]
+    t = part["type"]
+
+    if t == "box":
+        local_center = [p["length"] / 2.0, p["width"] / 2.0, p["height"] / 2.0]
+    elif t == "cylinder":
+        local_center = [0.0, 0.0, p["height"] / 2.0]
+    elif t in {"sphere", "torus"}:
+        local_center = [0.0, 0.0, 0.0]
+    elif t == "cone":
+        r1 = p["radius1"]
+        r2 = p["radius2"]
+        radius_sum = r1 ** 2 + r1 * r2 + r2 ** 2
+        if radius_sum == 0.0:
+            return _get_position(part)
+        # Centroid of a solid conical frustum, measured from the radius1 base.
+        z = p["height"] * (r1 ** 2 + 2.0 * r1 * r2 + 3.0 * r2 ** 2)
+        z /= 4.0 * radius_sum
+        local_center = [0.0, 0.0, z]
+    else:
+        return _bbox_center(part)
+
+    return _to_world(part, local_center)
 
 
 # ---------------------------------------------------------------------------
@@ -517,10 +534,7 @@ def measure_center_of_mass(
     project: Dict[str, Any], index: int,
     additive: bool = False,
 ) -> Dict[str, Any]:
-    """Estimate the centre of mass (geometric centre for simple shapes).
-
-    For uniform-density primitives the centre of mass coincides with the
-    bounding-box centre.
+    """Estimate the centre of mass for a uniform-density primitive.
 
     Returns
     -------
@@ -528,7 +542,7 @@ def measure_center_of_mass(
         Measurement record with ``center_of_mass`` ``[x, y, z]``.
     """
     part = get_part(project, index)
-    com = _bbox_center(part)
+    com = _center_of_mass(part)
 
     result_com: Dict[str, Any] = {
         "part_index": index,

--- a/freecad/agent-harness/cli_anything/freecad/core/measure.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/measure.py
@@ -60,20 +60,25 @@ def _to_world(part: Dict[str, Any], local_point: List[float]) -> List[float]:
     )
 
 
-def _bbox_center(part: Dict[str, Any]) -> List[float]:
+def _bbox_center(part: Dict[str, Any]) -> Optional[List[float]]:
     """Return the world-axis-aligned bounding-box centre of a part."""
     supported_bounds = {"box", "cylinder", "sphere", "cone", "torus", "wedge"}
     bounds = world_bounds(part) if part["type"] in supported_bounds else None
     if bounds is None:
-        # Boolean or unknown — fall back to placement position
+        if part["type"] in supported_bounds:
+            return None
+        # Boolean or unknown — preserve the placement-position fallback.
         return _get_position(part)
     return [bounds["center"][axis] for axis in ("x", "y", "z")]
 
 
-def _center_of_mass(part: Dict[str, Any]) -> List[float]:
+def _center_of_mass(part: Dict[str, Any]) -> Optional[List[float]]:
     """Return the analytical centre of mass for supported uniform primitives."""
     p = part["params"]
     t = part["type"]
+
+    if t in {"cylinder", "sphere", "cone", "torus"} and world_bounds(part) is None:
+        return None
 
     if t == "box":
         local_center = [p["length"] / 2.0, p["width"] / 2.0, p["height"] / 2.0]
@@ -232,13 +237,26 @@ def measure_distance(
     Returns
     -------
     dict
-        Measurement record with ``distance`` value and axis deltas.
+        Measurement record with ``distance`` value and axis deltas. Partial
+        angular primitives are deferred when their exact bounds are unknown.
     """
     part1 = get_part(project, index1)
     part2 = get_part(project, index2)
 
     c1 = _bbox_center(part1)
     c2 = _bbox_center(part2)
+
+    if c1 is None or c2 is None:
+        result_deferred: Dict[str, Any] = {
+            "part1_index": index1,
+            "part2_index": index2,
+            "distance": None,
+            "delta": None,
+            "deferred": True,
+        }
+        if additive:
+            result_deferred["additive"] = True
+        return _store_measurement(project, "distance", result_deferred)
 
     dx = c2[0] - c1[0]
     dy = c2[1] - c1[1]
@@ -250,6 +268,7 @@ def measure_distance(
         "part2_index": index2,
         "distance": round(dist, 6),
         "delta": [round(dx, 6), round(dy, 6), round(dz, 6)],
+        "deferred": False,
     }
     if additive:
         result["additive"] = True
@@ -338,13 +357,25 @@ def measure_angle(
     Returns
     -------
     dict
-        Measurement record with ``angle_deg`` value.
+        Measurement record with ``angle_deg`` value. Partial angular
+        primitives are deferred when their exact bounds are unknown.
     """
     part1 = get_part(project, index1)
     part2 = get_part(project, index2)
 
     c1 = _bbox_center(part1)
     c2 = _bbox_center(part2)
+
+    if c1 is None or c2 is None:
+        result_deferred: Dict[str, Any] = {
+            "part1_index": index1,
+            "part2_index": index2,
+            "angle_deg": None,
+            "deferred": True,
+        }
+        if additive:
+            result_deferred["additive"] = True
+        return _store_measurement(project, "angle", result_deferred)
 
     mag1 = math.sqrt(sum(v ** 2 for v in c1))
     mag2 = math.sqrt(sum(v ** 2 for v in c2))
@@ -360,6 +391,7 @@ def measure_angle(
         "part1_index": index1,
         "part2_index": index2,
         "angle_deg": round(angle_deg, 6),
+        "deferred": False,
     }
     if additive:
         result_angle["additive"] = True
@@ -526,14 +558,16 @@ def measure_center_of_mass(
     Returns
     -------
     dict
-        Measurement record with ``center_of_mass`` ``[x, y, z]``.
+        Measurement record with ``center_of_mass`` ``[x, y, z]``. Partial
+        angular primitives are deferred when no analytical result is available.
     """
     part = get_part(project, index)
     com = _center_of_mass(part)
 
     result_com: Dict[str, Any] = {
         "part_index": index,
-        "center_of_mass": [round(v, 6) for v in com],
+        "center_of_mass": [round(v, 6) for v in com] if com is not None else None,
+        "deferred": com is None,
     }
     if additive:
         result_com["additive"] = True

--- a/freecad/agent-harness/cli_anything/freecad/core/measure.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/measure.py
@@ -10,7 +10,12 @@ import math
 from typing import Any, Dict, List, Optional
 
 from cli_anything.freecad.core.document import ensure_collection
-from cli_anything.freecad.core.parts import PRIMITIVES, _transform_point, get_part
+from cli_anything.freecad.core.parts import (
+    PRIMITIVES,
+    _rotation_matrix,
+    _transform_point,
+    get_part,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -55,6 +60,34 @@ def _to_world(part: Dict[str, Any], local_point: List[float]) -> List[float]:
     )
 
 
+def _cone_aabb_center(part: Dict[str, Any]) -> List[float]:
+    """Return the exact world-axis-aligned bounding-box centre of a cone."""
+    params = part["params"]
+    placement = part["placement"]
+    position = list(placement["position"])
+    matrix = _rotation_matrix(list(placement["rotation"]))
+    radius1 = float(params["radius1"])
+    radius2 = float(params["radius2"])
+    height = float(params["height"])
+
+    center: List[float] = []
+    for axis in range(3):
+        radial_support = math.hypot(matrix[axis][0], matrix[axis][1])
+        upper_center = matrix[axis][2] * height
+        # Each world-axis support is linear along the frustum, so its
+        # extrema occur on one of the two end disks.
+        axis_min = min(
+            -radial_support * radius1,
+            upper_center - radial_support * radius2,
+        )
+        axis_max = max(
+            radial_support * radius1,
+            upper_center + radial_support * radius2,
+        )
+        center.append(position[axis] + (axis_min + axis_max) / 2.0)
+    return center
+
+
 def _bbox_center(part: Dict[str, Any]) -> List[float]:
     """Estimate the bounding-box centre of a part from its position and params."""
     p = part["params"]
@@ -67,7 +100,7 @@ def _bbox_center(part: Dict[str, Any]) -> List[float]:
     elif t == "sphere":
         local_center = [0.0, 0.0, 0.0]
     elif t == "cone":
-        local_center = [0.0, 0.0, p["height"] / 2.0]
+        return _cone_aabb_center(part)
     elif t == "torus":
         local_center = [0.0, 0.0, 0.0]
     elif t == "wedge":

--- a/freecad/agent-harness/cli_anything/freecad/core/measure.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/measure.py
@@ -60,7 +60,7 @@ def _to_world(part: Dict[str, Any], local_point: List[float]) -> List[float]:
     placement = part["placement"]
     return transform_point(
         local_point,
-        list(placement["rotation"]),
+        list(placement.get("rotation", [0.0, 0.0, 0.0])),
         list(placement["position"]),
     )
 

--- a/freecad/agent-harness/cli_anything/freecad/core/parts.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/parts.py
@@ -136,7 +136,7 @@ def _validate_vec3(value: Any, label: str) -> List[float]:
         raise ValueError(f"{label} elements must be numeric: {exc}") from exc
 
 
-def _rotation_matrix(rotation: List[float]) -> List[List[float]]:
+def rotation_matrix(rotation: List[float]) -> List[List[float]]:
     """Return a simple XYZ Euler rotation matrix for *rotation* in degrees."""
     rx, ry, rz = [math.radians(float(v)) for v in rotation]
     cx, sx = math.cos(rx), math.sin(rx)
@@ -171,9 +171,9 @@ def _rotation_matrix(rotation: List[float]) -> List[List[float]]:
     return _matmul(mz, _matmul(my, mx))
 
 
-def _transform_point(point: List[float], rotation: List[float], translation: List[float]) -> List[float]:
+def transform_point(point: List[float], rotation: List[float], translation: List[float]) -> List[float]:
     """Apply an XYZ Euler rotation and translation to a point."""
-    matrix = _rotation_matrix(rotation)
+    matrix = rotation_matrix(rotation)
     x, y, z = point
     tx, ty, tz = translation
     return [
@@ -278,11 +278,73 @@ def _local_bounds(part_type: str, params: Dict[str, Any]) -> Optional[Dict[str, 
     return None
 
 
-def _world_bounds(part: Dict[str, Any]) -> Optional[Dict[str, Dict[str, float]]]:
+def world_bounds(part: Dict[str, Any]) -> Optional[Dict[str, Dict[str, float]]]:
     """Return a world-space bounding box for supported primitive parts."""
     local = _local_bounds(str(part.get("type", "")).lower(), part.get("params", {}))
     if local is None:
         return None
+
+    placement = part.get("placement", {})
+    position = _validate_vec3(placement.get("position", [0.0, 0.0, 0.0]), "position")
+    rotation = _validate_vec3(placement.get("rotation", [0.0, 0.0, 0.0]), "rotation")
+    matrix = rotation_matrix(rotation)
+    part_type = str(part.get("type", "")).lower()
+    params = part.get("params", {})
+
+    if (
+        part_type == "sphere"
+        and math.isclose(float(params["angle1"]), -90.0)
+        and math.isclose(float(params["angle2"]), 90.0)
+        and math.isclose(abs(float(params["angle3"])), 360.0)
+    ):
+        radius = float(params["radius"])
+        return _bbox_from_points([
+            [position[axis] - radius for axis in range(3)],
+            [position[axis] + radius for axis in range(3)],
+        ])
+
+    if (
+        part_type in {"cylinder", "cone"}
+        and math.isclose(abs(float(params["angle"])), 360.0)
+    ):
+        if part_type == "cylinder":
+            lower_radius = upper_radius = float(params["radius"])
+        else:
+            lower_radius = float(params["radius1"])
+            upper_radius = float(params["radius2"])
+        height = float(params["height"])
+        bounds_min = []
+        bounds_max = []
+        for axis in range(3):
+            radial_support = math.hypot(matrix[axis][0], matrix[axis][1])
+            upper_center = matrix[axis][2] * height
+            bounds_min.append(position[axis] + min(
+                -radial_support * lower_radius,
+                upper_center - radial_support * upper_radius,
+            ))
+            bounds_max.append(position[axis] + max(
+                radial_support * lower_radius,
+                upper_center + radial_support * upper_radius,
+            ))
+        return _bbox_from_points([bounds_min, bounds_max])
+
+    if (
+        part_type == "torus"
+        and math.isclose(float(params["angle1"]), -180.0)
+        and math.isclose(float(params["angle2"]), 180.0)
+        and math.isclose(abs(float(params["angle3"])), 360.0)
+    ):
+        major_radius = float(params["radius1"])
+        tube_radius = float(params["radius2"])
+        extents = [
+            major_radius * math.hypot(matrix[axis][0], matrix[axis][1])
+            + tube_radius
+            for axis in range(3)
+        ]
+        return _bbox_from_points([
+            [position[axis] - extents[axis] for axis in range(3)],
+            [position[axis] + extents[axis] for axis in range(3)],
+        ])
 
     min_corner = local["min"]
     max_corner = local["max"]
@@ -292,10 +354,7 @@ def _world_bounds(part: Dict[str, Any]) -> Optional[Dict[str, Dict[str, float]]]
             for z in (min_corner["z"], max_corner["z"]):
                 corners.append([x, y, z])
 
-    placement = part.get("placement", {})
-    position = _validate_vec3(placement.get("position", [0.0, 0.0, 0.0]), "position")
-    rotation = _validate_vec3(placement.get("rotation", [0.0, 0.0, 0.0]), "rotation")
-    return _bbox_from_points([_transform_point(point, rotation, position) for point in corners])
+    return _bbox_from_points([transform_point(point, rotation, position) for point in corners])
 
 
 def _anchor_value(bounds: Dict[str, Dict[str, float]], axis: str, anchor: str) -> float:
@@ -1500,7 +1559,7 @@ def part_bounds(
     """Return local and world bounding-box data for a part."""
     part = get_part(project, index)
     local = _local_bounds(str(part["type"]).lower(), part.get("params", {}))
-    world = _world_bounds(part)
+    world = world_bounds(part)
     return {
         "id": part["id"],
         "name": part["name"],
@@ -1528,8 +1587,8 @@ def align_part(
     """Move a part so selected bbox anchors match another part's anchors."""
     part = get_part(project, index)
     target = get_part(project, target_index)
-    source_bounds = _world_bounds(part)
-    target_bounds = _world_bounds(target)
+    source_bounds = world_bounds(part)
+    target_bounds = world_bounds(target)
     if source_bounds is None:
         raise ValueError(
             f"Part #{index} ({part['name']}) does not support bounding-box alignment for type '{part['type']}'"
@@ -1565,7 +1624,7 @@ def align_part(
         position[axis_to_index[axis]] += shift
 
     part["placement"]["position"] = position
-    updated_bounds = _world_bounds(part)
+    updated_bounds = world_bounds(part)
     return {
         "part_index": index,
         "target_index": target_index,
@@ -1597,7 +1656,7 @@ def part_info(
     """
     part = get_part(project, index)
     geo = _estimate_geometry(part["type"], part.get("params", {}))
-    world = _world_bounds(part)
+    world = world_bounds(part)
 
     return {
         "id": part["id"],

--- a/freecad/agent-harness/cli_anything/freecad/core/parts.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/parts.py
@@ -360,6 +360,15 @@ def world_bounds(part: Dict[str, Any]) -> Optional[Dict[str, Dict[str, float]]]:
             [position[axis] + extents[axis] for axis in range(3)],
         ])
 
+    if part_type == "wedge":
+        identity = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+        if any(
+            not math.isclose(matrix[row][column], identity[row][column], abs_tol=1e-12)
+            for row in range(3)
+            for column in range(3)
+        ):
+            return None
+
     min_corner = local["min"]
     max_corner = local["max"]
     corners = []

--- a/freecad/agent-harness/cli_anything/freecad/core/parts.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/parts.py
@@ -291,28 +291,35 @@ def world_bounds(part: Dict[str, Any]) -> Optional[Dict[str, Dict[str, float]]]:
     part_type = str(part.get("type", "")).lower()
     params = part.get("params", {})
 
-    if (
-        part_type == "sphere"
-        and math.isclose(float(params["angle1"]), -90.0)
-        and math.isclose(float(params["angle2"]), 90.0)
-        and math.isclose(abs(float(params["angle3"])), 360.0)
-    ):
+    if part_type == "sphere":
         radius = float(params["radius"])
+        latitude_start = float(params.get("angle1", -90.0))
+        latitude_end = float(params.get("angle2", 90.0))
+        sweep = float(params.get("angle3", 360.0))
+        if not (
+            math.isfinite(latitude_start)
+            and math.isfinite(latitude_end)
+            and math.isfinite(sweep)
+            and math.isclose(latitude_start, -90.0)
+            and math.isclose(latitude_end, 90.0)
+            and math.isclose(abs(sweep), 360.0)
+        ):
+            return None
         return _bbox_from_points([
             [position[axis] - radius for axis in range(3)],
             [position[axis] + radius for axis in range(3)],
         ])
 
-    if (
-        part_type in {"cylinder", "cone"}
-        and math.isclose(abs(float(params["angle"])), 360.0)
-    ):
+    if part_type in {"cylinder", "cone"}:
         if part_type == "cylinder":
             lower_radius = upper_radius = float(params["radius"])
         else:
             lower_radius = float(params["radius1"])
             upper_radius = float(params["radius2"])
         height = float(params["height"])
+        sweep = float(params.get("angle", 360.0))
+        if not math.isfinite(sweep) or not math.isclose(abs(sweep), 360.0):
+            return None
         bounds_min = []
         bounds_max = []
         for axis in range(3):
@@ -328,14 +335,21 @@ def world_bounds(part: Dict[str, Any]) -> Optional[Dict[str, Dict[str, float]]]:
             ))
         return _bbox_from_points([bounds_min, bounds_max])
 
-    if (
-        part_type == "torus"
-        and math.isclose(float(params["angle1"]), -180.0)
-        and math.isclose(float(params["angle2"]), 180.0)
-        and math.isclose(abs(float(params["angle3"])), 360.0)
-    ):
+    if part_type == "torus":
         major_radius = float(params["radius1"])
         tube_radius = float(params["radius2"])
+        tube_start = float(params.get("angle1", -180.0))
+        tube_end = float(params.get("angle2", 180.0))
+        sweep = float(params.get("angle3", 360.0))
+        if not (
+            math.isfinite(tube_start)
+            and math.isfinite(tube_end)
+            and math.isfinite(sweep)
+            and math.isclose(tube_start, -180.0)
+            and math.isclose(tube_end, 180.0)
+            and math.isclose(abs(sweep), 360.0)
+        ):
+            return None
         extents = [
             major_radius * math.hypot(matrix[axis][0], matrix[axis][1])
             + tube_radius

--- a/freecad/agent-harness/cli_anything/freecad/core/parts.py
+++ b/freecad/agent-harness/cli_anything/freecad/core/parts.py
@@ -171,7 +171,11 @@ def rotation_matrix(rotation: List[float]) -> List[List[float]]:
     return _matmul(mz, _matmul(my, mx))
 
 
-def transform_point(point: List[float], rotation: List[float], translation: List[float]) -> List[float]:
+def transform_point(
+    point: List[float],
+    rotation: List[float],
+    translation: List[float],
+) -> List[float]:
     """Apply an XYZ Euler rotation and translation to a point."""
     matrix = rotation_matrix(rotation)
     x, y, z = point
@@ -278,15 +282,21 @@ def _local_bounds(part_type: str, params: Dict[str, Any]) -> Optional[Dict[str, 
     return None
 
 
-def world_bounds(part: Dict[str, Any]) -> Optional[Dict[str, Dict[str, float]]]:
+def world_bounds(
+    part: Dict[str, Any],
+) -> Optional[Dict[str, Dict[str, float]]]:
     """Return a world-space bounding box for supported primitive parts."""
     local = _local_bounds(str(part.get("type", "")).lower(), part.get("params", {}))
     if local is None:
         return None
 
     placement = part.get("placement", {})
-    position = _validate_vec3(placement.get("position", [0.0, 0.0, 0.0]), "position")
-    rotation = _validate_vec3(placement.get("rotation", [0.0, 0.0, 0.0]), "rotation")
+    position = _validate_vec3(
+        placement.get("position", [0.0, 0.0, 0.0]), "position"
+    )
+    rotation = _validate_vec3(
+        placement.get("rotation", [0.0, 0.0, 0.0]), "rotation"
+    )
     matrix = rotation_matrix(rotation)
     part_type = str(part.get("type", "")).lower()
     params = part.get("params", {})
@@ -363,7 +373,11 @@ def world_bounds(part: Dict[str, Any]) -> Optional[Dict[str, Dict[str, float]]]:
     if part_type == "wedge":
         identity = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
         if any(
-            not math.isclose(matrix[row][column], identity[row][column], abs_tol=1e-12)
+            not math.isclose(
+                matrix[row][column],
+                identity[row][column],
+                abs_tol=1e-12,
+            )
             for row in range(3)
             for column in range(3)
         ):
@@ -377,7 +391,10 @@ def world_bounds(part: Dict[str, Any]) -> Optional[Dict[str, Dict[str, float]]]:
             for z in (min_corner["z"], max_corner["z"]):
                 corners.append([x, y, z])
 
-    return _bbox_from_points([transform_point(point, rotation, position) for point in corners])
+    return _bbox_from_points([
+        transform_point(point, rotation, position)
+        for point in corners
+    ])
 
 
 def _anchor_value(bounds: Dict[str, Dict[str, float]], axis: str, anchor: str) -> float:

--- a/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
+++ b/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
@@ -416,7 +416,7 @@ class TestMeasure:
 
         result = measure_center_of_mass(proj, 0)
 
-        assert result["center_of_mass"] == expected
+        assert result["center_of_mass"] == pytest.approx(expected, abs=1e-6)
 
     def test_center_of_mass_applies_part_rotation(self):
         proj = _make_project()
@@ -431,6 +431,24 @@ class TestMeasure:
         result = measure_center_of_mass(proj, 0)
 
         assert result["center_of_mass"] == [14.0, 20.0, 30.0]
+
+    def test_measurements_normalize_loaded_primitive_type_case(self):
+        proj = _make_project()
+        add_part(proj, "sphere", position=[0.0, 0.0, 0.0])
+        add_part(proj, "sphere", position=[3.0, 4.0, 0.0])
+        proj["parts"][0]["type"] = "SpHeRe"
+
+        center = measure_center_of_mass(proj, 0)
+        bounds = measure_bounding_box(proj, 0)
+        distance = measure_distance(proj, 0, 1)
+
+        assert center["center_of_mass"] == [0.0, 0.0, 0.0]
+        assert center["deferred"] is False
+        assert bounds["min"] == [-5.0, -5.0, -5.0]
+        assert bounds["max"] == [5.0, 5.0, 5.0]
+        assert bounds["deferred"] is False
+        assert distance["distance"] == 5.0
+        assert distance["deferred"] is False
 
     @pytest.mark.parametrize(
         ("part_type", "params"),

--- a/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
+++ b/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
@@ -21,6 +21,7 @@ from cli_anything.freecad.core.document import (
     save_document,
 )
 from cli_anything.freecad.core.measure import (
+    measure_angle,
     measure_bounding_box,
     measure_center_of_mass,
     measure_distance,
@@ -431,6 +432,54 @@ class TestMeasure:
 
         assert result["center_of_mass"] == [14.0, 20.0, 30.0]
 
+    @pytest.mark.parametrize(
+        ("part_type", "params"),
+        [
+            (
+                "sphere",
+                {"radius": 5.0, "angle1": 0.0, "angle2": 90.0},
+            ),
+            (
+                "cylinder",
+                {"radius": 3.0, "height": 8.0, "angle": 90.0},
+            ),
+            (
+                "cone",
+                {"radius1": 3.0, "radius2": 1.0, "height": 8.0, "angle": 90.0},
+            ),
+            (
+                "torus",
+                {"radius1": 10.0, "radius2": 2.0, "angle3": 180.0},
+            ),
+        ],
+    )
+    def test_center_of_mass_defers_partial_sweeps(self, part_type, params):
+        proj = _make_project()
+        add_part(proj, part_type, params=params)
+
+        result = measure_center_of_mass(proj, 0)
+
+        assert result["center_of_mass"] is None
+        assert result["deferred"] is True
+
+    def test_distance_and_angle_defer_partial_sweeps(self):
+        proj = _make_project()
+        add_part(
+            proj,
+            "cylinder",
+            params={"radius": 3.0, "height": 8.0, "angle": 90.0},
+        )
+        add_part(proj, "box", position=[10.0, 0.0, 0.0])
+
+        distance = measure_distance(proj, 0, 1)
+        angle = measure_angle(proj, 0, 1)
+
+        assert distance["distance"] is None
+        assert distance["delta"] is None
+        assert distance["deferred"] is True
+        assert angle["angle_deg"] is None
+        assert angle["deferred"] is True
+
     def test_distance_uses_primitive_bounding_box_centers(self):
         proj = _make_project()
         add_part(proj, "sphere", position=[0.0, 0.0, 0.0], params={"radius": 10.0})
@@ -567,24 +616,113 @@ class TestMeasure:
         ]
         assert distance["delta"] == pytest.approx(expected_center, abs=1e-6)
 
-    def test_partial_sweep_keeps_conservative_world_bounds(self):
+    @pytest.mark.parametrize(
+        ("part_type", "params"),
+        [
+            (
+                "sphere",
+                {"radius": 5.0, "angle1": 0.0, "angle2": 90.0, "angle3": 180.0},
+            ),
+            (
+                "cylinder",
+                {"radius": 3.0, "height": 8.0, "angle": 90.0},
+            ),
+            (
+                "cone",
+                {"radius1": 3.0, "radius2": 1.0, "height": 8.0, "angle": 90.0},
+            ),
+            (
+                "torus",
+                {"radius1": 10.0, "radius2": 2.0, "angle3": 180.0},
+            ),
+        ],
+    )
+    def test_partial_sweeps_are_deferred(self, part_type, params):
+        proj = _make_project()
+        add_part(proj, part_type, rotation=[25.0, 35.0, 45.0], params=params)
+
+        bounds = measure_bounding_box(proj, 0)
+
+        assert bounds["min"] is None
+        assert bounds["max"] is None
+        assert bounds["size"] is None
+        assert bounds["deferred"] is True
+
+    @pytest.mark.parametrize(
+        (
+            "part_type",
+            "params",
+            "rotation",
+            "removed_keys",
+            "expected_min",
+            "expected_max",
+        ),
+        [
+            (
+                "sphere",
+                {"radius": 5.0},
+                [0.0, 0.0, 0.0],
+                ("angle1", "angle2", "angle3"),
+                [-5.0, -5.0, -5.0],
+                [5.0, 5.0, 5.0],
+            ),
+            (
+                "cylinder",
+                {"radius": 3.0, "height": 8.0},
+                [0.0, 45.0, 0.0],
+                ("angle",),
+                [-2.12132, -3.0, -2.12132],
+                [7.778175, 3.0, 7.778175],
+            ),
+            (
+                "cone",
+                {"radius1": 3.0, "radius2": 1.0, "height": 8.0},
+                [0.0, 0.0, 0.0],
+                ("angle",),
+                [-3.0, -3.0, 0.0],
+                [3.0, 3.0, 8.0],
+            ),
+            (
+                "torus",
+                {"radius1": 10.0, "radius2": 2.0},
+                [0.0, 0.0, 0.0],
+                ("angle1", "angle2", "angle3"),
+                [-12.0, -12.0, -2.0],
+                [12.0, 12.0, 2.0],
+            ),
+        ],
+    )
+    def test_missing_sweep_angles_use_primitive_defaults(
+        self,
+        part_type,
+        params,
+        rotation,
+        removed_keys,
+        expected_min,
+        expected_max,
+    ):
+        proj = _make_project()
+        add_part(proj, part_type, rotation=rotation, params=params)
+        for key in removed_keys:
+            del proj["parts"][0]["params"][key]
+
+        bounds = measure_bounding_box(proj, 0)
+
+        assert bounds["min"] == pytest.approx(expected_min, abs=1e-6)
+        assert bounds["max"] == pytest.approx(expected_max, abs=1e-6)
+
+    @pytest.mark.parametrize("angle", [float("inf"), float("-inf"), float("nan")])
+    def test_non_finite_sweep_is_deferred(self, angle):
         proj = _make_project()
         add_part(
             proj,
-            "sphere",
-            rotation=[25.0, 35.0, 45.0],
-            params={
-                "radius": 5.0,
-                "angle1": 0.0,
-                "angle2": 90.0,
-                "angle3": 90.0,
-            },
+            "cylinder",
+            params={"radius": 3.0, "height": 8.0, "angle": angle},
         )
 
         bounds = measure_bounding_box(proj, 0)
 
-        assert bounds["deferred"] is False
-        assert all(size >= 10.0 for size in bounds["size"])
+        assert bounds["deferred"] is True
 
     def test_bounding_box_keeps_unsupported_parts_deferred(self):
         proj = _make_project()

--- a/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
+++ b/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
@@ -604,7 +604,7 @@ class TestMeasure:
         assert bounds["min"] == pytest.approx(expected_min, abs=1e-6)
         assert bounds["max"] == pytest.approx(expected_max, abs=1e-6)
 
-    def test_rotated_wedge_distance_uses_reported_bounding_box_center(self):
+    def test_rotated_wedge_measurements_are_deferred(self):
         proj = _make_project()
         add_part(proj, "sphere", position=[0.0, 0.0, 0.0])
         add_part(
@@ -627,12 +627,30 @@ class TestMeasure:
         )
 
         bounds = measure_bounding_box(proj, 1)
+        center = measure_center_of_mass(proj, 1)
         distance = measure_distance(proj, 0, 1)
+        angle = measure_angle(proj, 0, 1)
 
-        expected_center = [
-            (low + high) / 2.0 for low, high in zip(bounds["min"], bounds["max"])
-        ]
-        assert distance["delta"] == pytest.approx(expected_center, abs=1e-6)
+        assert bounds["min"] is None
+        assert bounds["max"] is None
+        assert bounds["deferred"] is True
+        assert center["center_of_mass"] is None
+        assert center["deferred"] is True
+        assert distance["distance"] is None
+        assert distance["delta"] is None
+        assert distance["deferred"] is True
+        assert angle["angle_deg"] is None
+        assert angle["deferred"] is True
+
+    def test_unrotated_wedge_bounds_remain_available(self):
+        proj = _make_project()
+        add_part(proj, "wedge", position=[10.0, 20.0, 30.0])
+
+        bounds = measure_bounding_box(proj, 0)
+
+        assert bounds["min"] == [10.0, 20.0, 30.0]
+        assert bounds["max"] == [20.0, 30.0, 40.0]
+        assert bounds["deferred"] is False
 
     @pytest.mark.parametrize(
         ("part_type", "params"),

--- a/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
+++ b/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
@@ -397,7 +397,11 @@ class TestMeasure:
     @pytest.mark.parametrize(
         ("part_type", "params", "expected"),
         [
-            ("box", {"length": 6.0, "width": 8.0, "height": 10.0}, [5.0, 1.0, 9.0]),
+            (
+                "box",
+                {"length": 6.0, "width": 8.0, "height": 10.0},
+                [5.0, 1.0, 9.0],
+            ),
             ("cylinder", {"radius": 7.0, "height": 10.0}, [2.0, -3.0, 9.0]),
             ("sphere", {"radius": 7.0}, [2.0, -3.0, 4.0]),
             (
@@ -500,7 +504,12 @@ class TestMeasure:
 
     def test_distance_uses_primitive_bounding_box_centers(self):
         proj = _make_project()
-        add_part(proj, "sphere", position=[0.0, 0.0, 0.0], params={"radius": 10.0})
+        add_part(
+            proj,
+            "sphere",
+            position=[0.0, 0.0, 0.0],
+            params={"radius": 10.0},
+        )
         add_part(
             proj,
             "torus",
@@ -537,7 +546,8 @@ class TestMeasure:
             [7.071068, 5.0, 7.071068], abs=1e-6
         )
         assert [
-            (low + high) / 2.0 for low, high in zip(bounds["min"], bounds["max"])
+            (low + high) / 2.0
+            for low, high in zip(bounds["min"], bounds["max"])
         ] == pytest.approx(result["delta"], abs=1e-6)
 
     def test_bounding_box_applies_rotation_consistently_with_distance(self):
@@ -558,7 +568,10 @@ class TestMeasure:
         assert bounds["max"] == pytest.approx([10.0, 24.0, 33.0])
         assert bounds["size"] == pytest.approx([2.0, 4.0, 3.0])
         assert distance["delta"] == pytest.approx(
-            [(low + high) / 2.0 for low, high in zip(bounds["min"], bounds["max"])]
+            [
+                (low + high) / 2.0
+                for low, high in zip(bounds["min"], bounds["max"])
+            ]
         )
 
     @pytest.mark.parametrize(
@@ -657,7 +670,12 @@ class TestMeasure:
         [
             (
                 "sphere",
-                {"radius": 5.0, "angle1": 0.0, "angle2": 90.0, "angle3": 180.0},
+                {
+                    "radius": 5.0,
+                    "angle1": 0.0,
+                    "angle2": 90.0,
+                    "angle3": 180.0,
+                },
             ),
             (
                 "cylinder",
@@ -747,7 +765,9 @@ class TestMeasure:
         assert bounds["min"] == pytest.approx(expected_min, abs=1e-6)
         assert bounds["max"] == pytest.approx(expected_max, abs=1e-6)
 
-    @pytest.mark.parametrize("angle", [float("inf"), float("-inf"), float("nan")])
+    @pytest.mark.parametrize(
+        "angle", [float("inf"), float("-inf"), float("nan")]
+    )
     def test_non_finite_sweep_is_deferred(self, angle):
         proj = _make_project()
         add_part(

--- a/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
+++ b/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
@@ -20,6 +20,7 @@ from cli_anything.freecad.core.document import (
     open_document,
     save_document,
 )
+from cli_anything.freecad.core.measure import measure_center_of_mass, measure_distance
 from cli_anything.freecad.core.parts import (
     PRIMITIVES,
     add_part,
@@ -378,6 +379,68 @@ class TestParts:
 
         with pytest.raises(ValueError, match="must differ"):
             boolean_op(proj, "cut", 0, 0)
+
+
+# ===========================================================================
+# TestMeasure
+# ===========================================================================
+
+
+class TestMeasure:
+    """Tests for analytical measurements of simple primitives."""
+
+    @pytest.mark.parametrize(
+        ("part_type", "params", "expected"),
+        [
+            ("box", {"length": 6.0, "width": 8.0, "height": 10.0}, [5.0, 1.0, 9.0]),
+            ("cylinder", {"radius": 7.0, "height": 10.0}, [2.0, -3.0, 9.0]),
+            ("sphere", {"radius": 7.0}, [2.0, -3.0, 4.0]),
+            (
+                "cone",
+                {"radius1": 4.0, "radius2": 2.0, "height": 12.0},
+                [2.0, -3.0, 8.714286],
+            ),
+            ("torus", {"radius1": 10.0, "radius2": 3.0}, [2.0, -3.0, 4.0]),
+        ],
+    )
+    def test_center_of_mass_uses_primitive_local_origin(
+        self, part_type, params, expected
+    ):
+        proj = _make_project()
+        add_part(proj, part_type, position=[2.0, -3.0, 4.0], params=params)
+
+        result = measure_center_of_mass(proj, 0)
+
+        assert result["center_of_mass"] == expected
+
+    def test_center_of_mass_applies_part_rotation(self):
+        proj = _make_project()
+        add_part(
+            proj,
+            "cylinder",
+            position=[10.0, 20.0, 30.0],
+            rotation=[0.0, 90.0, 0.0],
+            params={"radius": 3.0, "height": 8.0},
+        )
+
+        result = measure_center_of_mass(proj, 0)
+
+        assert result["center_of_mass"] == [14.0, 20.0, 30.0]
+
+    def test_distance_uses_primitive_bounding_box_centers(self):
+        proj = _make_project()
+        add_part(proj, "sphere", position=[0.0, 0.0, 0.0], params={"radius": 10.0})
+        add_part(
+            proj,
+            "torus",
+            position=[3.0, 4.0, 0.0],
+            params={"radius1": 20.0, "radius2": 5.0},
+        )
+
+        result = measure_distance(proj, 0, 1)
+
+        assert result["distance"] == 5.0
+        assert result["delta"] == [3.0, 4.0, 0.0]
 
 
 # ===========================================================================

--- a/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
+++ b/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
@@ -494,6 +494,98 @@ class TestMeasure:
             [(low + high) / 2.0 for low, high in zip(bounds["min"], bounds["max"])]
         )
 
+    @pytest.mark.parametrize(
+        ("part_type", "params", "rotation", "expected_min", "expected_max"),
+        [
+            (
+                "sphere",
+                {"radius": 5.0},
+                [25.0, 35.0, 45.0],
+                [5.0, 15.0, 25.0],
+                [15.0, 25.0, 35.0],
+            ),
+            (
+                "cylinder",
+                {"radius": 3.0, "height": 8.0},
+                [0.0, 45.0, 0.0],
+                [7.87868, 17.0, 27.87868],
+                [17.778175, 23.0, 37.778175],
+            ),
+            (
+                "torus",
+                {"radius1": 10.0, "radius2": 2.0},
+                [0.0, 45.0, 0.0],
+                [0.928932, 8.0, 20.928932],
+                [19.071068, 32.0, 39.071068],
+            ),
+        ],
+    )
+    def test_rotated_curved_primitives_use_exact_world_bounds(
+        self, part_type, params, rotation, expected_min, expected_max
+    ):
+        proj = _make_project()
+        add_part(
+            proj,
+            part_type,
+            position=[10.0, 20.0, 30.0],
+            rotation=rotation,
+            params=params,
+        )
+
+        bounds = measure_bounding_box(proj, 0)
+
+        assert bounds["min"] == pytest.approx(expected_min, abs=1e-6)
+        assert bounds["max"] == pytest.approx(expected_max, abs=1e-6)
+
+    def test_rotated_wedge_distance_uses_reported_bounding_box_center(self):
+        proj = _make_project()
+        add_part(proj, "sphere", position=[0.0, 0.0, 0.0])
+        add_part(
+            proj,
+            "wedge",
+            position=[10.0, 20.0, 30.0],
+            rotation=[20.0, 30.0, 40.0],
+            params={
+                "xmin": 0.0,
+                "ymin": 0.0,
+                "zmin": 0.0,
+                "x2min": -8.0,
+                "z2min": -2.0,
+                "xmax": 8.0,
+                "ymax": 10.0,
+                "zmax": 6.0,
+                "x2max": 12.0,
+                "z2max": 10.0,
+            },
+        )
+
+        bounds = measure_bounding_box(proj, 1)
+        distance = measure_distance(proj, 0, 1)
+
+        expected_center = [
+            (low + high) / 2.0 for low, high in zip(bounds["min"], bounds["max"])
+        ]
+        assert distance["delta"] == pytest.approx(expected_center, abs=1e-6)
+
+    def test_partial_sweep_keeps_conservative_world_bounds(self):
+        proj = _make_project()
+        add_part(
+            proj,
+            "sphere",
+            rotation=[25.0, 35.0, 45.0],
+            params={
+                "radius": 5.0,
+                "angle1": 0.0,
+                "angle2": 90.0,
+                "angle3": 90.0,
+            },
+        )
+
+        bounds = measure_bounding_box(proj, 0)
+
+        assert bounds["deferred"] is False
+        assert all(size >= 10.0 for size in bounds["size"])
+
     def test_bounding_box_keeps_unsupported_parts_deferred(self):
         proj = _make_project()
         proj["parts"].append(

--- a/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
+++ b/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
@@ -442,6 +442,23 @@ class TestMeasure:
         assert result["distance"] == 5.0
         assert result["delta"] == [3.0, 4.0, 0.0]
 
+    def test_distance_uses_rotated_asymmetric_cone_aabb_center(self):
+        proj = _make_project()
+        add_part(proj, "sphere", position=[0.0, 0.0, 0.0])
+        add_part(
+            proj,
+            "cone",
+            rotation=[0.0, 45.0, 0.0],
+            params={"radius1": 5.0, "radius2": 0.0, "height": 10.0},
+        )
+
+        result = measure_distance(proj, 0, 1)
+
+        assert result["distance"] == 2.5
+        assert result["delta"] == pytest.approx(
+            [1.767767, 0.0, 1.767767], abs=1e-6
+        )
+
 
 # ===========================================================================
 # TestSketch

--- a/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
+++ b/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
@@ -20,7 +20,11 @@ from cli_anything.freecad.core.document import (
     open_document,
     save_document,
 )
-from cli_anything.freecad.core.measure import measure_center_of_mass, measure_distance
+from cli_anything.freecad.core.measure import (
+    measure_bounding_box,
+    measure_center_of_mass,
+    measure_distance,
+)
 from cli_anything.freecad.core.parts import (
     PRIMITIVES,
     add_part,
@@ -453,11 +457,64 @@ class TestMeasure:
         )
 
         result = measure_distance(proj, 0, 1)
+        bounds = measure_bounding_box(proj, 1)
 
         assert result["distance"] == 2.5
         assert result["delta"] == pytest.approx(
             [1.767767, 0.0, 1.767767], abs=1e-6
         )
+        assert bounds["min"] == pytest.approx(
+            [-3.535534, -5.0, -3.535534], abs=1e-6
+        )
+        assert bounds["max"] == pytest.approx(
+            [7.071068, 5.0, 7.071068], abs=1e-6
+        )
+        assert [
+            (low + high) / 2.0 for low, high in zip(bounds["min"], bounds["max"])
+        ] == pytest.approx(result["delta"], abs=1e-6)
+
+    def test_bounding_box_applies_rotation_consistently_with_distance(self):
+        proj = _make_project()
+        add_part(proj, "sphere", position=[0.0, 0.0, 0.0])
+        add_part(
+            proj,
+            "box",
+            position=[10.0, 20.0, 30.0],
+            rotation=[0.0, 0.0, 90.0],
+            params={"length": 4.0, "width": 2.0, "height": 3.0},
+        )
+
+        bounds = measure_bounding_box(proj, 1)
+        distance = measure_distance(proj, 0, 1)
+
+        assert bounds["min"] == pytest.approx([8.0, 20.0, 30.0])
+        assert bounds["max"] == pytest.approx([10.0, 24.0, 33.0])
+        assert bounds["size"] == pytest.approx([2.0, 4.0, 3.0])
+        assert distance["delta"] == pytest.approx(
+            [(low + high) / 2.0 for low, high in zip(bounds["min"], bounds["max"])]
+        )
+
+    def test_bounding_box_keeps_unsupported_parts_deferred(self):
+        proj = _make_project()
+        proj["parts"].append(
+            {
+                "id": 1,
+                "name": "Plane",
+                "type": "plane",
+                "params": {"length": 4.0, "width": 2.0},
+                "placement": {
+                    "position": [10.0, 20.0, 30.0],
+                    "rotation": [0.0, 0.0, 90.0],
+                },
+            }
+        )
+
+        bounds = measure_bounding_box(proj, 0)
+
+        assert bounds["min"] is None
+        assert bounds["max"] is None
+        assert bounds["size"] is None
+        assert bounds["deferred"] is True
 
 
 # ===========================================================================

--- a/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
+++ b/freecad/agent-harness/cli_anything/freecad/tests/test_core.py
@@ -412,11 +412,17 @@ class TestMeasure:
             ("torus", {"radius1": 10.0, "radius2": 3.0}, [2.0, -3.0, 4.0]),
         ],
     )
+    @pytest.mark.parametrize("omit_rotation", [False, True])
     def test_center_of_mass_uses_primitive_local_origin(
-        self, part_type, params, expected
+        self, part_type, params, expected, omit_rotation, tmp_path
     ):
         proj = _make_project()
         add_part(proj, part_type, position=[2.0, -3.0, 4.0], params=params)
+        if omit_rotation:
+            del proj["parts"][0]["placement"]["rotation"]
+            path = str(tmp_path / "missing-rotation.json")
+            save_document(proj, path)
+            proj = open_document(path)
 
         result = measure_center_of_mass(proj, 0)
 

--- a/registry.json
+++ b/registry.json
@@ -790,7 +790,7 @@
     {
       "name": "freecad",
       "display_name": "FreeCAD",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Parametric 3D CAD modeling via FreeCAD CLI (258 commands: Part, Sketcher, PartDesign, Assembly, Mesh, TechDraw, Draft, FEM, CAM, and more)",
       "requires": "FreeCAD >= 1.1 (freecad.org)",
       "homepage": "https://www.freecad.org",


### PR DESCRIPTION
## Description

### What

- Correct primitive bounding-box centers for cylinders, spheres, cones, and tori. Rotated asymmetric cones and full curved primitives use exact world-axis support bounds.
- Compute analytical centers of mass for boxes, cylinders, spheres, conical frustums, and tori, then transform them through the part placement.
- Defer bounding-box, center-of-mass, distance, and angle results for partial or invalid angular primitives instead of returning plausible but incorrect values.
- Keep older project files compatible by applying FreeCAD's default sweep angles when angle keys are absent and a zero rotation when the placement omits it.
- Add regression coverage for translated and rotated primitives, asymmetric conical frustums, curved bounds, wedge consistency, missing angles, partial sweeps, and downstream measurements.

### Why

FreeCAD places cylinders and cones at the center of their lower face, while spheres and tori are placed at their geometric center. Adding a radius to every placement silently reported incorrect coordinates, including centers outside the solid. A conical frustum also needs its volume centroid rather than the midpoint of its bounding box.

### Design

Bounding-box centers and centers of mass remain separate concepts. Full primitives use analytical support bounds and local uniform-density centroids, transformed through the existing placement convention. Partial angular geometry is not consistently represented by the current export and analytical-measurement pipeline, so affected measurements are explicitly deferred rather than approximated. Rotated wedges are likewise deferred until exact transformed-vertex bounds are available; identity-placed wedges remain measurable. Unknown and boolean parts retain their existing placement-position fallback.

Fixes #452

## Type of Change

- [ ] **New Software CLI (in-repo)** — adds a CLI harness inside this monorepo
- [ ] **New Software CLI (standalone repo)** — registry-only PR pointing to an external repo
- [ ] **New Feature** — adds new functionality to an existing harness or the plugin
- [x] **Bug Fix** — fixes incorrect behavior
- [ ] **Documentation** — updates docs only
- [ ] **Other** — please describe:

---

### For Existing CLI Modifications

- [x] All unit tests pass: `python -m pytest cli_anything/freecad/tests/test_core.py -v`
- [ ] All E2E tests pass: tests requiring a local FreeCAD installation are skipped on this machine
- [x] No test regressions — no previously passing tests were removed or weakened
- [x] `registry.json` entry is updated if version, description, or requirements changed (version bumped to 1.1.1)

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands (no new commands)
- [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
- [x] I have tested my changes locally

## Verification

```text
python -m pytest -q
138 passed, 11 skipped

python -m compileall -q cli_anything
git diff --check
```

The 11 skipped tests invoke a real FreeCAD backend, which is not installed on this machine. All portable tests passed. Independent standards and issue-spec reviews found no remaining actionable issues.

Regression tests were mutation-checked during development: restoring the old radius-offset behavior, transformed local midpoint for asymmetric cones, conservative rotated curved bounds, or non-deferred partial-sweep behavior makes the relevant new tests fail.

## How to review

1. Check the local-center definitions in `core/measure.py` against FreeCAD primitive placement semantics.
2. Verify the solid conical-frustum centroid formula, especially the unequal-radius test case.
3. Review `world_bounds()` for rotated full primitives and the explicit deferred contract for partial angular primitives.
