### PR TITLE
fix(gimp): stop hiding GIMP failures behind a silent Pillow fallback

### DIFF
--- a/gimp/agent-harness/cli_anything/gimp/core/export.py
+++ b/gimp/agent-harness/cli_anything/gimp/core/export.py
@@ -23,6 +23,27 @@ _GIMP_BACKEND_ERROR: Optional[str] = None
 _REQUEST_SCOPED_ERRORS = (FileExistsError, FileNotFoundError, ValueError, KeyError)
 
 
+def _summarise_backend_error(exc: BaseException) -> str:
+    """Bounded, non-leaky description of a GIMP backend failure.
+
+    subprocess.TimeoutExpired and CalledProcessError stringify their whole
+    argv, and the argv here embeds the generated Script-Fu program — layer
+    names, text-layer contents and file paths. That text would otherwise be
+    printed, returned in JSON, and retained in the process-wide cache, so
+    summarise those by exception type instead of interpolating the message.
+    """
+    import subprocess
+
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return f"TimeoutExpired: GIMP batch exceeded {exc.timeout}s"
+    if isinstance(exc, subprocess.CalledProcessError):
+        return f"CalledProcessError: GIMP batch exited {exc.returncode}"
+    detail = str(exc).splitlines()[0] if str(exc) else ""
+    if len(detail) > 200:
+        detail = detail[:200] + "…"
+    return f"{type(exc).__name__}: {detail}" if detail else type(exc).__name__
+
+
 # Export presets
 EXPORT_PRESETS = {
     "png": {"format": "PNG", "ext": ".png", "params": {"compress_level": 6}},
@@ -109,7 +130,7 @@ def render(
             # and never let it disable GIMP for subsequent renders.
             raise
         except Exception as exc:
-            skip_reason = f"{type(exc).__name__}: {exc}"
+            skip_reason = _summarise_backend_error(exc)
             _GIMP_BACKEND_ERROR = skip_reason
 
     if require_gimp:

--- a/gimp/agent-harness/cli_anything/gimp/core/export.py
+++ b/gimp/agent-harness/cli_anything/gimp/core/export.py
@@ -20,7 +20,13 @@ _GIMP_BACKEND_ERROR: Optional[str] = None
 # Errors that describe this particular request rather than the state of the
 # GIMP installation. They must not be cached, and must not be reported as a
 # reason to fall back to Pillow.
-_REQUEST_SCOPED_ERRORS = (FileExistsError, FileNotFoundError, ValueError, KeyError)
+#
+# OSError subsumes FileExistsError and FileNotFoundError and adds the other
+# pre-batch output-path failures — PermissionError on an unwritable parent,
+# ENAMETOOLONG, ENOSPC — none of which say anything about whether GIMP works.
+# subprocess.TimeoutExpired and CalledProcessError are not OSErrors, so real
+# backend failures still reach the cache.
+_REQUEST_SCOPED_ERRORS = (ValueError, KeyError, OSError)
 
 
 def _summarise_backend_error(exc: BaseException) -> str:

--- a/gimp/agent-harness/cli_anything/gimp/core/export.py
+++ b/gimp/agent-harness/cli_anything/gimp/core/export.py
@@ -13,8 +13,14 @@ from typing import Dict, Any, Optional, Tuple
 
 # Remembers a GIMP batch failure for the life of the process. A hanging batch
 # run costs the full subprocess timeout, so retrying it on every render would
-# make each export pay that cost again.
+# make each export pay that cost again. Only failures of the backend itself
+# belong here — see _REQUEST_SCOPED_ERRORS.
 _GIMP_BACKEND_ERROR: Optional[str] = None
+
+# Errors that describe this particular request rather than the state of the
+# GIMP installation. They must not be cached, and must not be reported as a
+# reason to fall back to Pillow.
+_REQUEST_SCOPED_ERRORS = (FileExistsError, FileNotFoundError, ValueError, KeyError)
 
 
 # Export presets
@@ -96,6 +102,12 @@ def render(
                     preset=preset, overwrite=overwrite,
                     quality=quality, format_override=format_override,
                 )
+        except _REQUEST_SCOPED_ERRORS:
+            # Bad arguments for this one call — an existing output file without
+            # --overwrite, an unreadable source. GIMP is fine; the request is
+            # not. Surface it instead of disguising it as a renderer fallback,
+            # and never let it disable GIMP for subsequent renders.
+            raise
         except Exception as exc:
             skip_reason = f"{type(exc).__name__}: {exc}"
             _GIMP_BACKEND_ERROR = skip_reason

--- a/gimp/agent-harness/cli_anything/gimp/core/export.py
+++ b/gimp/agent-harness/cli_anything/gimp/core/export.py
@@ -11,6 +11,11 @@ Rendering backends (tried in order):
 import os
 from typing import Dict, Any, Optional, Tuple
 
+# Remembers a GIMP batch failure for the life of the process. A hanging batch
+# run costs the full subprocess timeout, so retrying it on every render would
+# make each export pay that cost again.
+_GIMP_BACKEND_ERROR: Optional[str] = None
+
 
 # Export presets
 EXPORT_PRESETS = {
@@ -58,30 +63,56 @@ def render(
     overwrite: bool = False,
     quality: Optional[int] = None,
     format_override: Optional[str] = None,
+    require_gimp: bool = False,
 ) -> Dict[str, Any]:
     """Render the project: flatten layers, apply filters, export.
 
     Tries the GIMP Script-Fu backend first (native image processing via
-    ``gimp -i -b``).  Falls back to Pillow when GIMP is not installed.
+    ``gimp -i -b``).  Falls back to Pillow when GIMP is unavailable or the
+    batch run fails, and reports which renderer actually produced the file.
+
+    Pass ``require_gimp=True`` to raise instead of falling back, for callers
+    that need GIMP's own rendering rather than an approximation.
     """
+    global _GIMP_BACKEND_ERROR
+
+    skip_reason = None
+
     # --- GIMP-native rendering (preferred) ---
-    try:
-        from cli_anything.gimp.utils.gimp_backend import is_available, render_project
-        if is_available() and not _project_has_draw_ops(project):
-            return render_project(
-                project, output_path,
-                preset=preset, overwrite=overwrite,
-                quality=quality, format_override=format_override,
-            )
-    except Exception:
-        pass  # fall through to Pillow
+    if _project_has_draw_ops(project):
+        skip_reason = "project uses draw ops, which the Script-Fu path does not implement"
+    elif _GIMP_BACKEND_ERROR is not None:
+        # A previous render in this process already failed; a GIMP batch run
+        # that hangs costs the full timeout, so don't pay it again.
+        skip_reason = _GIMP_BACKEND_ERROR
+    else:
+        try:
+            from cli_anything.gimp.utils.gimp_backend import is_available, render_project
+            if not is_available():
+                skip_reason = "GIMP was not found on PATH"
+            else:
+                return render_project(
+                    project, output_path,
+                    preset=preset, overwrite=overwrite,
+                    quality=quality, format_override=format_override,
+                )
+        except Exception as exc:
+            skip_reason = f"{type(exc).__name__}: {exc}"
+            _GIMP_BACKEND_ERROR = skip_reason
+
+    if require_gimp:
+        raise RuntimeError(
+            f"GIMP rendering was requested but is unavailable: {skip_reason}"
+        )
 
     # --- Pillow fallback ---
-    return _render_via_pillow(
+    result = _render_via_pillow(
         project, output_path,
         preset=preset, overwrite=overwrite,
         quality=quality, format_override=format_override,
     )
+    result["gimp_skipped"] = skip_reason
+    return result
 
 
 def _render_via_pillow(

--- a/gimp/agent-harness/cli_anything/gimp/gimp_cli.py
+++ b/gimp/agent-harness/cli_anything/gimp/gimp_cli.py
@@ -610,16 +610,22 @@ def export_preset_info(name):
 @click.option("--overwrite", is_flag=True, help="Overwrite existing file")
 @click.option("--quality", "-q", type=int, default=None, help="Quality override")
 @click.option("--format", "fmt", type=str, default=None, help="Format override")
+@click.option("--require-gimp", is_flag=True,
+              help="Fail instead of falling back to the Pillow renderer")
 @handle_error
-def export_render(output_path, preset, overwrite, quality, fmt):
+def export_render(output_path, preset, overwrite, quality, fmt, require_gimp):
     """Render the project to an image file."""
     sess = get_session()
     result = export_mod.render(
         sess.get_project(), output_path,
         preset=preset, overwrite=overwrite,
         quality=quality, format_override=fmt,
+        require_gimp=require_gimp,
     )
-    output(result, f"Rendered to: {output_path}")
+    msg = f"Rendered to: {output_path} (via {result.get('method', 'unknown')})"
+    if result.get("gimp_skipped"):
+        msg += f"\n  GIMP not used: {result['gimp_skipped']}"
+    output(result, msg)
 
 
 # ── Session Commands ─────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`core/export.py::render()` tries the GIMP Script-Fu backend, then falls back to Pillow:

```python
try:
    from cli_anything.gimp.utils.gimp_backend import is_available, render_project
    if is_available() and not _project_has_draw_ops(project):
        return render_project(...)
except Exception:
    pass  # fall through to Pillow
```

When the GIMP batch run fails, the exception is discarded and Pillow renders the image instead. The command reports success and gives no indication that GIMP was not used. Since the two renderers do not produce identical output, the caller cannot tell what made the file.

This is not hypothetical. On GIMP 3, the GIMP-2 Script-Fu API used by this harness does not run. With GIMP 3.2.4 installed and on `PATH`:

- `find_gimp()` → `/opt/homebrew/bin/gimp`
- `is_available()` → `True`
- the batch call hangs until the subprocess timeout expires
- the old code then reported plain success, having quietly rendered with Pillow

Every render also paid that timeout again, because nothing remembered the failure.

## Change

`core/export.py` and `gimp_cli.py`:

- **Report the reason instead of swallowing it.** Pillow results carry `gimp_skipped` — GIMP not found, project uses draw ops, or the exception text. `export render` prints which renderer ran.
- **`--require-gimp` / `require_gimp=True`** raises instead of falling back, for callers that need GIMP's own rendering rather than an approximation.
- **Remember a batch failure for the process lifetime.** Only the first render pays the timeout.

This deliberately does **not** port the Script-Fu layer to GIMP 3. That touches layer creation, blend modes and every filter mapping, needs its own validation, and belongs in a separate PR. This change makes the existing failure visible rather than silently switching renderer.

## Verification

macOS, GIMP 3.2.4, editable install.

| check | result |
|---|---|
| `export render out.png` | `Rendered to: out.png (via pillow)` + `GIMP not used: TimeoutExpired: ...` — previously reported plain success |
| `require_gimp=True` | raises `RuntimeError: GIMP rendering was requested but is unavailable: ...` |
| failure memo | with a stubbed failing backend, three renders call it **once**: 2.07s, 0.00s, 0.00s |
| suite | 113 passed, 2 failed |

The two failures are `TestGIMPRenderE2E::test_create_and_export_png` and `_jpeg`. Both call `gimp_backend.create_and_export` directly, never reach `render()`, and fail on the GIMP 3 incompatibility described above — unrelated to this diff.

For reference while diagnosing: `gimp-console-3.2 -idf --batch-interpreter plug-in-script-fu-eval -b '(gimp-version)' -b '(gimp-quit 0)'` does execute successfully on GIMP 3, so the invocation form is fixable; the GIMP-2 procedure names in the generated scripts are the remaining blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
