### PR TITLE
fix(blender): make `render execute` actually invoke Blender

### DIFF
--- a/blender/agent-harness/cli_anything/blender/blender_cli.py
+++ b/blender/agent-harness/cli_anything/blender/blender_cli.py
@@ -168,6 +168,17 @@ def handle_error(func):
                 click.echo(f"Error: {e}", err=True)
             if not _repl_mode:
                 sys.exit(1)
+        except subprocess.TimeoutExpired as e:
+            # Blender exceeding --timeout must follow the CLI's error contract
+            # rather than escaping as a traceback with no --json payload.
+            msg = (f"Render timed out after {e.timeout}s. "
+                   f"Raise --timeout to allow longer renders.")
+            if _json_output:
+                click.echo(json.dumps({"error": msg, "type": "TimeoutExpired"}))
+            else:
+                click.echo(f"Error: {msg}", err=True)
+            if not _repl_mode:
+                sys.exit(1)
         except (ValueError, IndexError, RuntimeError) as e:
             if _json_output:
                 click.echo(json.dumps({"error": str(e), "type": type(e).__name__}))

--- a/blender/agent-harness/cli_anything/blender/blender_cli.py
+++ b/blender/agent-harness/cli_anything/blender/blender_cli.py
@@ -862,15 +862,22 @@ def render_presets():
 @click.option("--frame", "-f", type=int, default=None, help="Specific frame to render")
 @click.option("--animation", "-a", is_flag=True, help="Render full animation")
 @click.option("--overwrite", is_flag=True, help="Overwrite existing file")
+@click.option("--timeout", type=int, default=300, help="Max seconds to wait for Blender")
+@click.option("--no-execute", is_flag=True, help="Only write the bpy script, do not render")
 @handle_error
-def render_execute(output_path, frame, animation, overwrite):
-    """Render the scene (generates bpy script)."""
+def render_execute(output_path, frame, animation, overwrite, timeout, no_execute):
+    """Render the scene with Blender headless."""
     sess = get_session()
     result = render_mod.render_scene(
         sess.get_project(), output_path,
         frame=frame, animation=animation, overwrite=overwrite,
+        execute=not no_execute, timeout=timeout,
     )
-    output(result, f"Render script generated: {result['script_path']}")
+    if result.get("executed"):
+        msg = f"Rendered: {result['output']}"
+    else:
+        msg = f"Render script generated (not executed): {result['script_path']}"
+    output(result, msg)
 
 
 @render_group.command("script")

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -185,11 +185,14 @@ def render_scene(
     frame: Optional[int] = None,
     animation: bool = False,
     overwrite: bool = False,
+    execute: bool = True,
+    timeout: int = 300,
 ) -> Dict[str, Any]:
-    """Render the scene by generating a bpy script.
+    """Render the scene with Blender headless.
 
-    Since we cannot call Blender directly in all environments, this generates
-    a Python script that can be run with `blender --background --python script.py`.
+    Generates a bpy script, then invokes the real Blender to render it and
+    verifies an output file was actually produced. Pass execute=False to stop
+    after writing the script (useful for inspecting the generated bpy source).
 
     Args:
         project: The scene dict
@@ -197,9 +200,11 @@ def render_scene(
         frame: Specific frame to render (None = current frame)
         animation: If True, render the full animation range
         overwrite: Allow overwriting existing files
+        execute: If True, invoke Blender; if False, only write the script
+        timeout: Maximum seconds to wait for Blender
 
     Returns:
-        Dict with render info and script path
+        Dict with render info, script path, and (when executed) the real output
     """
     if os.path.exists(output_path) and not overwrite and not animation:
         raise FileExistsError(f"Output file exists: {output_path}. Use --overwrite.")
@@ -235,6 +240,19 @@ def render_scene(
         result["frame_range"] = f"{scene_settings.get('frame_start', 1)}-{scene_settings.get('frame_end', 250)}"
     else:
         result["frame"] = frame or scene_settings.get("frame_current", 1)
+
+    if not execute:
+        result["executed"] = False
+        return result
+
+    from cli_anything.blender.utils import blender_backend
+
+    render_result = blender_backend.render_script_file(
+        script_path, abs_output_path, timeout=timeout, animation=animation,
+    )
+    result.update(render_result)
+    result["executed"] = True
+    result["script_path"] = os.path.abspath(script_path)
 
     return result
 

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -238,11 +238,20 @@ def render_scene(
         from cli_anything.blender.utils import blender_backend as _bb
 
         if animation:
-            existing = sorted(_bb._frame_files(output_path, expected_ext))
+            # Only frames this render will actually write count as a
+            # collision: reusing a prefix for a different range should not be
+            # refused because frame_0250.png from an earlier one is present.
+            this_range = (
+                scene_settings.get("frame_start", 1),
+                scene_settings.get("frame_end", 250),
+            )
+            existing = sorted(
+                _bb._frame_files(output_path, expected_ext, frame_range=this_range)
+            )
             if existing:
                 raise FileExistsError(
-                    f"{len(existing)} frame(s) already match this prefix "
-                    f"(e.g. {existing[0]}). Use --overwrite."
+                    f"{len(existing)} frame(s) in range {this_range[0]}-{this_range[1]} "
+                    f"already exist (e.g. {existing[0]}). Use --overwrite."
                 )
         else:
             clash = _bb.resolve_output(output_path, expected_ext)

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -6,6 +6,7 @@ for actual Blender rendering.
 
 import os
 import json
+import tempfile
 from typing import Dict, Any, Optional, List
 from datetime import datetime
 
@@ -218,17 +219,39 @@ def render_scene(
     Returns:
         Dict with render info, script path, and (when executed) the real output
     """
-    if os.path.exists(output_path) and not overwrite and not animation:
-        raise FileExistsError(f"Output file exists: {output_path}. Use --overwrite.")
-
     render_settings = project.get("render", {})
     scene_settings = project.get("scene", {})
+    expected_ext = FORMAT_EXTENSIONS.get(render_settings.get("output_format", "PNG"))
+
+    # Guard the files Blender will actually write, not the path as typed.
+    # `render execute result` with PNG output writes result.png, and an
+    # animation writes a whole frame sequence; checking only `output_path`
+    # let both clobber existing files without --overwrite.
+    if not overwrite:
+        from cli_anything.blender.utils import blender_backend as _bb
+
+        if animation:
+            existing = sorted(_bb._frame_files(output_path, expected_ext))
+            if existing:
+                raise FileExistsError(
+                    f"{len(existing)} frame(s) already match this prefix "
+                    f"(e.g. {existing[0]}). Use --overwrite."
+                )
+        else:
+            clash = _bb.resolve_output(output_path, expected_ext)
+            if clash:
+                raise FileExistsError(f"Output file exists: {clash}. Use --overwrite.")
 
     # Determine output directory for the script
     script_dir = os.path.dirname(os.path.abspath(output_path))
     os.makedirs(script_dir, exist_ok=True)
 
-    script_path = os.path.join(script_dir, "_render_script.py")
+    # Unique per invocation: two concurrent renders into the same directory
+    # would otherwise overwrite each other's script before Blender read it.
+    script_fd, script_path = tempfile.mkstemp(
+        prefix="_render_script_", suffix=".py", dir=script_dir,
+    )
+    os.close(script_fd)
     # Ensure output_path is absolute before passing it to the script generator
     # as Blender's background process may have a different CWD.
     abs_output_path = os.path.abspath(output_path)
@@ -261,7 +284,7 @@ def render_scene(
 
     render_result = blender_backend.render_script_file(
         script_path, abs_output_path, timeout=timeout, animation=animation,
-        expected_ext=FORMAT_EXTENSIONS.get(render_settings.get("output_format", "PNG")),
+        expected_ext=expected_ext,
     )
     result.update(render_result)
     result["executed"] = True

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -60,6 +60,18 @@ RENDER_PRESETS = {
 VALID_ENGINES = ["CYCLES", "EEVEE", "WORKBENCH"]
 VALID_OUTPUT_FORMATS = ["PNG", "JPEG", "BMP", "TIFF", "OPEN_EXR", "HDR", "FFMPEG"]
 
+# Extension Blender appends when the output path has none and
+# use_file_extension is on (the default).
+FORMAT_EXTENSIONS = {
+    "PNG": ".png",
+    "JPEG": ".jpg",
+    "BMP": ".bmp",
+    "TIFF": ".tif",
+    "OPEN_EXR": ".exr",
+    "HDR": ".hdr",
+    "FFMPEG": ".mp4",
+}
+
 
 def set_render_settings(
     project: Dict[str, Any],
@@ -249,6 +261,7 @@ def render_scene(
 
     render_result = blender_backend.render_script_file(
         script_path, abs_output_path, timeout=timeout, animation=animation,
+        expected_ext=FORMAT_EXTENSIONS.get(render_settings.get("output_format", "PNG")),
     )
     result.update(render_result)
     result["executed"] = True

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -73,6 +73,10 @@ FORMAT_EXTENSIONS = {
     "FFMPEG": ".mp4",
 }
 
+# Formats that emit a single movie file rather than a numbered frame
+# sequence, even when a frame range is rendered.
+MOVIE_FORMATS = {"FFMPEG"}
+
 
 def set_render_settings(
     project: Dict[str, Any],
@@ -285,6 +289,7 @@ def render_scene(
     render_result = blender_backend.render_script_file(
         script_path, abs_output_path, timeout=timeout, animation=animation,
         expected_ext=expected_ext,
+        movie=render_settings.get("output_format") in MOVIE_FORMATS,
     )
     result.update(render_result)
     result["executed"] = True

--- a/blender/agent-harness/cli_anything/blender/core/render.py
+++ b/blender/agent-harness/cli_anything/blender/core/render.py
@@ -231,7 +231,10 @@ def render_scene(
     # `render execute result` with PNG output writes result.png, and an
     # animation writes a whole frame sequence; checking only `output_path`
     # let both clobber existing files without --overwrite.
-    if not overwrite:
+    # Only when the render will actually run: --no-execute writes a uniquely
+    # named script and touches no artifact, so refusing it over unrelated
+    # existing output would block harmless script inspection.
+    if execute and not overwrite:
         from cli_anything.blender.utils import blender_backend as _bb
 
         if animation:

--- a/blender/agent-harness/cli_anything/blender/tests/test_core.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_core.py
@@ -885,7 +885,7 @@ class TestRender:
         add_object(proj, name="Cube")
         with tempfile.TemporaryDirectory() as tmp:
             output_path = os.path.join(tmp, "render.png")
-            result = render_scene(proj, output_path, overwrite=True)
+            result = render_scene(proj, output_path, overwrite=True, execute=False)
             assert os.path.exists(result["script_path"])
             assert "blender" in result["command"]
             assert result["engine"] == "CYCLES"

--- a/blender/agent-harness/cli_anything/blender/tests/test_full_e2e.py
+++ b/blender/agent-harness/cli_anything/blender/tests/test_full_e2e.py
@@ -366,7 +366,7 @@ class TestBPYScriptGeneration:
         proj = create_scene()
         add_object(proj, name="Cube")
         output_path = os.path.join(tmp_dir, "render.png")
-        result = render_scene(proj, output_path, overwrite=True)
+        result = render_scene(proj, output_path, overwrite=True, execute=False)
         assert os.path.exists(result["script_path"])
         with open(result["script_path"]) as f:
             content = f.read()
@@ -426,7 +426,7 @@ class TestWorkflows:
 
         # Generate script
         output_path = os.path.join(tmp_dir, "product.png")
-        result = render_scene(proj, output_path, overwrite=True)
+        result = render_scene(proj, output_path, overwrite=True, execute=False)
         assert os.path.exists(result["script_path"])
         assert result["engine"] == "CYCLES"
 
@@ -455,7 +455,7 @@ class TestWorkflows:
 
         # Generate animation render
         output_path = os.path.join(tmp_dir, "frame_")
-        result = render_scene(proj, output_path, animation=True, overwrite=True)
+        result = render_scene(proj, output_path, animation=True, overwrite=True, execute=False)
         assert result["animation"] is True
         assert "1-120" in result["frame_range"]
 

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -180,11 +180,20 @@ def render_script_file(
         after = _frame_files(output_path, expected_ext)
         # Re-rendered frames keep their names, so compare mtimes rather than
         # names alone: a frame is ours if it is new or was just rewritten.
-        frames = sorted(
+        mine = [
             f for f in after
             if f not in pre_existing
             or os.path.getmtime(os.path.join(frame_dir, f)) >= render_started
-        )
+        ]
+
+        # Sort by frame number, not lexicographically: across a digit-width
+        # boundary a plain sort puts frame10000.png before frame9999.png, and
+        # first_frame would then name the wrong frame.
+        def _frame_number(name: str) -> int:
+            m = re.search(r"(\d+)(?:\.[^.]*)?$", name)
+            return int(m.group(1)) if m else 0
+
+        frames = sorted(mine, key=_frame_number)
         if not frames:
             raise RuntimeError(
                 f"Blender render produced no frames.\n"

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -170,11 +170,18 @@ def render_script_file(
                 f"  Expected: {output_path}\n"
                 f"  stdout: {result['stdout'][-500:]}"
             )
+        # An animation prefix is usually extensionless ("frame_"), so take the
+        # format from expected_ext or an emitted frame rather than returning ""
+        # and clobbering the caller's already-correct format.
+        fmt = ext.lstrip(".")
+        if not fmt:
+            fmt = (expected_ext or os.path.splitext(frames[0])[1]).lstrip(".")
+
         return {
             "output": frame_dir,
             "frames": len(frames),
             "first_frame": os.path.join(frame_dir, frames[0]),
-            "format": ext.lstrip("."),
+            "format": fmt,
             "method": "blender-headless",
             "blender_version": get_version(),
             "command": result["command"],

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -51,7 +51,11 @@ def render_script(
         raise FileNotFoundError(f"Script not found: {script_path}")
 
     blender = find_blender()
-    cmd = [blender, "--background", "--python", script_path]
+    # Without --python-exit-code, Blender exits 0 even when the bpy script
+    # raises, so returncode alone cannot tell a completed render from a
+    # script that died partway through.
+    cmd = [blender, "--background", "--python-exit-code", "1",
+           "--python", script_path]
 
     result = subprocess.run(
         cmd,
@@ -132,14 +136,11 @@ def render_script_file(
 
     # Mark the start on the same filesystem as the frames rather than trusting
     # wall-clock time: the two can disagree, and mtime granularity varies.
-    started_marker = None
-    render_started = 0.0
-    if animation:
-        marker_dir = os.path.dirname(os.path.abspath(output_path)) or "."
-        os.makedirs(marker_dir, exist_ok=True)
-        fd, started_marker = tempfile.mkstemp(prefix=".render_started_", dir=marker_dir)
-        os.close(fd)
-        render_started = os.path.getmtime(started_marker)
+    marker_dir = os.path.dirname(os.path.abspath(output_path)) or "."
+    os.makedirs(marker_dir, exist_ok=True)
+    fd, started_marker = tempfile.mkstemp(prefix=".render_started_", dir=marker_dir)
+    os.close(fd)
+    render_started = os.path.getmtime(started_marker)
 
     try:
         result = render_script(script_path, timeout=timeout)
@@ -188,6 +189,17 @@ def render_script_file(
         }
 
     actual_output = resolve_output(output_path, expected_ext)
+
+    # A pre-existing file at the target is not proof of a render. With
+    # --overwrite the guard in render_scene deliberately steps aside, so a
+    # script that died before writing would otherwise let the stale file be
+    # reported as this run's output.
+    if actual_output is not None and os.path.getmtime(actual_output) < render_started:
+        raise RuntimeError(
+            f"Blender left the existing file untouched — no new render was produced.\n"
+            f"  Path: {actual_output}\n"
+            f"  stderr: {result['stderr'][-500:]}"
+        )
     if actual_output is None:
         raise RuntimeError(
             f"Blender render produced no output file.\n"

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -5,6 +5,7 @@ Requires: blender (system package)
 """
 
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -97,7 +98,13 @@ def resolve_output(output_path: str, expected_ext: Optional[str] = None) -> Opti
 
 
 def _frame_files(output_path: str, expected_ext: Optional[str] = None) -> set:
-    """Names in the output directory that match the frame-sequence prefix."""
+    """Names in the output directory that are frames of this sequence.
+
+    Blender numbers frames as <prefix><digits><ext>. Matching on prefix and
+    extension alone would also pick up unrelated neighbours such as
+    frame_preview.png, which would then block a render without --overwrite
+    and be miscounted as an emitted frame with it.
+    """
     base, ext = os.path.splitext(os.path.abspath(output_path))
     frame_dir = os.path.dirname(base) or "."
     prefix = os.path.basename(base)
@@ -105,10 +112,12 @@ def _frame_files(output_path: str, expected_ext: Optional[str] = None) -> set:
         ext = expected_ext if expected_ext.startswith(".") else f".{expected_ext}"
     if not os.path.isdir(frame_dir):
         return set()
-    return {
-        f for f in os.listdir(frame_dir)
-        if f.startswith(prefix) and (not ext or f.endswith(ext))
-    }
+
+    pattern = re.compile(
+        rf"^{re.escape(prefix)}\d+{re.escape(ext)}$" if ext
+        else rf"^{re.escape(prefix)}\d+$"
+    )
+    return {f for f in os.listdir(frame_dir) if pattern.match(f)}
 
 
 def render_script_file(
@@ -117,6 +126,7 @@ def render_script_file(
     timeout: int = 300,
     animation: bool = False,
     expected_ext: Optional[str] = None,
+    movie: bool = False,
 ) -> dict:
     """Render an on-disk bpy script with Blender headless and verify the output.
 
@@ -132,7 +142,10 @@ def render_script_file(
     # Frames already on disk from an earlier render with the same prefix are
     # not ours; without this snapshot a 10-frame render into a directory
     # holding 250 old frames would report 250.
-    pre_existing = _frame_files(output_path, expected_ext) if animation else set()
+    # A video format emits one movie file, not a numbered sequence, so it
+    # follows the single-artifact path even when rendering a frame range.
+    sequence = animation and not movie
+    pre_existing = _frame_files(output_path, expected_ext) if sequence else set()
 
     # Mark the start on the same filesystem as the frames rather than trusting
     # wall-clock time: the two can disagree, and mtime granularity varies.
@@ -154,7 +167,7 @@ def render_script_file(
             f"  stderr: {result['stderr'][-500:]}"
         )
 
-    if animation:
+    if sequence:
         base, ext = os.path.splitext(os.path.abspath(output_path))
         frame_dir = os.path.dirname(base) or "."
         after = _frame_files(output_path, expected_ext)

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -67,6 +67,89 @@ def render_script(
     }
 
 
+def resolve_output(output_path: str) -> Optional[str]:
+    """Return the real rendered file, or None if nothing was produced.
+
+    Blender appends a frame number to the output path for single frames,
+    e.g. /tmp/render.png becomes /tmp/render0001.png.
+    """
+    if os.path.exists(output_path):
+        return output_path
+    base, ext = os.path.splitext(output_path)
+    for suffix in ("0001", "0000", "1"):
+        candidate = f"{base}{suffix}{ext}"
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def render_script_file(
+    script_path: str,
+    output_path: str,
+    timeout: int = 300,
+    animation: bool = False,
+) -> dict:
+    """Render an on-disk bpy script with Blender headless and verify the output.
+
+    Args:
+        script_path: Path to the bpy script to execute
+        output_path: Expected output file, or the frame-sequence base for animation
+        timeout: Maximum seconds to wait
+        animation: True when the script renders a frame range
+
+    Returns:
+        Dict with output path, file size, method, blender version, command
+    """
+    result = render_script(script_path, timeout=timeout)
+
+    if result["returncode"] != 0:
+        raise RuntimeError(
+            f"Blender render failed (exit {result['returncode']}):\n"
+            f"  stderr: {result['stderr'][-500:]}"
+        )
+
+    if animation:
+        base, ext = os.path.splitext(os.path.abspath(output_path))
+        frame_dir = os.path.dirname(base) or "."
+        prefix = os.path.basename(base)
+        frames = sorted(
+            f for f in os.listdir(frame_dir)
+            if f.startswith(prefix) and f.endswith(ext)
+        )
+        if not frames:
+            raise RuntimeError(
+                f"Blender render produced no frames.\n"
+                f"  Expected: {output_path}\n"
+                f"  stdout: {result['stdout'][-500:]}"
+            )
+        return {
+            "output": frame_dir,
+            "frames": len(frames),
+            "first_frame": os.path.join(frame_dir, frames[0]),
+            "format": ext.lstrip("."),
+            "method": "blender-headless",
+            "blender_version": get_version(),
+            "command": result["command"],
+        }
+
+    actual_output = resolve_output(output_path)
+    if actual_output is None:
+        raise RuntimeError(
+            f"Blender render produced no output file.\n"
+            f"  Expected: {output_path}\n"
+            f"  stdout: {result['stdout'][-500:]}"
+        )
+
+    return {
+        "output": os.path.abspath(actual_output),
+        "format": os.path.splitext(actual_output)[1].lstrip("."),
+        "method": "blender-headless",
+        "blender_version": get_version(),
+        "file_size": os.path.getsize(actual_output),
+        "command": result["command"],
+    }
+
+
 def render_scene_headless(
     bpy_script_content: str,
     output_path: str,
@@ -89,40 +172,6 @@ def render_scene_headless(
         script_path = f.name
 
     try:
-        result = render_script(script_path, timeout=timeout)
-
-        if result["returncode"] != 0:
-            raise RuntimeError(
-                f"Blender render failed (exit {result['returncode']}):\n"
-                f"  stderr: {result['stderr'][-500:]}"
-            )
-
-        # Verify the output file was created
-        # Blender appends frame number to output path for single frames
-        # e.g., /tmp/render.png becomes /tmp/render0001.png
-        actual_output = output_path
-        if not os.path.exists(actual_output):
-            # Try with frame number suffix
-            base, ext = os.path.splitext(output_path)
-            for suffix in ["0001", "0000", "1"]:
-                candidate = f"{base}{suffix}{ext}"
-                if os.path.exists(candidate):
-                    actual_output = candidate
-                    break
-
-        if not os.path.exists(actual_output):
-            raise RuntimeError(
-                f"Blender render produced no output file.\n"
-                f"  Expected: {output_path}\n"
-                f"  stdout: {result['stdout'][-500:]}"
-            )
-
-        return {
-            "output": os.path.abspath(actual_output),
-            "format": os.path.splitext(actual_output)[1].lstrip("."),
-            "method": "blender-headless",
-            "blender_version": get_version(),
-            "file_size": os.path.getsize(actual_output),
-        }
+        return render_script_file(script_path, output_path, timeout=timeout)
     finally:
         os.unlink(script_path)

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -67,20 +67,44 @@ def render_script(
     }
 
 
-def resolve_output(output_path: str) -> Optional[str]:
+def resolve_output(output_path: str, expected_ext: Optional[str] = None) -> Optional[str]:
     """Return the real rendered file, or None if nothing was produced.
 
     Blender appends a frame number to the output path for single frames,
-    e.g. /tmp/render.png becomes /tmp/render0001.png.
+    e.g. /tmp/render.png becomes /tmp/render0001.png. With the default
+    ``use_file_extension`` it also appends the format's extension when the
+    path has none, so ``render execute /tmp/result`` with PNG output writes
+    /tmp/result.png — pass ``expected_ext`` so that spelling is probed too.
     """
-    if os.path.exists(output_path):
-        return output_path
     base, ext = os.path.splitext(output_path)
-    for suffix in ("0001", "0000", "1"):
-        candidate = f"{base}{suffix}{ext}"
-        if os.path.exists(candidate):
-            return candidate
+
+    # Blender only appends an extension when the path lacks one; if the path
+    # already has an extension it is used as written.
+    tails = [ext]
+    if expected_ext and not ext:
+        tails.append(expected_ext if expected_ext.startswith(".") else f".{expected_ext}")
+
+    for tail in tails:
+        for suffix in ("", "0001", "0000", "1"):
+            candidate = f"{base}{suffix}{tail}"
+            if os.path.exists(candidate):
+                return candidate
     return None
+
+
+def _frame_files(output_path: str, expected_ext: Optional[str] = None) -> set:
+    """Names in the output directory that match the frame-sequence prefix."""
+    base, ext = os.path.splitext(os.path.abspath(output_path))
+    frame_dir = os.path.dirname(base) or "."
+    prefix = os.path.basename(base)
+    if not ext and expected_ext:
+        ext = expected_ext if expected_ext.startswith(".") else f".{expected_ext}"
+    if not os.path.isdir(frame_dir):
+        return set()
+    return {
+        f for f in os.listdir(frame_dir)
+        if f.startswith(prefix) and (not ext or f.endswith(ext))
+    }
 
 
 def render_script_file(
@@ -88,6 +112,7 @@ def render_script_file(
     output_path: str,
     timeout: int = 300,
     animation: bool = False,
+    expected_ext: Optional[str] = None,
 ) -> dict:
     """Render an on-disk bpy script with Blender headless and verify the output.
 
@@ -100,7 +125,27 @@ def render_script_file(
     Returns:
         Dict with output path, file size, method, blender version, command
     """
-    result = render_script(script_path, timeout=timeout)
+    # Frames already on disk from an earlier render with the same prefix are
+    # not ours; without this snapshot a 10-frame render into a directory
+    # holding 250 old frames would report 250.
+    pre_existing = _frame_files(output_path, expected_ext) if animation else set()
+
+    # Mark the start on the same filesystem as the frames rather than trusting
+    # wall-clock time: the two can disagree, and mtime granularity varies.
+    started_marker = None
+    render_started = 0.0
+    if animation:
+        marker_dir = os.path.dirname(os.path.abspath(output_path)) or "."
+        os.makedirs(marker_dir, exist_ok=True)
+        fd, started_marker = tempfile.mkstemp(prefix=".render_started_", dir=marker_dir)
+        os.close(fd)
+        render_started = os.path.getmtime(started_marker)
+
+    try:
+        result = render_script(script_path, timeout=timeout)
+    finally:
+        if started_marker and os.path.exists(started_marker):
+            os.unlink(started_marker)
 
     if result["returncode"] != 0:
         raise RuntimeError(
@@ -111,10 +156,13 @@ def render_script_file(
     if animation:
         base, ext = os.path.splitext(os.path.abspath(output_path))
         frame_dir = os.path.dirname(base) or "."
-        prefix = os.path.basename(base)
+        after = _frame_files(output_path, expected_ext)
+        # Re-rendered frames keep their names, so compare mtimes rather than
+        # names alone: a frame is ours if it is new or was just rewritten.
         frames = sorted(
-            f for f in os.listdir(frame_dir)
-            if f.startswith(prefix) and f.endswith(ext)
+            f for f in after
+            if f not in pre_existing
+            or os.path.getmtime(os.path.join(frame_dir, f)) >= render_started
         )
         if not frames:
             raise RuntimeError(
@@ -132,7 +180,7 @@ def render_script_file(
             "command": result["command"],
         }
 
-    actual_output = resolve_output(output_path)
+    actual_output = resolve_output(output_path, expected_ext)
     if actual_output is None:
         raise RuntimeError(
             f"Blender render produced no output file.\n"

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -104,13 +104,18 @@ def resolve_output(output_path: str, expected_ext: Optional[str] = None) -> Opti
     return None
 
 
-def _frame_files(output_path: str, expected_ext: Optional[str] = None) -> set:
+def _frame_files(output_path: str, expected_ext: Optional[str] = None,
+                 frame_range: Optional[tuple] = None) -> set:
     """Names in the output directory that are frames of this sequence.
 
     Blender numbers frames as <prefix><digits><ext>. Matching on prefix and
     extension alone would also pick up unrelated neighbours such as
     frame_preview.png, which would then block a render without --overwrite
     and be miscounted as an emitted frame with it.
+
+    ``frame_range`` narrows the match to (start, end) inclusive. The collision
+    preflight passes it so that rendering frames 1-10 is not refused because
+    frame_0250.png from an unrelated earlier range happens to be present.
     """
     base, ext = os.path.splitext(os.path.abspath(output_path))
     frame_dir = os.path.dirname(base) or "."
@@ -121,10 +126,20 @@ def _frame_files(output_path: str, expected_ext: Optional[str] = None) -> set:
         return set()
 
     pattern = re.compile(
-        rf"^{re.escape(prefix)}\d+{re.escape(ext)}$" if ext
-        else rf"^{re.escape(prefix)}\d+$"
+        rf"^{re.escape(prefix)}(\d+){re.escape(ext)}$" if ext
+        else rf"^{re.escape(prefix)}(\d+)$"
     )
-    return {f for f in os.listdir(frame_dir) if pattern.match(f)}
+    matches = set()
+    for f in os.listdir(frame_dir):
+        m = pattern.match(f)
+        if not m:
+            continue
+        if frame_range is not None:
+            n = int(m.group(1))
+            if not (frame_range[0] <= n <= frame_range[1]):
+                continue
+        matches.add(f)
+    return matches
 
 
 def render_script_file(

--- a/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
+++ b/blender/agent-harness/cli_anything/blender/utils/blender_backend.py
@@ -84,15 +84,22 @@ def resolve_output(output_path: str, expected_ext: Optional[str] = None) -> Opti
     base, ext = os.path.splitext(output_path)
 
     # Blender only appends an extension when the path lacks one; if the path
-    # already has an extension it is used as written.
-    tails = [ext]
+    # already has an extension it is used as written. When it does append,
+    # that spelling is what this render just wrote — probe it first, or an
+    # older bare file of the same name wins and the freshness check then
+    # rejects a render that actually succeeded.
+    tails = []
     if expected_ext and not ext:
         tails.append(expected_ext if expected_ext.startswith(".") else f".{expected_ext}")
+    tails.append(ext)
 
     for tail in tails:
         for suffix in ("", "0001", "0000", "1"):
             candidate = f"{base}{suffix}{tail}"
-            if os.path.exists(candidate):
+            # isfile, not exists: an output_path naming an existing directory
+            # would otherwise be returned as the rendered artifact, with the
+            # directory entry's size reported as the image size.
+            if os.path.isfile(candidate):
                 return candidate
     return None
 


### PR DESCRIPTION
## Problem

`cli-anything-blender render execute <out.png>` never renders. It generates the bpy script, prints the command, and returns:

```
Render script generated: /tmp/_render_script.py
command: blender --background --python /tmp/_render_script.py
```

Exit code 0, no image. The user has to copy that command and run it themselves. An agent reading the success output would reasonably conclude a render happened.

This contradicts HARNESS.md's first rule:

> **The real software is a hard dependency.** The CLI MUST invoke the actual application (LibreOffice, Blender, GIMP, etc.) for rendering and export.

## Cause

`utils/blender_backend.py` already contains the complete headless implementation — `find_blender()`, `render_script()`, `render_scene_headless()` with return-code checking, frame-suffix resolution, and output verification. Nothing outside `tests/` imports it. `core/render.py` writes the script, builds a `command` string, and returns without ever calling the backend.

## Changes

**`utils/blender_backend.py`** — extracted the frame-suffix probe into `resolve_output()` and added `render_script_file(script_path, output_path, timeout, animation)`, which renders an on-disk script and verifies the artifact. `render_scene_headless()` delegates to it; signature and return keys are unchanged, so the five existing tests that call it are unaffected.

**`core/render.py`** — `render_scene()` gains `execute=True` and `timeout=300`. After writing the script it invokes Blender through the backend and merges the real result (`output`, `file_size`, `method`, `blender_version`, actual `command`) plus an `executed` flag. The animation branch counts emitted frames rather than probing for one file. The existing `abs_output_path` handling is preserved and is what gets passed to the backend.

**`blender_cli.py`** — `render execute` gains `--timeout` and `--no-execute`, and reports the rendered path instead of the script path. `render script` is untouched — it remains the script-only surface.

**tests** — four call sites assert script shape only and now pass `execute=False`, including one 120-frame Cycles animation that would otherwise render for real.

All new parameters are keyword-defaulted, so every existing call site binds unchanged.

## Verification

macOS 15, Blender 5.2.1 LTS, editable install of `blender/agent-harness`.

| check | result |
|---|---|
| single `render execute` | `Rendered: pr_render.png`, `executed: True`, `blender_version: Blender 5.2.1 LTS`, 479,106 bytes |
| `--no-execute` | script written, `executed: False`, no image produced |
| `blender` absent from PATH | fails with the existing install instructions, creates no output file |
| suite (`CLI_ANYTHING_FORCE_INSTALLED=1`) | 238 passed, 1 failed |

The single failure is `TestBPYScriptGeneration::test_script_render_settings_eevee` (expects `BLENDER_EEVEE_NEXT` in the generated script). It reproduces on unmodified HEAD — I confirmed via `git stash` — so it is pre-existing and left alone rather than bundled into this PR.

Scene used for verification was built entirely through the CLI (Suzanne + plane, two PBR materials, camera, sun + area lights, Cycles at 48 samples), then rendered with one `render execute`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
