### PR TITLE
fix(obsidian): open notes via POST /open/ instead of overwriting the active note

### DIFF
--- a/obsidian/agent-harness/OBSIDIAN.md
+++ b/obsidian/agent-harness/OBSIDIAN.md
@@ -48,7 +48,8 @@ Our CLI wraps the Obsidian Local REST API plugin with:
 | `/search/` | POST | Structured search — Dataview DQL (`application/vnd.olrapi.dataview.dql+txt`) or JsonLogic (`application/vnd.olrapi.jsonlogic+json`) |
 | `/search/simple/` | POST | Plain text search |
 | `/active/` | GET | Get active note |
-| `/active/` | PUT | Open a note |
+| `/active/` | PUT | Overwrite the currently open note |
+| `/open/{path}` | POST | Open a note in the Obsidian UI |
 | `/commands/` | GET | List commands |
 | `/commands/{id}/` | POST | Execute command |
 
@@ -71,7 +72,7 @@ All requests use HTTPS with a self-signed certificate (`verify=False`).
 | `search query <q> [--type dql\|jsonlogic]` | `POST /search/` (raw body, vendor Content-Type) |
 | `search simple <q>` | `POST /search/simple/` |
 | `note active` | `GET /active/` |
-| `note open <path>` | `PUT /active/` |
+| `note open <path>` | `POST /open/{path}` |
 | `command list` | `GET /commands/` |
 | `command execute <id>` | `POST /commands/{id}/` |
 | `server status` | `GET /` |

--- a/obsidian/agent-harness/cli_anything/obsidian/core/note.py
+++ b/obsidian/agent-harness/cli_anything/obsidian/core/note.py
@@ -1,5 +1,7 @@
 """Obsidian active note operations — get and open."""
 
+from urllib.parse import quote
+
 from cli_anything.obsidian.utils.obsidian_backend import api_get, api_post
 
 
@@ -14,5 +16,6 @@ def open_note(base_url: str, api_key: str, path: str) -> dict:
     Uses POST /open/{path}. PUT /active/ overwrites the currently
     open note's content (Local REST API).
     """
-    endpoint = f"/open/{path.lstrip('/')}"
+    encoded = quote(path.lstrip("/"), safe="/")
+    endpoint = f"/open/{encoded}"
     return api_post(base_url, endpoint, api_key)

--- a/obsidian/agent-harness/cli_anything/obsidian/core/note.py
+++ b/obsidian/agent-harness/cli_anything/obsidian/core/note.py
@@ -1,6 +1,6 @@
 """Obsidian active note operations — get and open."""
 
-from cli_anything.obsidian.utils.obsidian_backend import api_get, api_put
+from cli_anything.obsidian.utils.obsidian_backend import api_get, api_post
 
 
 def get_active(base_url: str, api_key: str) -> dict:
@@ -9,6 +9,10 @@ def get_active(base_url: str, api_key: str) -> dict:
 
 
 def open_note(base_url: str, api_key: str, path: str) -> dict:
-    """Open a note in Obsidian."""
-    return api_put(base_url, "/active/", api_key, content=path,
-                   content_type="text/plain")
+    """Open a note in the Obsidian UI.
+
+    Uses POST /open/{path}. PUT /active/ overwrites the currently
+    open note's content (Local REST API).
+    """
+    endpoint = f"/open/{path.lstrip('/')}"
+    return api_post(base_url, endpoint, api_key)

--- a/obsidian/agent-harness/cli_anything/obsidian/obsidian_cli.py
+++ b/obsidian/agent-harness/cli_anything/obsidian/obsidian_cli.py
@@ -408,7 +408,7 @@ def repl():
     global _repl_mode
     _repl_mode = True
 
-    skin = ReplSkin("obsidian", version="1.1.0")
+    skin = ReplSkin("obsidian", version="1.1.1")
     skin.print_banner()
 
     pt_session = skin.create_prompt_session()

--- a/obsidian/agent-harness/cli_anything/obsidian/skills/SKILL.md
+++ b/obsidian/agent-harness/cli_anything/obsidian/skills/SKILL.md
@@ -237,4 +237,4 @@ When using this CLI programmatically:
 
 ## Version
 
-1.1.0
+1.1.1

--- a/obsidian/agent-harness/cli_anything/obsidian/tests/test_core.py
+++ b/obsidian/agent-harness/cli_anything/obsidian/tests/test_core.py
@@ -287,12 +287,27 @@ class TestNoteModule:
         result = get_active("https://localhost:27124", "test-key")
         assert result["content"] == "# Active Note"
 
-    @patch("cli_anything.obsidian.core.note.api_put")
-    def test_open_note(self, mock_api):
+    @patch("cli_anything.obsidian.core.note.api_post")
+    def test_open_note(self, mock_post):
         from cli_anything.obsidian.core.note import open_note
-        mock_api.return_value = {"status": "ok"}
+        mock_post.return_value = {"status": "ok"}
         result = open_note("https://localhost:27124", "test-key", "folder/note.md")
         assert result["status"] == "ok"
+        mock_post.assert_called_once_with(
+            "https://localhost:27124", "/open/folder/note.md", "test-key"
+        )
+
+    @patch("cli_anything.obsidian.core.note.api_post")
+    def test_open_note_does_not_put_active(self, mock_post):
+        """POST /open/{path} opens the note; PUT /active/ would overwrite it."""
+        from cli_anything.obsidian.core.note import open_note
+        mock_post.return_value = {"status": "ok"}
+        open_note("https://localhost:27124", "test-key", "/Daily.md")
+        mock_post.assert_called_once_with(
+            "https://localhost:27124", "/open/Daily.md", "test-key"
+        )
+        assert mock_post.call_args.args[1].startswith("/open/")
+        assert "/active/" not in mock_post.call_args.args[1]
 
 
 class TestCommandModule:

--- a/obsidian/agent-harness/cli_anything/obsidian/tests/test_core.py
+++ b/obsidian/agent-harness/cli_anything/obsidian/tests/test_core.py
@@ -309,6 +309,24 @@ class TestNoteModule:
         assert mock_post.call_args.args[1].startswith("/open/")
         assert "/active/" not in mock_post.call_args.args[1]
 
+    @patch("cli_anything.obsidian.core.note.api_post")
+    def test_open_note_encodes_reserved_url_chars(self, mock_post):
+        from cli_anything.obsidian.core.note import open_note
+        mock_post.return_value = {"status": "ok"}
+        open_note("https://localhost:27124", "test-key", "folder/a#b.md")
+        mock_post.assert_called_once_with(
+            "https://localhost:27124", "/open/folder/a%23b.md", "test-key"
+        )
+
+    @patch("cli_anything.obsidian.core.note.api_post")
+    def test_open_note_encodes_query_char_and_keeps_slashes(self, mock_post):
+        from cli_anything.obsidian.core.note import open_note
+        mock_post.return_value = {"status": "ok"}
+        open_note("https://localhost:27124", "test-key", "folder/a?b.md")
+        mock_post.assert_called_once_with(
+            "https://localhost:27124", "/open/folder/a%3Fb.md", "test-key"
+        )
+
 
 class TestCommandModule:
     @patch("cli_anything.obsidian.core.command.api_get")

--- a/obsidian/agent-harness/setup.py
+++ b/obsidian/agent-harness/setup.py
@@ -12,7 +12,7 @@ with open("cli_anything/obsidian/README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="cli-anything-obsidian",
-    version="1.1.0",
+    version="1.1.1",
     author="Doruk Ozgen",
     author_email="",
     description="CLI harness for Obsidian — Knowledge management and note-taking via Obsidian Local REST API. Recommended: Obsidian with Local REST API plugin enabled",

--- a/registry.json
+++ b/registry.json
@@ -1132,7 +1132,7 @@
     {
       "name": "obsidian",
       "display_name": "Obsidian",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Knowledge management and note-taking — manage notes, search vault, execute commands via Obsidian Local REST API",
       "requires": "Obsidian desktop app with Local REST API plugin enabled",
       "homepage": "https://obsidian.md",

--- a/skills/cli-anything-obsidian/SKILL.md
+++ b/skills/cli-anything-obsidian/SKILL.md
@@ -236,4 +236,4 @@ When using this CLI programmatically:
 
 ## Version
 
-1.1.0
+1.1.1


### PR DESCRIPTION
## Description

`note open` called `PUT /active/` with the note path as the request body. On the Obsidian Local REST API, `PUT /active/` overwrites the currently open note. `POST /open/{path}` is the open-in-UI endpoint (`/open/*` in the plugin).

Fixes #454

## Type of Change

- [ ] **New Software CLI (in-repo)** — adds a CLI harness inside this monorepo
- [ ] **New Software CLI (standalone repo)** — registry-only PR pointing to an external repo
- [ ] **New Feature** — adds new functionality to an existing harness or the plugin
- [x] **Bug Fix** — fixes incorrect behavior
- [ ] **Documentation** — updates docs only
- [ ] **Other** — please describe:

---

### For Existing CLI Modifications

- [x] All unit tests pass: `python3 -m pytest cli_anything/<software>/tests/test_core.py -v`
- [ ] All E2E tests pass: `python3 -m pytest cli_anything/<software>/tests/test_full_e2e.py -v`
- [x] No test regressions — no previously passing tests were removed or weakened
- [x] `registry.json` entry is updated if version, description, or requirements changed

E2E (`test_full_e2e.py`) was not run. It requires a live Obsidian instance with the Local REST API plugin.

### General Checklist

- [x] Code follows existing patterns and conventions
- [x] `--json` flag is supported on any new commands
- [x] Commit messages follow the conventional format (`feat:`, `fix:`, `docs:`, `test:`)
- [x] I have tested my changes locally

## Test Results

Windows, Python 3.12.11, pytest 9.1.1, from `obsidian/agent-harness`:

```
python -m pytest cli_anything/obsidian/tests/test_core.py -v
============================= 53 passed in 0.24s ==============================
```

Same command with the previous `PUT /active/` implementation: the two `TestNoteModule` open-note tests failed.